### PR TITLE
arbitrum docs entry point (WIP/proposal)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,47 @@
+## Arbitrum Docs
+
+Arbitrum is a trustless, permissionless layer 2 protocol for running scalable smart contracts.
+
+For an introduction to what Arbitrum is and how it works, see [Rollup Basics]
+
+##### For Developers:
+
+Get started developing and integrating with Arbitrum technology:
+
+- [Quickstart]
+- [Installation]
+- [Deploying contracts]
+- [Integrating your frontend]
+
+##### Core Protocol
+
+Learn how Arbitrum achieves its trustless security guaruntees:
+
+- [Rollup Protocol]
+- [Dispute Resolution]
+- [Finality]
+
+##### Execution
+
+Learn about Arbitrum's custom layer 2 contract execution environment:
+
+- [AVM design] / [AVM spec]
+- [ArbOs] / [ArbOS formats]
+- [Arb Gas]
+- [Solidity Support]
+
+##### L1 and L2 properties
+
+Learn about how the Arbitrum chain and the L1 Ethereum chain interact:
+
+- [Ethereum Interop]
+- [Withdrawals]
+- [Tx lifecycle]
+- [Aggregator]
+
+##### Misc:
+
+- [Glossary]
+- [Time in arbitrum]
+- [Arbsys]
+- [Chain Parameters]


### PR DESCRIPTION
One possible structure for the landing page / entry point to the docs; essentially a table of contents sort of thing that links to everything directly with a bit of categorization. Slightly redundant with Rollup Basics, but that may be okay. 