### PR TITLE
fix cpp opcode 'isZero' number of parameters and bug where assertion …

### DIFF
--- a/packages/arb-avm-cpp/avm/include/avm/opcodes.hpp
+++ b/packages/arb-avm-cpp/avm/include/avm/opcodes.hpp
@@ -182,7 +182,7 @@ const std::map<OpCode, std::vector<bool>> InstructionStackPops = {
     {OpCode::SLT, {true, true}},
     {OpCode::SGT, {true, true}},
     {OpCode::EQ, {false, false}},
-    {OpCode::ISZERO, {true, true}},
+    {OpCode::ISZERO, {true}},
     {OpCode::BITWISE_AND, {true, true}},
     {OpCode::BITWISE_OR, {true, true}},
     {OpCode::BITWISE_XOR, {true, true}},

--- a/packages/arb-avm-cpp/avm/src/machine.cpp
+++ b/packages/arb-avm-cpp/avm/src/machine.cpp
@@ -303,8 +303,6 @@ void Machine::runOne() {
         return;
     }
 
-    m.context.numSteps++;
-
     auto& instruction = m.code[m.pc];
 
     auto startStackSize = m.stack.stacksize();
@@ -324,6 +322,10 @@ void Machine::runOne() {
         } catch (const bad_tuple_index& e) {
             m.state = Status::Error;
         }
+    }
+
+    if (nonstd::get_if<NotBlocked>(&m.blockReason)) {
+        m.context.numSteps++;
     }
 
     if (m.state != Status::Error) {

--- a/packages/arb-avm-go/vm/instructions.go
+++ b/packages/arb-avm-go/vm/instructions.go
@@ -134,7 +134,6 @@ func RunInstruction(m *Machine, op value.Operation) (StackMods, machine.BlockRea
 	if m.HaveSizeException() {
 		return NewStackMods(0, 0), machine.ErrorBlocked{}
 	}
-	m.context.NotifyStep()
 	mods, err := func() (StackMods, error) {
 		if _, ok := code.InstructionNames[op.GetOp()]; !ok {
 			return StackMods{}, errors.New("invalid opcode")
@@ -148,12 +147,14 @@ func RunInstruction(m *Machine, op value.Operation) (StackMods, machine.BlockRea
 	}()
 
 	if err == nil {
+		m.context.NotifyStep()
 		return mods, nil
 	}
 
 	if blocked, isBlocked := err.(BlockedError); isBlocked {
 		return mods, blocked.reason
 	}
+	m.context.NotifyStep()
 
 	//fmt.Printf("error running instruction %v: %v\n", code.InstructionNames[op.GetOp()], err)
 


### PR DESCRIPTION
fix cpp opcode 'isZero' number of parameters and bug where assertion step count was incremented when machine was blocked - both cpp and go AVMs.