### PR TITLE
Initial vm values bugfix

### DIFF
--- a/packages/arb-avm-cpp/avm_values/src/vmValueParser.cpp
+++ b/packages/arb-avm-cpp/avm_values/src/vmValueParser.cpp
@@ -63,34 +63,33 @@ InitialVmValues parseInitialVmValues(const std::string& contract_filename,
 
         initial_state.valid_state = false;
         return initial_state;
-    } else {
-        uint32_t extentionId = 1;
-        while (extentionId != 0) {
-            memcpy(&extentionId, bufptr, sizeof(extentionId));
-            extentionId = boost::endian::big_to_native(extentionId);
-            bufptr += sizeof(extentionId);
-            if (extentionId > 0) {
-                uint32_t extensionLength;
-                memcpy(&extensionLength, bufptr, sizeof(extensionLength));
-                extensionLength = boost::endian::big_to_native(extensionLength);
-                bufptr += sizeof(extensionLength) + extensionLength;
-            }
-        }
-        uint64_t codeCount;
-        memcpy(&codeCount, bufptr, sizeof(codeCount));
-        bufptr += sizeof(codeCount);
-        codeCount = boost::endian::big_to_native(codeCount);
-
-        initial_state.code.reserve(codeCount);
-
-        std::vector<Operation> ops;
-        for (uint64_t i = 0; i < codeCount; i++) {
-            ops.emplace_back(deserializeOperation(bufptr, pool));
-        }
-        initial_state.code = opsToCodePoints(ops);
-        initial_state.staticVal = deserialize_value(bufptr, pool);
-        initial_state.valid_state = true;
-
-        return initial_state;
     }
+    uint32_t extentionId = 1;
+    while (extentionId != 0) {
+        memcpy(&extentionId, bufptr, sizeof(extentionId));
+        extentionId = boost::endian::big_to_native(extentionId);
+        bufptr += sizeof(extentionId);
+        if (extentionId > 0) {
+            uint32_t extensionLength;
+            memcpy(&extensionLength, bufptr, sizeof(extensionLength));
+            extensionLength = boost::endian::big_to_native(extensionLength);
+            bufptr += sizeof(extensionLength) + extensionLength;
+        }
+    }
+    uint64_t codeCount;
+    memcpy(&codeCount, bufptr, sizeof(codeCount));
+    bufptr += sizeof(codeCount);
+    codeCount = boost::endian::big_to_native(codeCount);
+
+    initial_state.code.reserve(codeCount);
+
+    std::vector<Operation> ops;
+    for (uint64_t i = 0; i < codeCount; i++) {
+        ops.emplace_back(deserializeOperation(bufptr, pool));
+    }
+    initial_state.code = opsToCodePoints(ops);
+    initial_state.staticVal = deserialize_value(bufptr, pool);
+    initial_state.valid_state = true;
+
+    return initial_state;
 }

--- a/packages/arb-avm-cpp/avm_values/src/vmValueParser.cpp
+++ b/packages/arb-avm-cpp/avm_values/src/vmValueParser.cpp
@@ -45,6 +45,12 @@ InitialVmValues parseInitialVmValues(const std::string& contract_filename,
 
     auto bufptr = getContractData(contract_filename);
 
+    if (!bufptr) {
+        std::cerr << "Failed to open path: " << contract_filename << std::endl;
+        initial_state.valid_state = false;
+        return initial_state;
+    }
+
     uint32_t version;
     memcpy(&version, bufptr, sizeof(version));
     version = boost::endian::big_to_native(version);

--- a/packages/arb-avm-cpp/avm_values/src/vmValueParser.cpp
+++ b/packages/arb-avm-cpp/avm_values/src/vmValueParser.cpp
@@ -27,12 +27,12 @@ const char* getContractData(const std::string& contract_filename) {
     struct stat filestatus;
     stat(contract_filename.c_str(), &filestatus);
 
-    char* buf = (char*)malloc(filestatus.st_size);
+    char* buf = static_cast<char*>(malloc(filestatus.st_size));
 
     myfile.open(contract_filename, std::ios::in);
 
     if (myfile.is_open()) {
-        myfile.read((char*)buf, filestatus.st_size);
+        myfile.read(buf, filestatus.st_size);
         myfile.close();
     }
 

--- a/packages/arb-avm-cpp/tests/datastack.cpp
+++ b/packages/arb-avm-cpp/tests/datastack.cpp
@@ -312,3 +312,12 @@ TEST_CASE("Save and get datastack") {
     }
     boost::filesystem::remove_all(dbpath);
 }
+
+TEST_CASE("Initial VM Values") {
+    SECTION("parse invalid path") {
+        TuplePool pool = TuplePool();
+        TuplePool& pool_ref = pool;
+        auto values = parseInitialVmValues("nonexistent/path", pool_ref);
+    }
+    boost::filesystem::remove_all(dbpath);
+}


### PR DESCRIPTION
Fixes a segfault in `parseInitialVmValues`, where an invalid path will cause a segfault.  

Also removed some C-style casts and an unnecessary `else` branch in the same file.