### PR TITLE
minimum viable L2 to L1 pull-able data packets [demo]

### DIFF
--- a/packages/arb-bridge-eth/contracts/DataPackets.sol
+++ b/packages/arb-bridge-eth/contracts/DataPackets.sol
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019-2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pragma solidity ^0.5.3;
+
+contract DataPackets {
+    Packet[] public packets;
+
+    struct Packet {
+        bytes data;
+        uint messageType;
+        address sender;
+        uint blockHeight;
+    }
+
+    function sendDataPacket(bytes calldata encodedData, uint messageType) external {
+        packets.push(Packet(
+            {
+                data: encodedData,
+                messageType: messageType,
+                sender: msg.sender,
+                blockHeight: block.number
+            }
+        ));
+    }
+}

--- a/packages/arb-bridge-eth/contracts/DataPackets.sol
+++ b/packages/arb-bridge-eth/contracts/DataPackets.sol
@@ -17,7 +17,7 @@
 pragma solidity ^0.5.3;
 
 contract DataPackets {
-    mapping(uint => Packet) public packets;
+    mapping(bytes32 => Packet) public packets;
 
     struct Packet {
         bytes data;
@@ -26,12 +26,15 @@ contract DataPackets {
     }
 
     function sendDataPacket(bytes calldata encodedData, uint messageType) external {
-        packets[messageType] = Packet(
+        packets[ getDataPacketId(msg.sender, messageType) ] = Packet(
             {
                 data: encodedData,
                 sender: msg.sender,
                 blockHeight: block.number
             }
         );
+    }
+    function getDataPacketId(address sender, uint messageType) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(sender, messageType));
     }
 }

--- a/packages/arb-bridge-eth/contracts/DataPackets.sol
+++ b/packages/arb-bridge-eth/contracts/DataPackets.sol
@@ -17,23 +17,21 @@
 pragma solidity ^0.5.3;
 
 contract DataPackets {
-    Packet[] public packets;
+    mapping(uint => Packet) public packets;
 
     struct Packet {
         bytes data;
-        uint messageType;
         address sender;
         uint blockHeight;
     }
 
     function sendDataPacket(bytes calldata encodedData, uint messageType) external {
-        packets.push(Packet(
+        packets[messageType] = Packet(
             {
                 data: encodedData,
-                messageType: messageType,
                 sender: msg.sender,
                 blockHeight: block.number
             }
-        ));
+        );
     }
 }

--- a/packages/arb-bridge-eth/contracts/GlobalInbox.sol
+++ b/packages/arb-bridge-eth/contracts/GlobalInbox.sol
@@ -22,6 +22,7 @@ import "./GlobalNFTWallet.sol";
 import "./IGlobalInbox.sol";
 import "./Messages.sol";
 import "./PaymentRecords.sol";
+import "./DataPackets.sol";
 
 import "./arch/Protocol.sol";
 import "./arch/Value.sol";
@@ -29,7 +30,7 @@ import "./arch/Value.sol";
 import "./libraries/SigUtils.sol";
 import "bytes/contracts/BytesLib.sol";
 
-contract GlobalInbox is GlobalEthWallet, GlobalFTWallet, GlobalNFTWallet, IGlobalInbox, PaymentRecords {
+contract GlobalInbox is GlobalEthWallet, GlobalFTWallet, GlobalNFTWallet, IGlobalInbox, PaymentRecords, DataPackets {
     uint8 internal constant TRANSACTION_MSG = 0;
     uint8 internal constant ETH_DEPOSIT = 1;
     uint8 internal constant ERC20_DEPOSIT = 2;

--- a/packages/arb-compiler-evm/contract-templates/contracts/ArbSys.sol
+++ b/packages/arb-compiler-evm/contract-templates/contracts/ArbSys.sol
@@ -49,4 +49,7 @@ interface ArbSys {
     // This function returns the address of the new contract
     // This is currently the only way to create new contracts in a compiled rollup instance
     function cloneContract(address account) external returns(address);
+
+    // Send arbitrary data to L1 
+    function sendDataPacket(bytes encodedData, uint messageType) external;
 }


### PR DESCRIPTION
Super-simple; takes arbitrary abi-encoded data (puller decodes).

I'm guessing ArbSys gets the methods from the GlobalInbox when its instantiated? Or do I have to more explicitly inherit something somewhere? 
