### PR TITLE
 arb-provider-ethers integration test coverage

### DIFF
--- a/packages/arb-provider-ethers/package.json
+++ b/packages/arb-provider-ethers/package.json
@@ -35,9 +35,11 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.0",
+    "@types/node-fetch": "^2.5.7",
     "install-peers-cli": "^2.2.0",
     "jest": "^25.1.0",
     "jest-junit": "^10.0.0",
+    "node-fetch": "^2.6.0",
     "ts-jest": "^25.2.0",
     "typechain": "^1.0.4",
     "typechain-target-ethers": "^1.0.3"

--- a/packages/arb-provider-ethers/tests/arb-provider.test.ts
+++ b/packages/arb-provider-ethers/tests/arb-provider.test.ts
@@ -1,0 +1,127 @@
+import { ArbProvider } from '../src/lib/provider'
+import { ArbClient } from '../src/lib/client'
+import { ArbWallet } from '../src/lib/wallet'
+import * as ethers from 'ethers'
+
+const ethProviderUrl = 'http://0.0.0.0:7545'
+const arbProviderUrl = 'http://0.0.0.0:1235'
+const ethereumProvider = new ethers.providers.JsonRpcProvider(ethProviderUrl)
+import fetch from 'node-fetch'
+
+const pubAddresss = '0xc7711f36b2C13E00821fFD9EC54B04A60AEfbd1b'
+// @ts-ignore: override fetch w/ node fetch for test suite
+if (!global.fetch) {
+  // @ts-ignore
+  global.fetch = fetch
+}
+
+describe('arbProvider tests', function () {
+  const arbProvider = new ArbProvider(
+    arbProviderUrl,
+    ethereumProvider,
+    '',
+    true
+  )
+  test('instantiates', async function () {
+    expect(arbProvider.client instanceof ArbClient).toBe(true)
+  })
+})
+
+describe('arbWallet tests', function () {
+  const arbProvider = new ArbProvider(
+    arbProviderUrl,
+    ethereumProvider,
+    undefined,
+    true
+  )
+  const ethereumWallet = new ethers.Wallet(
+    '0x979f020f6f6f71577c09db93ba944c89945f10fade64cfc7eb26137d5816fb76',
+    ethereumProvider
+  )
+  const arbWallet = new ArbWallet(ethereumWallet, arbProvider)
+
+  test('arbWallet instantiates properly', async function () {
+    const address = await arbWallet.getAddress()
+    expect(address).toBe(pubAddresss)
+  })
+
+  let tx: ethers.providers.TransactionReceipt
+  let txnHash: string
+
+  test('deposit ETH', async function () {
+    jest.setTimeout(30000)
+    const initialEthBalance = await ethereumWallet.getBalance()
+    const initialArbBalance = await arbProvider.getBalance(pubAddresss)
+
+    const response = await arbWallet.depositETH(pubAddresss, 1000)
+    tx = await response.wait()
+    txnHash = tx.transactionHash || ''
+
+    expect(txnHash).toBeTruthy()
+    const newEthBalance = await ethereumWallet.getBalance()
+    const newArbBalance = await arbProvider.getBalance(pubAddresss)
+
+    expect(newEthBalance.add(1000).lt(initialEthBalance)).toBe(true)
+    expect(newArbBalance.sub(1000).eq(initialArbBalance)).toBe(true)
+  })
+
+  test('gets message result data from hash', async function () {
+    const result = await arbProvider.getMessageResult(txnHash)
+    expect(result).toBeTruthy()
+    // todo: better parsing/checking message
+    expect(typeof (result && result.nodeInfo.nodeHash)).toEqual('string')
+  })
+  test('gets txn receipt from txn hash', async function () {
+    const result = await arbProvider.perform('getTransactionReceipt', {
+      transactionHash: txnHash,
+    })
+    result.contractAddress = null
+    // todo: is this failing sometimes?
+    expect(result).toEqual(tx)
+  })
+
+  test('sendTransactionMessage and assertion count', async function () {
+    jest.setTimeout(30000)
+    let preAssertionCount = await arbProvider.client.getAssertionCount()
+
+    const rec = '0x755449b9901f91deC52DB39AF8c655206C63eD8e'
+    const initialArbSenderBalance = await arbProvider.getBalance(pubAddresss)
+    const initialRecipientBalance = await arbProvider.getBalance(rec)
+    const oldSeq = await arbWallet.generateSeq()
+
+    const response = await arbWallet.sendTransactionMessage(rec, 150, '0xabc')
+    tx = await response.wait()
+    txnHash = tx.transactionHash || ''
+    expect(txnHash).toBeTruthy()
+
+    const newSenderBalance = await arbProvider.getBalance(pubAddresss)
+    const newRecipientBalance = await arbProvider.getBalance(rec)
+
+    expect(newSenderBalance.add(150).eq(initialArbSenderBalance)).toBe(true)
+    expect(newRecipientBalance.sub(150).eq(initialRecipientBalance)).toBe(true)
+    expect((oldSeq || 0) + 1).toBe(arbWallet.seqCache)
+
+    let postAssetionCount = await arbProvider.client.getAssertionCount()
+    expect(preAssertionCount + 1).toBe(postAssetionCount)
+  })
+
+  test('widthdraw ETH', async function () {
+    jest.setTimeout(30000)
+    const initialArbBalance = await arbProvider.getBalance(pubAddresss)
+
+    const response = await arbWallet.withdrawEthFromChain(100)
+    tx = await response.wait()
+    txnHash = tx.transactionHash || ''
+
+    expect(txnHash).toBeTruthy()
+    const newArbBalance = await arbProvider.getBalance(pubAddresss)
+    expect(newArbBalance.add(100).eq(initialArbBalance)).toBe(true)
+  })
+
+  test('gets node location', async function () {
+    const nodeLocation = await arbProvider.client.getLatestNodeLocation()
+    expect(nodeLocation).toBeTruthy()
+    const pendingNodeLocation = await arbProvider.client.getLatestPendingNodeLocation()
+    expect(pendingNodeLocation).toBeTruthy()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,6 +1136,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/node-fetch@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
+  integrity sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "12.7.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
@@ -3494,7 +3502,7 @@ colors@^1.1.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -5705,6 +5713,15 @@ form-data@^2.2.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
 form-data@~2.3.2:
@@ -9135,6 +9152,11 @@ node-fetch@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
+
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-fetch@~1.7.1:
   version "1.7.3"


### PR DESCRIPTION
Testing assorted bits in ArbWallet, Client, and ArbProvider; requires geth and validator to be running (and assumes a pre-funded address)