### PR TITLE
Add HTTPS support to validator and tx-aggregator RPC servers

### DIFF
--- a/packages/arb-tx-aggregator/cmd/arb-tx-aggregator/arb-tx-aggregator.go
+++ b/packages/arb-tx-aggregator/cmd/arb-tx-aggregator/arb-tx-aggregator.go
@@ -36,7 +36,8 @@ import (
 
 func main() {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
-	walletArgs := utils.AddFlags(fs)
+	walletArgs := utils.AddWalletFlags(fs)
+	rpcVars := utils.AddRPCFlags(fs)
 
 	err := fs.Parse(os.Args[1:])
 	if err != nil {
@@ -104,5 +105,5 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Fatal(utils.LaunchRPC(s, "1237"))
+	log.Fatal(utils.LaunchRPC(s, "1237", rpcVars))
 }

--- a/packages/arb-validator-core/utils/rpc.go
+++ b/packages/arb-validator-core/utils/rpc.go
@@ -17,13 +17,29 @@
 package utils
 
 import (
+	"flag"
 	"net/http"
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 )
 
-func LaunchRPC(handler http.Handler, port string) error {
+type RPCFlags struct {
+	certFile string
+	keyFile  string
+}
+
+func AddRPCFlags(fs *flag.FlagSet) RPCFlags {
+	certFile := fs.String("cert", "", "path to certificate file (if using ssl)")
+	privkeyFile := fs.String("privkey", "", "path to private key file (if using ssl)")
+
+	return RPCFlags{
+		certFile: *certFile,
+		keyFile:  *privkeyFile,
+	}
+}
+
+func LaunchRPC(handler http.Handler, port string, flags RPCFlags) error {
 	r := mux.NewRouter()
 	r.Handle("/", handler).Methods("GET", "POST", "OPTIONS")
 
@@ -34,9 +50,20 @@ func LaunchRPC(handler http.Handler, port string) error {
 	methodsOk := handlers.AllowedMethods(
 		[]string{"GET", "HEAD", "POST", "PUT", "OPTIONS"},
 	)
+	h := handlers.CORS(headersOk, originsOk, methodsOk)(r)
 
-	return http.ListenAndServe(
-		":"+port,
-		handlers.CORS(headersOk, originsOk, methodsOk)(r),
-	)
+	if flags.certFile != "" && flags.keyFile != "" {
+		return http.ListenAndServeTLS(
+			":"+port,
+			flags.certFile,
+			flags.keyFile,
+			h,
+		)
+	} else {
+		return http.ListenAndServe(
+			":"+port,
+			h,
+		)
+	}
+
 }

--- a/packages/arb-validator-core/utils/rpc.go
+++ b/packages/arb-validator-core/utils/rpc.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"flag"
+	"log"
 	"net/http"
 
 	"github.com/gorilla/handlers"
@@ -53,6 +54,7 @@ func LaunchRPC(handler http.Handler, port string, flags RPCFlags) error {
 	h := handlers.CORS(headersOk, originsOk, methodsOk)(r)
 
 	if flags.certFile != "" && flags.keyFile != "" {
+		log.Println("Launching rpc server over http")
 		return http.ListenAndServeTLS(
 			":"+port,
 			flags.certFile,
@@ -60,6 +62,7 @@ func LaunchRPC(handler http.Handler, port string, flags RPCFlags) error {
 			h,
 		)
 	} else {
+		log.Println("Launching rpc server over https")
 		return http.ListenAndServe(
 			":"+port,
 			h,

--- a/packages/arb-validator-core/utils/rpc.go
+++ b/packages/arb-validator-core/utils/rpc.go
@@ -26,8 +26,8 @@ import (
 )
 
 type RPCFlags struct {
-	certFile string
-	keyFile  string
+	certFile *string
+	keyFile  *string
 }
 
 func AddRPCFlags(fs *flag.FlagSet) RPCFlags {
@@ -35,8 +35,8 @@ func AddRPCFlags(fs *flag.FlagSet) RPCFlags {
 	privkeyFile := fs.String("privkey", "", "path to private key file (if using ssl)")
 
 	return RPCFlags{
-		certFile: *certFile,
-		keyFile:  *privkeyFile,
+		certFile: certFile,
+		keyFile:  privkeyFile,
 	}
 }
 
@@ -53,16 +53,16 @@ func LaunchRPC(handler http.Handler, port string, flags RPCFlags) error {
 	)
 	h := handlers.CORS(headersOk, originsOk, methodsOk)(r)
 
-	if flags.certFile != "" && flags.keyFile != "" {
-		log.Println("Launching rpc server over http with cert", flags.certFile, "and key", flags.keyFile)
+	if *flags.certFile != "" && *flags.keyFile != "" {
+		log.Println("Launching rpc server over https with cert", *flags.certFile, "and key", *flags.keyFile)
 		return http.ListenAndServeTLS(
 			":"+port,
-			flags.certFile,
-			flags.keyFile,
+			*flags.certFile,
+			*flags.keyFile,
 			h,
 		)
 	} else {
-		log.Println("Launching rpc server over https")
+		log.Println("Launching rpc server over http")
 		return http.ListenAndServe(
 			":"+port,
 			h,

--- a/packages/arb-validator-core/utils/rpc.go
+++ b/packages/arb-validator-core/utils/rpc.go
@@ -53,7 +53,7 @@ func LaunchRPC(handler http.Handler, port string, flags RPCFlags) error {
 	)
 	h := handlers.CORS(headersOk, originsOk, methodsOk)(r)
 
-	if *flags.certFile != "" && *flags.keyFile != "" {
+	if flags.certFile != nil && flags.keyFile != nil && *flags.certFile != "" && *flags.keyFile != "" {
 		log.Println("Launching rpc server over https with cert", *flags.certFile, "and key", *flags.keyFile)
 		return http.ListenAndServeTLS(
 			":"+port,

--- a/packages/arb-validator-core/utils/rpc.go
+++ b/packages/arb-validator-core/utils/rpc.go
@@ -54,7 +54,7 @@ func LaunchRPC(handler http.Handler, port string, flags RPCFlags) error {
 	h := handlers.CORS(headersOk, originsOk, methodsOk)(r)
 
 	if flags.certFile != "" && flags.keyFile != "" {
-		log.Println("Launching rpc server over http")
+		log.Println("Launching rpc server over http with cert", flags.certFile, "and key", flags.keyFile)
 		return http.ListenAndServeTLS(
 			":"+port,
 			flags.certFile,

--- a/packages/arb-validator-core/utils/wallet.go
+++ b/packages/arb-validator-core/utils/wallet.go
@@ -36,7 +36,7 @@ type WalletFlags struct {
 	gasPrice   *float64
 }
 
-func AddFlags(fs *flag.FlagSet) WalletFlags {
+func AddWalletFlags(fs *flag.FlagSet) WalletFlags {
 	passphrase := fs.String(
 		"password",
 		"",

--- a/packages/arb-validator/cmd/arb-validator/arb-validator.go
+++ b/packages/arb-validator/cmd/arb-validator/arb-validator.go
@@ -64,7 +64,7 @@ func main() {
 
 func createRollupChain() error {
 	createCmd := flag.NewFlagSet("validate", flag.ExitOnError)
-	walletVars := utils.AddFlags(createCmd)
+	walletVars := utils.AddWalletFlags(createCmd)
 	err := createCmd.Parse(os.Args[2:])
 	if err != nil {
 		return err

--- a/packages/arb-validator/go.sum
+++ b/packages/arb-validator/go.sum
@@ -221,7 +221,6 @@ github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150 h1:ZeU+auZj1iNzN
 github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rjeczalik/notify v0.9.1 h1:CLCKso/QK1snAlnhNR/CNvNiFU2saUtjV0bx3EwNeCE=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=
-github.com/robertkrimen/otto v0.0.0-20170205013659-6a77b7cbc37d/go.mod h1:xvqspoSXJTIpemEonrMDFq6XzwHYYgToXWj5eRX1OtY=
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00 h1:8DPul/X0IT/1TNMIxoKLwdemEOBBHDC/K4EB16Cw5WE=
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 h1:3hxavr+IHMsQBrYUPQM5v0CgENFktkkbg1sfpgM3h20=
@@ -339,7 +338,6 @@ gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200316214253-d7b0ff38cac9 h1:ITeyKbRetrVzqR3U1eY+ywgp7IBspGd1U/bkwd1gWu4=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200316214253-d7b0ff38cac9/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=
-gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/urfave/cli.v1 v1.20.0 h1:NdAVW6RYxDif9DhDHaAortIu956m2c0v+09AZBPTbE0=

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -208,7 +208,7 @@ func setupValidators(
 			t.Fatal(err)
 		}
 
-		if err := utils.LaunchRPC(s, "1235"); err != nil {
+		if err := utils.LaunchRPC(s, "1235", utils.RPCFlags{}); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -229,6 +229,8 @@ waitloop:
 			if err := conn.Close(); err != nil {
 				t.Fatal(err)
 			}
+			// Wait for the validator to catch up to head
+			time.Sleep(time.Second * 2)
 			break waitloop
 		case <-time.After(time.Second * 5):
 			t.Fatal("Couldn't connect to rpc")


### PR DESCRIPTION
This PR adds two additional command line parameters to the validator and tx-aggregator. If both `--cert=[path]` and `--privkey=[path]` are specified (along with `--rpc` in the case of the validator as before), the RPC server will be launched over HTTPS. This PR is fully backwards compatible since validators will default to running over http.