### PR TITLE
Copy contract declaration files to build folder after compilation

### DIFF
--- a/packages/arb-provider-ethers/package.json
+++ b/packages/arb-provider-ethers/package.json
@@ -20,7 +20,7 @@
         "prepublishOnly": "yarn shrinkABI && yarn test && yarn lint",
         "preversion": "npm run lint",
         "shrinkABI": "node shrinkABI.js && yarn run prettier src/lib/ArbChain.json src/lib/ArbChannel.json src/lib/GlobalPendingInbox.json --write",
-        "build": "tsc",
+        "build": "tsc && cp src/lib/index.d.ts src/lib/ArbRollup.d.ts src/lib/GlobalPendingInbox.d.ts dist/lib/",
         "test": "jest --config jest.config.js",
         "format": "yarn run prettier '**/*.{js,json,md,ts,yml}' --write && yarn run lint --fix",
         "lint": "eslint . src/**/*.ts tests/**/*.ts",


### PR DESCRIPTION
The contract interfaces aren't copied to the `build` folder because they're declarations and thus don't compile to JS. This copies them over after the build so they can be imported from the package, as well as providing the types for consumers within the package.