### PR TITLE
Add new call server assertion type

### DIFF
--- a/packages/arb-avm-cpp/avm/include/avm/machine.hpp
+++ b/packages/arb-avm-cpp/avm/include/avm/machine.hpp
@@ -36,7 +36,11 @@ class Machine {
     friend std::ostream& operator<<(std::ostream&, const Machine&);
 
     Assertion executeMachine(uint64_t stepCount,
-                             std::chrono::seconds wallLimit);
+                             std::chrono::seconds wallLimit,
+                             std::vector<Tuple> inbox_messages,
+                             Tuple sideload,
+                             bool blockingSideload_,
+                             nonstd::optional<value> fake_inbox_peak_value_);
 
    public:
     MachineState machine_state;
@@ -63,6 +67,11 @@ class Machine {
     Assertion run(uint64_t stepCount,
                   std::vector<Tuple> inbox_messages,
                   std::chrono::seconds wallLimit);
+
+    Assertion runCallServer(uint64_t stepCount,
+                            std::vector<Tuple> inbox_messages,
+                            std::chrono::seconds wallLimit,
+                            value fake_inbox_peak_value);
 
     Status currentStatus() { return machine_state.state; }
     uint256_t hash() const { return machine_state.hash(); }

--- a/packages/arb-avm-cpp/avm/include/avm/machine.hpp
+++ b/packages/arb-avm-cpp/avm/include/avm/machine.hpp
@@ -40,7 +40,7 @@ class Machine {
                              std::vector<Tuple> inbox_messages,
                              Tuple sideload,
                              bool blockingSideload_,
-                             nonstd::optional<value> fake_inbox_peak_value_);
+                             nonstd::optional<value> fake_inbox_peek_value_);
 
    public:
     MachineState machine_state;
@@ -71,7 +71,7 @@ class Machine {
     Assertion runCallServer(uint64_t stepCount,
                             std::vector<Tuple> inbox_messages,
                             std::chrono::seconds wallLimit,
-                            value fake_inbox_peak_value);
+                            value fake_inbox_peek_value);
 
     Status currentStatus() { return machine_state.state; }
     uint256_t hash() const { return machine_state.hash(); }

--- a/packages/arb-avm-cpp/avm/include/avm/machinestate/machinestate.hpp
+++ b/packages/arb-avm-cpp/avm/include/avm/machinestate/machinestate.hpp
@@ -33,7 +33,7 @@ struct AssertionContext {
     uint32_t numSteps;
     uint64_t numGas;
     bool blockingSideload;
-    nonstd::optional<value> fake_inbox_peak_value;
+    nonstd::optional<value> fake_inbox_peek_value;
     std::vector<value> outMessage;
     std::vector<value> logs;
 
@@ -42,7 +42,7 @@ struct AssertionContext {
     AssertionContext(std::vector<Tuple> inbox_messages,
                      Tuple sideload,
                      bool blockingSideload_,
-                     nonstd::optional<value> fake_inbox_peak_value_);
+                     nonstd::optional<value> fake_inbox_peek_value_);
 
     // popInbox assumes that the number of messages already consumed is less
     // than the number of messages in the inbox

--- a/packages/arb-avm-cpp/avm/include/avm/machinestate/machinestate.hpp
+++ b/packages/arb-avm-cpp/avm/include/avm/machinestate/machinestate.hpp
@@ -33,14 +33,16 @@ struct AssertionContext {
     uint32_t numSteps;
     uint64_t numGas;
     bool blockingSideload;
+    nonstd::optional<value> fake_inbox_peak_value;
     std::vector<value> outMessage;
     std::vector<value> logs;
 
     AssertionContext() : inbox_messages_consumed(0), numSteps(0), numGas(0) {}
 
-    explicit AssertionContext(std::vector<Tuple> inbox_messages,
-                              Tuple sideload);
-    explicit AssertionContext(std::vector<Tuple> inbox_messages);
+    AssertionContext(std::vector<Tuple> inbox_messages,
+                     Tuple sideload,
+                     bool blockingSideload_,
+                     nonstd::optional<value> fake_inbox_peak_value_);
 
     // popInbox assumes that the number of messages already consumed is less
     // than the number of messages in the inbox

--- a/packages/arb-avm-cpp/avm/src/machine.cpp
+++ b/packages/arb-avm-cpp/avm/src/machine.cpp
@@ -46,14 +46,14 @@ Assertion Machine::executeMachine(
     std::vector<Tuple> inbox_messages,
     Tuple sideload,
     bool blockingSideload,
-    nonstd::optional<value> fake_inbox_peak_value) {
+    nonstd::optional<value> fake_inbox_peek_value) {
     if (!validMessages(inbox_messages)) {
         throw std::runtime_error("invalid message format");
     }
 
     machine_state.context =
         AssertionContext{std::move(inbox_messages), std::move(sideload),
-                         blockingSideload, std::move(fake_inbox_peak_value)};
+                         blockingSideload, std::move(fake_inbox_peek_value)};
 
     bool has_time_limit = wallLimit.count() != 0;
     auto start_time = std::chrono::system_clock::now();
@@ -86,9 +86,9 @@ Assertion Machine::run(uint64_t stepCount,
 Assertion Machine::runCallServer(uint64_t stepCount,
                                  std::vector<Tuple> inbox_messages,
                                  std::chrono::seconds wallLimit,
-                                 value fake_inbox_peak_value) {
+                                 value fake_inbox_peek_value) {
     return executeMachine(stepCount, wallLimit, std::move(inbox_messages),
-                          Tuple(), false, std::move(fake_inbox_peak_value));
+                          Tuple(), false, std::move(fake_inbox_peek_value));
 }
 
 Assertion Machine::runSideloaded(uint64_t stepCount,

--- a/packages/arb-avm-cpp/avm/src/machine.cpp
+++ b/packages/arb-avm-cpp/avm/src/machine.cpp
@@ -26,8 +26,35 @@ std::ostream& operator<<(std::ostream& os, const Machine& val) {
     return os;
 }
 
-Assertion Machine::executeMachine(uint64_t stepCount,
-                                  std::chrono::seconds wallLimit) {
+namespace {
+bool validMessages(const std::vector<Tuple>& messages) {
+    for (const auto& msg : messages) {
+        if (msg.tuple_size() < 2) {
+            return false;
+        }
+        if (!nonstd::holds_alternative<uint256_t>(msg.get_element(1))) {
+            return false;
+        }
+    }
+    return true;
+}
+}  // namespace
+
+Assertion Machine::executeMachine(
+    uint64_t stepCount,
+    std::chrono::seconds wallLimit,
+    std::vector<Tuple> inbox_messages,
+    Tuple sideload,
+    bool blockingSideload,
+    nonstd::optional<value> fake_inbox_peak_value) {
+    if (!validMessages(inbox_messages)) {
+        throw std::runtime_error("invalid message format");
+    }
+
+    machine_state.context =
+        AssertionContext{std::move(inbox_messages), std::move(sideload),
+                         blockingSideload, std::move(fake_inbox_peak_value)};
+
     bool has_time_limit = wallLimit.count() != 0;
     auto start_time = std::chrono::system_clock::now();
     while (machine_state.context.numSteps < stepCount) {
@@ -49,38 +76,25 @@ Assertion Machine::executeMachine(uint64_t stepCount,
             std::move(machine_state.context.logs)};
 }
 
-namespace {
-bool validMessages(const std::vector<Tuple>& messages) {
-    for (const auto& msg : messages) {
-        if (msg.tuple_size() < 2) {
-            return false;
-        }
-        if (!nonstd::holds_alternative<uint256_t>(msg.get_element(1))) {
-            return false;
-        }
-    }
-    return true;
-}
-}  // namespace
-
 Assertion Machine::run(uint64_t stepCount,
                        std::vector<Tuple> inbox_messages,
                        std::chrono::seconds wallLimit) {
-    if (!validMessages(inbox_messages)) {
-        throw std::runtime_error("invalid message format");
-    }
-    machine_state.context = AssertionContext{std::move(inbox_messages)};
-    return executeMachine(stepCount, wallLimit);
+    return executeMachine(stepCount, wallLimit, std::move(inbox_messages),
+                          Tuple(), false, nonstd::nullopt);
+}
+
+Assertion Machine::runCallServer(uint64_t stepCount,
+                                 std::vector<Tuple> inbox_messages,
+                                 std::chrono::seconds wallLimit,
+                                 value fake_inbox_peak_value) {
+    return executeMachine(stepCount, wallLimit, std::move(inbox_messages),
+                          Tuple(), false, std::move(fake_inbox_peak_value));
 }
 
 Assertion Machine::runSideloaded(uint64_t stepCount,
                                  std::vector<Tuple> inbox_messages,
                                  std::chrono::seconds wallLimit,
                                  Tuple sideload_value) {
-    if (!validMessages(inbox_messages)) {
-        throw std::runtime_error("invalid message format");
-    }
-    machine_state.context =
-        AssertionContext{std::move(inbox_messages), std::move(sideload_value)};
-    return executeMachine(stepCount, wallLimit);
+    return executeMachine(stepCount, wallLimit, std::move(inbox_messages),
+                          std::move(sideload_value), true, nonstd::nullopt);
 }

--- a/packages/arb-avm-cpp/avm/src/machinestate/machineoperation.cpp
+++ b/packages/arb-avm-cpp/avm/src/machinestate/machineoperation.cpp
@@ -723,7 +723,15 @@ BlockReason inboxPeekOp(MachineState& m) {
     m.stack.prepForMod(1);
     bool has_staged_message = m.staged_message != Tuple{};
     if (!has_staged_message && m.context.inboxEmpty()) {
-        return InboxBlocked();
+        if (!m.context.fake_inbox_peak_value) {
+            return InboxBlocked();
+        }
+
+        // When fake_inbox_peak_value is set we're in callserver mode. Use
+        // that value as the message value
+        m.stack[0] = m.stack[0] == *m.context.fake_inbox_peak_value ? 1 : 0;
+        ++m.pc;
+        return NotBlocked{};
     }
     if (!has_staged_message) {
         m.staged_message = m.context.popInbox();

--- a/packages/arb-avm-cpp/avm/src/machinestate/machineoperation.cpp
+++ b/packages/arb-avm-cpp/avm/src/machinestate/machineoperation.cpp
@@ -723,13 +723,13 @@ BlockReason inboxPeekOp(MachineState& m) {
     m.stack.prepForMod(1);
     bool has_staged_message = m.staged_message != Tuple{};
     if (!has_staged_message && m.context.inboxEmpty()) {
-        if (!m.context.fake_inbox_peak_value) {
+        if (!m.context.fake_inbox_peek_value) {
             return InboxBlocked();
         }
 
-        // When fake_inbox_peak_value is set we're in callserver mode. Use
+        // When fake_inbox_peek_value is set we're in callserver mode. Use
         // that value as the message value
-        m.stack[0] = m.stack[0] == *m.context.fake_inbox_peak_value ? 1 : 0;
+        m.stack[0] = m.stack[0] == *m.context.fake_inbox_peek_value ? 1 : 0;
         ++m.pc;
         return NotBlocked{};
     }

--- a/packages/arb-avm-cpp/avm/src/machinestate/machinestate.cpp
+++ b/packages/arb-avm-cpp/avm/src/machinestate/machinestate.cpp
@@ -32,14 +32,14 @@ AssertionContext::AssertionContext(
     std::vector<Tuple> inbox_messages,
     Tuple sideload,
     bool blockingSideload_,
-    nonstd::optional<value> fake_inbox_peak_value_)
+    nonstd::optional<value> fake_inbox_peek_value_)
     : inbox_messages(std::move(inbox_messages)),
       inbox_messages_consumed(0),
       sideload_value(std::move(sideload)),
       numSteps{0},
       numGas{0},
       blockingSideload(blockingSideload_),
-      fake_inbox_peak_value(std::move(fake_inbox_peak_value_)) {}
+      fake_inbox_peek_value(std::move(fake_inbox_peek_value_)) {}
 
 MachineState::MachineState()
     : pool(std::make_unique<TuplePool>()),

--- a/packages/arb-avm-cpp/avm/src/machinestate/machinestate.cpp
+++ b/packages/arb-avm-cpp/avm/src/machinestate/machinestate.cpp
@@ -28,22 +28,18 @@ namespace {
 uint256_t max_arb_gas_remaining = std::numeric_limits<uint256_t>::max();
 }  // namespace
 
-AssertionContext::AssertionContext(std::vector<Tuple> inbox_messages,
-                                   Tuple sideload)
+AssertionContext::AssertionContext(
+    std::vector<Tuple> inbox_messages,
+    Tuple sideload,
+    bool blockingSideload_,
+    nonstd::optional<value> fake_inbox_peak_value_)
     : inbox_messages(std::move(inbox_messages)),
       inbox_messages_consumed(0),
       sideload_value(std::move(sideload)),
       numSteps{0},
       numGas{0},
-      blockingSideload(true) {}
-
-AssertionContext::AssertionContext(std::vector<Tuple> inbox_messages)
-    : inbox_messages(std::move(inbox_messages)),
-      inbox_messages_consumed(0),
-      sideload_value(Tuple{}),
-      numSteps{0},
-      numGas{0},
-      blockingSideload(false) {}
+      blockingSideload(blockingSideload_),
+      fake_inbox_peak_value(std::move(fake_inbox_peak_value_)) {}
 
 MachineState::MachineState()
     : pool(std::make_unique<TuplePool>()),

--- a/packages/arb-avm-cpp/cavm/cmachine.cpp
+++ b/packages/arb-avm-cpp/cavm/cmachine.cpp
@@ -211,22 +211,22 @@ RawAssertion executeCallServerAssertion(CMachine* m,
                                         uint64_t maxSteps,
                                         void* inbox_messages,
                                         uint64_t message_count,
-                                        void* fake_inbox_peak_value,
+                                        void* fake_inbox_peek_value,
                                         uint64_t wallLimit) {
     assert(m);
     Machine* mach = static_cast<Machine*>(m);
 
     auto messages =
         getInboxMessages(mach->getPool(), inbox_messages, message_count);
-    auto fake_inbox_peak_value_data =
-        reinterpret_cast<const char*>(fake_inbox_peak_value);
-    auto fake_inbox_peak =
-        deserialize_value(fake_inbox_peak_value_data, mach->getPool());
+    auto fake_inbox_peek_value_data =
+        reinterpret_cast<const char*>(fake_inbox_peek_value);
+    auto fake_inbox_peek =
+        deserialize_value(fake_inbox_peek_value_data, mach->getPool());
 
     try {
         Assertion assertion = mach->runCallServer(
             maxSteps, std::move(messages), std::chrono::seconds{wallLimit},
-            std::move(fake_inbox_peak));
+            std::move(fake_inbox_peek));
         return makeRawAssertion(assertion);
     } catch (const std::exception& e) {
         std::cerr << "Failed to make assertion " << e.what() << "\n";

--- a/packages/arb-avm-cpp/cavm/cmachine.cpp
+++ b/packages/arb-avm-cpp/cavm/cmachine.cpp
@@ -207,6 +207,33 @@ RawAssertion executeAssertion(CMachine* m,
     }
 }
 
+RawAssertion executeCallServerAssertion(CMachine* m,
+                                        uint64_t maxSteps,
+                                        void* inbox_messages,
+                                        uint64_t message_count,
+                                        void* fake_inbox_peak_value,
+                                        uint64_t wallLimit) {
+    assert(m);
+    Machine* mach = static_cast<Machine*>(m);
+
+    auto messages =
+        getInboxMessages(mach->getPool(), inbox_messages, message_count);
+    auto fake_inbox_peak_value_data =
+        reinterpret_cast<const char*>(fake_inbox_peak_value);
+    auto fake_inbox_peak =
+        deserialize_value(fake_inbox_peak_value_data, mach->getPool());
+
+    try {
+        Assertion assertion = mach->runCallServer(
+            maxSteps, std::move(messages), std::chrono::seconds{wallLimit},
+            std::move(fake_inbox_peak));
+        return makeRawAssertion(assertion);
+    } catch (const std::exception& e) {
+        std::cerr << "Failed to make assertion " << e.what() << "\n";
+        return makeEmptyAssertion();
+    }
+}
+
 RawAssertion executeSideloadedAssertion(CMachine* m,
                                         uint64_t maxSteps,
                                         void* inbox_messages,

--- a/packages/arb-avm-cpp/cavm/cmachine.h
+++ b/packages/arb-avm-cpp/cavm/cmachine.h
@@ -79,7 +79,7 @@ RawAssertion executeCallServerAssertion(CMachine* m,
                                         uint64_t maxSteps,
                                         void* inbox_messages,
                                         uint64_t message_count,
-                                        void* fake_inbox_peak_value,
+                                        void* fake_inbox_peek_value,
                                         uint64_t wallLimit);
 
 RawAssertion executeSideloadedAssertion(CMachine* m,

--- a/packages/arb-avm-cpp/cavm/cmachine.h
+++ b/packages/arb-avm-cpp/cavm/cmachine.h
@@ -75,6 +75,13 @@ RawAssertion executeAssertion(CMachine* m,
                               uint64_t message_count,
                               uint64_t wallLimit);
 
+RawAssertion executeCallServerAssertion(CMachine* m,
+                                        uint64_t maxSteps,
+                                        void* inbox_messages,
+                                        uint64_t message_count,
+                                        void* fake_inbox_peak_value,
+                                        uint64_t wallLimit);
+
 RawAssertion executeSideloadedAssertion(CMachine* m,
                                         uint64_t maxSteps,
                                         void* inbox_messages,

--- a/packages/arb-util/machine/machine.go
+++ b/packages/arb-util/machine/machine.go
@@ -47,6 +47,17 @@ type Machine interface {
 		maxWallTime time.Duration,
 	) (*protocol.ExecutionAssertion, uint64)
 
+	// Supply a value that the inbox peek opcode will return if the inbox
+	// runs out of messages. For ArbOS, this can be used to simulate a message
+	// from the next block arriving in order to trigger end-of-block processes
+	// without waiting for the next block
+	ExecuteCallServerAssertion(
+		maxSteps uint64,
+		inboxMessages []inbox.InboxMessage,
+		fakeInboxPeekValue value.Value,
+		maxWallTime time.Duration,
+	) (*protocol.ExecutionAssertion, uint64)
+
 	ExecuteSideloadedAssertion(
 		maxSteps uint64,
 		messages []inbox.InboxMessage,


### PR DESCRIPTION
This PR adds a new execution method, `ExecuteCallServerAssertion`. These assertions provide a fake value for use in the `inboxpeek` opcode if the runtime has run out of actual inbox messages. This can be used by the call server to notify the VM that it has seen the last message in the block before any messages from the next block actually arrive.