### PR TITLE
Disable pet shop aggregator

### DIFF
--- a/demos/pet-shop/src/app.js
+++ b/demos/pet-shop/src/app.js
@@ -54,11 +54,7 @@ let App = {
       web3Provider = new Web3.providers.HttpProvider('http://localhost:7545')
     }
 
-    let provider = ArbProvider(
-      'http://localhost:1235',
-      web3Provider,
-      'http://localhost:1237'
-    )
+    let provider = ArbProvider('http://localhost:1235', web3Provider)
     App.web3 = new Web3(provider) // eslint-disable-line require-atomic-updates
 
     return App.initContract()


### PR DESCRIPTION
Disable use of the tx aggregator in pet shop since starting it isn't included in demo instructions. We could re-enable this in the future if we add a transaction aggregator to the `arb_deploy.py` script.