### PR TITLE
Fix missing dependency on alpine edge

### DIFF
--- a/packages/arb-validator.Dockerfile
+++ b/packages/arb-validator.Dockerfile
@@ -8,6 +8,7 @@ FROM alpine:edge as arb-avm-cpp
 # Alpine dependencies
 RUN apk update && apk add --no-cache boost-dev cmake g++ \
     git make musl-dev python3-dev && \
+    apk add py-pip --no-cache && \
     apk add rocksdb-dev --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ && \
     pip3 install conan && \
     addgroup -g 1000 -S user && \


### PR DESCRIPTION
Fixes missing dependency for pip against the alpine:edge docker image. 

Seems as though pip is missing from the alpine:edge base image just added the package to fix. Feel free to ignore this in favor of other solutions. Just bringing it to your attention.