### PR TITLE
update installation docs to clone master

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -68,7 +68,7 @@ Here are the important dependencies in case you are not running on a supported O
 Download the Arbitrum Monorepo from source:
 
 ```bash
-git clone -b v0.4.2 --depth=1 -c advice.detachedHead=false https://github.com/offchainlabs/arbitrum.git
+git clone -b master --depth=1 -c advice.detachedHead=false https://github.com/offchainlabs/arbitrum.git
 cd arbitrum
 yarn
 yarn build


### PR DESCRIPTION
update the branch used in the installation docs. for the short term, might be more effective to just clone `master` so we don't have to update the docs while we make frequent updates. alternatively, perhaps we can adjust the script to grab the latest tag and clone that

fixes #242 