### PR TITLE
Split unit and integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
             yarn test --coverage --ci --runInBand --reporters=default --reporters=jest-junit
             yarn lint --format junit -o ${TEST_RESULTS}/arb-provider-ethers-lint.xml
           environment:
-            JEST_JUNIT_OUTPUT: "${TEST_RESULTS}/arb-provider-ethers.xml"
+            JEST_JUNIT_OUTPUT: '${TEST_RESULTS}/arb-provider-ethers.xml'
           working_directory: /home/user/project/packages/arb-provider-ethers
       - run:
           name: test arb-provider-web3
@@ -114,7 +114,7 @@ jobs:
             yarn test --pass-with-no-tests --coverage --ci --runInBand --reporters=default --reporters=jest-junit
             yarn lint --format junit -o ${TEST_RESULTS}/arb-provider-web3-lint.xml
           environment:
-            JEST_JUNIT_OUTPUT: "${TEST_RESULTS}/arb-provider-web3.xml"
+            JEST_JUNIT_OUTPUT: '${TEST_RESULTS}/arb-provider-web3.xml'
           working_directory: /home/user/project/packages/arb-provider-web3
       - run:
           name: test arb-provider-truffle
@@ -122,7 +122,7 @@ jobs:
             yarn test  --pass-with-no-tests --coverage --ci --runInBand --reporters=default --reporters=jest-junit
             yarn lint --format junit -o ${TEST_RESULTS}/arb-provider-truffle-lint.xml
           environment:
-            JEST_JUNIT_OUTPUT: "${TEST_RESULTS}/arb-provider-truffle.xml"
+            JEST_JUNIT_OUTPUT: '${TEST_RESULTS}/arb-provider-truffle.xml'
           working_directory: /home/user/project/packages/arb-provider-truffle
       - run: codecovbash -R /home/user/project
       - store_test_results:
@@ -267,6 +267,7 @@ jobs:
             cd arb-provider-go
             gotestsum --format short-verbose --junitfile ${TEST_RESULTS}/arb-provider-go.xml -- -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=$ARB_PACKAGES ./...
           working_directory: /home/user/project/packages/arb-provider-go
+      - run: codecovbash -R /home/user/project -c -F unit
       - run:
           name: test fibgo
           command: |
@@ -275,6 +276,6 @@ jobs:
             cd ../tests/fibgo
             gotestsum --format short-verbose --junitfile ${TEST_RESULTS}/fibgo.xml -- -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=$ARB_PACKAGES ./...
           working_directory: /home/user/project/packages
-      - run: codecovbash -R /home/user/project
+      - run: codecovbash -R /home/user/project -c -F integration
       - store_test_results:
           path: *test-path

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,51 +3,10 @@ coverage:
     project:
       default: off
       build:
-        flags:
-          [
-            arb_avm_cpp,
-            arb_avm_go,
-            arb_bridge_eth,
-            arb_compiler_evm,
-            arb_provider_ethers,
-            arb_provider_go,
-            arb_provider_truffle,
-            arb_provider_web3,
-            arb_util,
-            arb-validator,
-          ]
+        flags: [unit, integration]
 
-flags:
-  arb_avm_cpp:
-    paths:
-      - packages/arb-avm-cpp
-  arb_avm-go:
-    paths:
-      - packages/arb-avm-go
-  arb_bridge_eth:
-    paths:
-      - packages/arb-bridge-eth
-  arb_compiler_evm:
-    paths:
-      - packages/arb-compiler-evm
-  arb_provider_ethers:
-    paths:
-      - packages/arb-provider-ethers
-  arb_provider_go:
-    paths:
-      - packages/arb-provider-go
-  arb_provider_truffle:
-    paths:
-      - packages/arb-provider-truffle
-  arb_provider_web3:
-    paths:
-      - packages/arb-provider-web3
-  arb_util:
-    paths:
-      - packages/arb-util
-  arb_validator:
-    paths:
-      - packages/arb-validator
+flags: unit
+  integration
 
 ignore:
   - 'packages/arb-validator-core/ethbridge/arbfactory/*'

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,8 +2,12 @@ coverage:
   status:
     project:
       default: off
-      build:
-        flags: [unit, integration]
+      unit:
+        flags:
+          - unit
+      integration:
+        flags:
+          - integration
 
 flags: unit
   integration


### PR DESCRIPTION
Modified Codecov coverage reporting
- Fibgo test is now measured as integration test coverage
- Tests from all other packages are categorized as unit tests

See coverage of tests split into parts in Codecov comment below