### PR TITLE
Include onChainTxHash in getMessageResult

### DIFF
--- a/packages/arb-provider-ethers/src/lib/provider.ts
+++ b/packages/arb-provider-ethers/src/lib/provider.ts
@@ -53,6 +53,7 @@ interface MessageResult {
   evmVal: EVMResult
   txHash: string
   validNodeHash: string
+  onChainTxHash: string
 }
 
 interface Message {
@@ -283,6 +284,7 @@ export class ArbProvider extends ethers.providers.BaseProvider {
       evmVal,
       txHash: txHashCheck,
       validNodeHash,
+      onChainTxHash,
     }
   }
 


### PR DESCRIPTION
This will allow clients to access the hash of the assertion transaction that processed their message.