### PR TITLE
Clear already-tried Tx list every minute; reduce maxsteps

### DIFF
--- a/packages/arb-provider-go/test/connection_test.go
+++ b/packages/arb-provider-go/test/connection_test.go
@@ -140,7 +140,7 @@ func setupValidators(coordinatorKey string, followerKey string, t *testing.T) er
 	}
 	manager1.AddListener(&rollup.AnnouncerListener{"chainObserver1: "})
 
-	validatorListener1 := rollup.NewValidatorChainListener(rollupAddress, rollupActor1)
+	validatorListener1 := rollup.NewValidatorChainListener(context.Background(), rollupAddress, rollupActor1)
 	err = validatorListener1.AddStaker(client1)
 	if err != nil {
 		return err
@@ -153,7 +153,7 @@ func setupValidators(coordinatorKey string, followerKey string, t *testing.T) er
 	}
 	manager2.AddListener(&rollup.AnnouncerListener{"chainObserver2: "})
 
-	validatorListener2 := rollup.NewValidatorChainListener(rollupAddress, rollupActor2)
+	validatorListener2 := rollup.NewValidatorChainListener(context.Background(), rollupAddress, rollupActor2)
 	err = validatorListener2.AddStaker(client2)
 	if err != nil {
 		return err

--- a/packages/arb-validator/cmd/evilRollupServer/evilRollupServer.go
+++ b/packages/arb-validator/cmd/evilRollupServer/evilRollupServer.go
@@ -106,7 +106,7 @@ func createRollupChain() {
 	config := structures.ChainParams{
 		StakeRequirement:        big.NewInt(10),
 		GracePeriod:             common.TimeTicks{big.NewInt(13000 * 10)},
-		MaxExecutionSteps:       500000000,
+		MaxExecutionSteps:       100000000,
 		ArbGasSpeedLimitPerTick: 100000,
 	}
 
@@ -188,7 +188,7 @@ func validateRollupChain() error {
 		return err
 	}
 
-	validatorListener := rollup.NewValidatorChainListener(address, rollupActor)
+	validatorListener := rollup.NewValidatorChainListener(context.Background(), address, rollupActor)
 	err = validatorListener.AddStaker(client)
 	if err != nil {
 		return err

--- a/packages/arb-validator/cmd/rollupServer/rollupServer.go
+++ b/packages/arb-validator/cmd/rollupServer/rollupServer.go
@@ -105,7 +105,7 @@ func createRollupChain() {
 	config := structures.ChainParams{
 		StakeRequirement:        big.NewInt(10),
 		GracePeriod:             common.TimeTicks{big.NewInt(13000 * 10)},
-		MaxExecutionSteps:       500000000,
+		MaxExecutionSteps:       100000000,
 		ArbGasSpeedLimitPerTick: 100000,
 	}
 
@@ -187,7 +187,7 @@ func validateRollupChain() error {
 		return err
 	}
 
-	validatorListener := rollup.NewValidatorChainListener(address, rollupActor)
+	validatorListener := rollup.NewValidatorChainListener(context.Background(), address, rollupActor)
 	err = validatorListener.AddStaker(client)
 	if err != nil {
 		return err

--- a/packages/arb-validator/rollup/testListeners.go
+++ b/packages/arb-validator/rollup/testListeners.go
@@ -44,7 +44,7 @@ func NewEvil_WrongAssertionListener(
 	actor arbbridge.ArbRollup,
 	kind WrongAssertionType,
 ) *evil_WrongAssertionListener {
-	return &evil_WrongAssertionListener{NewValidatorChainListener(rollupAddress, actor), kind}
+	return &evil_WrongAssertionListener{NewValidatorChainListener(context.Background(), rollupAddress, actor), kind}
 }
 
 func (lis *evil_WrongAssertionListener) AssertionPrepared(ctx context.Context, obs *ChainObserver, assertion *preparedAssertion) {


### PR DESCRIPTION
This clears the list of already-submitted Tx actions, every 1 minute, to make sure that a failed Tx won't be forever impossible.

This seems to greatly reduce the backlog of unpruned and unmooted items.

Also reduce maxsteps in rollupServer, to avoid stale assertions on fast local geth.