### PR TITLE
Fix ethers call when provider has no signers

### DIFF
--- a/packages/arb-provider-ethers/src/lib/provider.ts
+++ b/packages/arb-provider-ethers/src/lib/provider.ts
@@ -403,14 +403,17 @@ export class ArbProvider extends ethers.providers.BaseProvider {
     if (!transaction.to) {
       throw Error('Cannot create call without a destination')
     }
-    const dest = await transaction.to
-    const sender = await this.ethProvider.getSigner(0).getAddress()
+    const to = await transaction.to
+    let from = await transaction.from
     const rawData = await transaction.data
+    if (!from) {
+      from = '0x1000000000000000000000000000000000000000'
+    }
     let data = '0x'
     if (rawData) {
       data = ethers.utils.hexlify(rawData)
     }
-    const resultData = await this.client.call(dest, sender, data)
+    const resultData = await this.client.call(to, from, data)
     return ethers.utils.hexlify(resultData)
   }
 


### PR DESCRIPTION
Currently calls from the ethers provider use the address of the first signer as the from address for the call. The correct behavior is to instead get the from address out of the `TransactionRequest`, using a default sender address if the request doesn't specify one. This allows a provider without a connected wallet to still make non-mutating calls.