### PR TITLE
Chain debug string

### DIFF
--- a/packages/arb-util/common/address.go
+++ b/packages/arb-util/common/address.go
@@ -37,8 +37,16 @@ func (a Address) String() string {
 	return a.Hex()
 }
 
+func (a Address) ShortString() string {
+	return a.String()[:8]
+}
+
 func (a Address) IsZero() bool {
 	return a == zeroAddress
+}
+
+func (a Address) Equals(a2 Address) bool {
+	return a == a2
 }
 
 func (a Address) ToEthAddress() ethcommon.Address {

--- a/packages/arb-util/common/address.go
+++ b/packages/arb-util/common/address.go
@@ -38,7 +38,7 @@ func (a Address) String() string {
 }
 
 func (a Address) ShortString() string {
-	return a.String()[:8]
+	return a.Hex()[2:8]
 }
 
 func (a Address) IsZero() bool {

--- a/packages/arb-util/common/hash.go
+++ b/packages/arb-util/common/hash.go
@@ -31,6 +31,11 @@ func (h Hash) String() string {
 	return hexutil.Encode(h[:])
 }
 
+func (h Hash) ShortString() string {
+	s := h.String()
+	return s[:8]
+}
+
 func (h Hash) Bytes() []byte {
 	return h[:]
 }

--- a/packages/arb-util/common/hash.go
+++ b/packages/arb-util/common/hash.go
@@ -32,8 +32,7 @@ func (h Hash) String() string {
 }
 
 func (h Hash) ShortString() string {
-	s := h.String()
-	return s[:8]
+	return h.String()[2:8]
 }
 
 func (h Hash) Bytes() []byte {

--- a/packages/arb-validator/rollup/rollup.go
+++ b/packages/arb-validator/rollup/rollup.go
@@ -145,6 +145,10 @@ func (m *ChainObserverBuf) UnmarshalFromCheckpoint(
 	}
 }
 
+func (chain *ChainObserver) DebugString(prefix string) string {
+	return chain.nodeGraph.DebugString(prefix)
+}
+
 func (chain *ChainObserver) HandleNotification(ctx context.Context, event arbbridge.Event) {
 	chain.Lock()
 	defer chain.Unlock()

--- a/packages/arb-validator/rollup/rollup.go
+++ b/packages/arb-validator/rollup/rollup.go
@@ -146,6 +146,8 @@ func (m *ChainObserverBuf) UnmarshalFromCheckpoint(
 }
 
 func (chain *ChainObserver) DebugString(prefix string) string {
+	chain.Lock()
+	defer chain.Unlock()
 	return chain.nodeGraph.DebugString(prefix)
 }
 

--- a/packages/arb-validator/rollup/stakedNodeGraph.go
+++ b/packages/arb-validator/rollup/stakedNodeGraph.go
@@ -67,6 +67,11 @@ func (m *StakedNodeGraphBuf) UnmarshalFromCheckpoint(ctx structures.RestoreConte
 	return chain
 }
 
+func (m *StakedNodeGraph) DebugString(prefix string) string {
+	subPrefix := prefix + "  "
+	return prefix + "nodes:\n" + m.NodeGraph.DebugString(subPrefix) + m.stakers.DebugString(subPrefix)
+}
+
 func (s *StakedNodeGraph) Equals(s2 *StakedNodeGraph) bool {
 	return s.NodeGraph.Equals(s2.NodeGraph) &&
 		s.stakers.Equals(s2.stakers)

--- a/packages/arb-validator/rollup/stakedNodeGraph.go
+++ b/packages/arb-validator/rollup/stakedNodeGraph.go
@@ -69,7 +69,7 @@ func (m *StakedNodeGraphBuf) UnmarshalFromCheckpoint(ctx structures.RestoreConte
 
 func (m *StakedNodeGraph) DebugString(prefix string) string {
 	subPrefix := prefix + "  "
-	return prefix + "nodes:\n" + m.NodeGraph.DebugString(subPrefix) + m.stakers.DebugString(subPrefix)
+	return "\n" + prefix + "nodes:\n" + m.NodeGraph.DebugString(subPrefix) + m.stakers.DebugString(subPrefix)
 }
 
 func (s *StakedNodeGraph) Equals(s2 *StakedNodeGraph) bool {

--- a/packages/arb-validator/rollup/stakedNodeGraph.go
+++ b/packages/arb-validator/rollup/stakedNodeGraph.go
@@ -69,7 +69,7 @@ func (m *StakedNodeGraphBuf) UnmarshalFromCheckpoint(ctx structures.RestoreConte
 
 func (m *StakedNodeGraph) DebugString(prefix string) string {
 	subPrefix := prefix + "  "
-	return "\n" + prefix + "nodes:\n" + m.NodeGraph.DebugString(m.stakers, subPrefix) + m.stakers.DebugString(subPrefix)
+	return "\n" + prefix + "nodes:\n" + m.NodeGraph.DebugString(m.stakers, subPrefix) + m.stakers.DebugString(prefix)
 }
 
 func (s *StakedNodeGraph) Equals(s2 *StakedNodeGraph) bool {

--- a/packages/arb-validator/rollup/stakedNodeGraph.go
+++ b/packages/arb-validator/rollup/stakedNodeGraph.go
@@ -69,7 +69,7 @@ func (m *StakedNodeGraphBuf) UnmarshalFromCheckpoint(ctx structures.RestoreConte
 
 func (m *StakedNodeGraph) DebugString(prefix string) string {
 	subPrefix := prefix + "  "
-	return "\n" + prefix + "nodes:\n" + m.NodeGraph.DebugString(subPrefix) + m.stakers.DebugString(subPrefix)
+	return "\n" + prefix + "nodes:\n" + m.NodeGraph.DebugString(m.stakers, subPrefix) + m.stakers.DebugString(subPrefix)
 }
 
 func (s *StakedNodeGraph) Equals(s2 *StakedNodeGraph) bool {

--- a/packages/arb-validator/rollup/stakerSet.go
+++ b/packages/arb-validator/rollup/stakerSet.go
@@ -109,7 +109,7 @@ func (ss *StakerSet) DebugString(prefix string) string {
 }
 
 func (s *Staker) DebugString(prefix string) string {
-	ret := prefix + s.address.ShortString() + " at:" + s.location.hash.ShortString()
+	ret := prefix + "addr:" + s.address.ShortString() + " loc:" + s.location.hash.ShortString()
 	if !s.challenge.IsZero() {
 		ret = ret + "chal:" + s.challenge.ShortString()
 	}

--- a/packages/arb-validator/rollup/stakerSet.go
+++ b/packages/arb-validator/rollup/stakerSet.go
@@ -99,6 +99,23 @@ func (buf *StakerBuf) Unmarshal(chain *StakedNodeGraph) *Staker {
 	}
 }
 
+func (ss *StakerSet) DebugString(prefix string) string {
+	ret := prefix + "stakers:\n"
+	subPrefix := prefix + "  "
+	ss.forall(func(s *Staker) {
+		ret = ret + s.DebugString(subPrefix)
+	})
+	return ret
+}
+
+func (s *Staker) DebugString(prefix string) string {
+	ret := prefix + s.address.ShortString() + " at:" + s.location.hash.ShortString()
+	if !s.challenge.IsZero() {
+		ret = ret + "chal:" + s.challenge.ShortString()
+	}
+	return ret + "\n"
+}
+
 func (ss *StakerSet) Equals(ss2 *StakerSet) bool {
 	if len(ss.idx) != len(ss2.idx) {
 		return false

--- a/packages/arb-validator/rollup/stakerSet.go
+++ b/packages/arb-validator/rollup/stakerSet.go
@@ -111,7 +111,7 @@ func (ss *StakerSet) DebugString(prefix string) string {
 func (s *Staker) DebugString(prefix string) string {
 	ret := prefix + "addr:" + s.address.ShortString() + " loc:" + s.location.hash.ShortString()
 	if !s.challenge.IsZero() {
-		ret = ret + "chal:" + s.challenge.ShortString()
+		ret = ret + " chal:" + s.challenge.ShortString()
 	}
 	return ret + "\n"
 }

--- a/packages/arb-validator/rollupmanager/manager.go
+++ b/packages/arb-validator/rollupmanager/manager.go
@@ -165,6 +165,7 @@ func CreateManager(
 					}
 
 					chain.NotifyNewBlock(blockId.Clone())
+					log.Print(chain.DebugString("== "))
 
 					events, err := watcher.GetEvents(runCtx, blockId)
 					if err != nil {


### PR DESCRIPTION
Create a succinct string description of the rollup chain state, and have the Manager print it on every new block.  This is useful for debugging.