### PR TITLE
Fix compiler code point serialization

### DIFF
--- a/packages/arb-compiler-evm/arbitrum/basic_vm.py
+++ b/packages/arb-compiler-evm/arbitrum/basic_vm.py
@@ -86,7 +86,7 @@ class Stack:
 
 class BasicVM:
     def __init__(self):
-        self.pc = value.AVMCodePoint(0, 0, b"")
+        self.pc = value.ERROR_CODE_POINT
         self.stack = Stack()
         self.aux_stack = Stack()
         self.register = value.Tuple([])

--- a/packages/arb-compiler-evm/arbitrum/marshall.py
+++ b/packages/arb-compiler-evm/arbitrum/marshall.py
@@ -46,7 +46,7 @@ def marshall_op(val, file):
 def marshall_codepoint(val, file):
     file.write(val.pc.to_bytes(8, byteorder="big", signed=True))
     marshall_op(val.op, file)
-    val.next_hash = b"0" * (32 - len(val.next_hash)) + val.next_hash
+    val.next_hash = b"\0" * (32 - len(val.next_hash)) + val.next_hash
     file.write(val.next_hash)
 
 

--- a/packages/arb-compiler-evm/arbitrum/value.py
+++ b/packages/arb-compiler-evm/arbitrum/value.py
@@ -152,7 +152,7 @@ class CodePointType:
         return "CodePointType()"
 
     def empty_val(self):
-        return AVMCodePoint(0, 0, b"")
+        return ERROR_CODE_POINT
 
     def typecode(self):
         return 1
@@ -351,7 +351,10 @@ class AVMCodePoint:
         self.path = path
 
     def __repr__(self):
-        return "AVMCodePoint({}, {})".format(self.pc, self.op)
+        return "AVMCodePoint({}, {}, {})".format(self.pc, self.op, self.next_hash.hex())
+
+
+ERROR_CODE_POINT = AVMCodePoint(0, 0, b"\0" * 32)
 
 
 def value_hash(val):

--- a/packages/arb-compiler-evm/arbitrum/vm.py
+++ b/packages/arb-compiler-evm/arbitrum/vm.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .value import AVMCodePoint
 from . import value
 from .basic_vm import BasicVM
 from .instructions import OP_CODES
@@ -37,7 +36,7 @@ class VM(BasicVM):
         if code:
             self.pc = code[0]
         else:
-            self.pc = AVMCodePoint(0, 0, b"")
+            self.pc = value.ERROR_CODE_POINT
 
     def debug_print(self):
         print(


### PR DESCRIPTION
Error code point should have next hash equal to all zeros, but we were using `b"0"*32` instead of `b"\0"*32`. I also did a bit of code point related refactoring while tracing this error.