### PR TITLE
Fix bug in GetConflictAncestor

### DIFF
--- a/packages/arb-validator/rollup/nodeGraph.go
+++ b/packages/arb-validator/rollup/nodeGraph.go
@@ -240,7 +240,7 @@ func (chain *NodeGraph) GetConflictAncestor(n1, n2 *Node) (*Node, *Node, structu
 	n1Orig := n1
 	n2Orig := n2
 	prevN1 := n1
-	prevN2 := n1
+	prevN2 := n2
 	for n1.depth > n2.depth {
 		prevN1 = n1
 		n1 = n1.prev


### PR DESCRIPTION
GetConflictAncestor was incorrectly calculating whether and how nodes were in conflict.  

This might have been contributing to slow/non-existent pruning of dead nodes and stakes.