### PR TITLE
added in a higher gas limit

### DIFF
--- a/packages/arb-provider-truffle/lib/index.js
+++ b/packages/arb-provider-truffle/lib/index.js
@@ -38,7 +38,7 @@ function provider(outputFolder, buildLocation, options, should_compile) {
     buildLocation = path.resolve(rootPath, 'build/contracts')
   }
   options.allowUnlimitedContractSize = true
-  options.gasLimit = 10000000;
+  options.gasLimit = 10000000
   options.network_id = 123456789
   const arbProvider = ganache.provider(options)
 

--- a/packages/arb-provider-truffle/lib/index.js
+++ b/packages/arb-provider-truffle/lib/index.js
@@ -38,6 +38,7 @@ function provider(outputFolder, buildLocation, options, should_compile) {
     buildLocation = path.resolve(rootPath, 'build/contracts')
   }
   options.allowUnlimitedContractSize = true
+  options.gasLimit = 10000000;
   options.network_id = 123456789
   const arbProvider = ganache.provider(options)
 


### PR DESCRIPTION
I noticed an issue while trying to launch our contracts. It seems like   options.allowUnlimitedContractSize = true should have solved it, however I do get block size limit when deploying

![image](https://user-images.githubusercontent.com/33698952/82071016-81d0c580-96a3-11ea-938f-bf968e01e034.png)

Setting the gas limit to 10 million which is pretty close to the mainnet limit solved it