### PR TITLE
Make nosetests timeout longer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,12 +98,7 @@ jobs:
       - run:
           name: test arb-compiler-evm
           command: |
-            python3 setup.py nosetests --processes=2 --process-timeout=60 --with-coverage --cover-package=arbitrum
-          # cd tests/sol-syscall
-          # truffle migrate --reset --compile-all --network arbitrum
-          # coverage run --source=/home/user/project truffle_runner.py compiled.json
-          # cd ../..
-          # coverage combine .coverage tests/sol-syscall/.coverage
+            python3 setup.py nosetests --processes=2 --process-timeout=120 --with-coverage --cover-package=arbitrum
           working_directory: /home/user/project/packages/arb-compiler-evm
       - run:
           name: test arb-provider-ethers


### PR DESCRIPTION
This PR should hopefully stop the random failures in the frontend tests due to test timeouts. PR has been merged without review since it doesn't involve any code.