### PR TITLE
arb-provider-web3 logIndex temporary fix

### DIFF
--- a/packages/arb-provider-web3/ethers-web3-bridge.js
+++ b/packages/arb-provider-web3/ethers-web3-bridge.js
@@ -57,6 +57,7 @@ function makeTransaction(tx) {
 function fillCompact(values, result, keys, keepNull) {
   keys.forEach(function(key) {
     var value = values[key];
+    // is this loose comparison a problem?
     if (value == null) {
       if (!keepNull) {
         return;
@@ -661,8 +662,19 @@ utils.defineProperty(ProviderBridge.prototype, "_sendAsync", function(
     case "eth_getTransactionReceipt":
       provider.getTransactionReceipt(params[0]).then(function(receipt) {
         if (receipt != null) {
+          // TODO formatReceipt nulls out logIndex
           receipt = formatReceipt(receipt);
+          receipt.logs = receipt.logs.map((log, logIndex) => {
+            if (log.logIndex === undefined || log.logIndex === null) {
+              return { ...log, logIndex: log.transactionLogIndex || logIndex };
+            } else {
+              return log;
+            }
+          });
+
+          // logIndex appears to disappear when returned
         }
+
         respond(receipt);
       });
       break;


### PR DESCRIPTION
This is a temporary fix for the `logIndex` being `null`ed when calling `getTransactionReceipt` through `arb-provider-web3`. still determining the source of this issue