### PR TITLE
Fix block hash

### DIFF
--- a/packages/arb-tx-aggregator/aggregator/aggregator.go
+++ b/packages/arb-tx-aggregator/aggregator/aggregator.go
@@ -41,7 +41,7 @@ import (
 )
 
 type Server struct {
-	client      ethutils.EthClient
+	Client      ethutils.EthClient
 	chain       common.Address
 	batch       *batcher.Batcher
 	db          *txdb.TxDB
@@ -57,7 +57,7 @@ func NewServer(
 	db *txdb.TxDB,
 ) *Server {
 	return &Server{
-		client:      client,
+		Client:      client,
 		chain:       rollupAddress,
 		batch:       batch,
 		db:          db,
@@ -66,7 +66,7 @@ func NewServer(
 	}
 }
 
-// SendTransaction takes a request signed transaction l2message from a client
+// SendTransaction takes a request signed transaction l2message from a Client
 // and puts it in a queue to be included in the next transaction batch
 func (m *Server) SendTransaction(tx *types.Transaction) (common.Hash, error) {
 	return m.batch.SendTransaction(tx)
@@ -126,7 +126,7 @@ func (m *Server) BlockInfo(height uint64) (*machine.BlockInfo, error) {
 }
 
 func (m *Server) GetBlockHeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
-	ethHeader, err := m.client.HeaderByHash(ctx, hash.ToEthHash())
+	ethHeader, err := m.Client.HeaderByHash(ctx, hash.ToEthHash())
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (m *Server) GetBlockHeaderByHash(ctx context.Context, hash common.Hash) (*t
 		return nil, err
 	}
 
-	return m.getBlockHeader(currentBlock, ethHeader)
+	return getBlockHeader(currentBlock, ethHeader)
 }
 
 func (m *Server) GetBlockHeaderByNumber(ctx context.Context, height uint64) (*types.Header, error) {
@@ -147,51 +147,54 @@ func (m *Server) GetBlockHeaderByNumber(ctx context.Context, height uint64) (*ty
 
 	var ethHeader *types.Header
 	if currentBlock != nil {
-		ethHeader, err = m.client.HeaderByHash(ctx, currentBlock.Hash.ToEthHash())
+		ethHeader, err = m.Client.HeaderByHash(ctx, currentBlock.Hash.ToEthHash())
 	} else {
-		ethHeader, err = m.client.HeaderByNumber(ctx, new(big.Int).SetUint64(height))
+		ethHeader, err = m.Client.HeaderByNumber(ctx, new(big.Int).SetUint64(height))
 	}
 	if err != nil {
 		return nil, err
 	}
-	return m.getBlockHeader(currentBlock, ethHeader)
+	return getBlockHeader(currentBlock, ethHeader)
 }
 
-func (m *Server) getBlockHeader(currentBlock *machine.BlockInfo, ethHeader *types.Header) (*types.Header, error) {
+func GetBlockFields(currentBlock *machine.BlockInfo, res *evm.BlockInfo) (types.Bloom, uint64, uint64) {
 	gasUsed := uint64(0)
 	gasLimit := uint64(100000000)
 	bloom := types.Bloom{}
 	if currentBlock != nil {
-		res, err := evm.NewBlockResultFromValue(currentBlock.BlockLog)
-		if err != nil {
-			return nil, err
-		}
 		gasUsed = res.BlockStats.GasUsed.Uint64()
 		gasLimit = res.GasLimit.Uint64()
 		bloom = currentBlock.Bloom
 	}
+	return bloom, gasLimit, gasUsed
+}
 
-	ethHeader.Bloom = bloom
-	ethHeader.GasLimit = gasLimit
-	ethHeader.GasUsed = gasUsed
+func getBlockHeader(currentBlock *machine.BlockInfo, ethHeader *types.Header) (*types.Header, error) {
+	var res *evm.BlockInfo
+	if currentBlock != nil {
+		var err error
+		res, err = evm.NewBlockResultFromValue(currentBlock.BlockLog)
+		if err != nil {
+			return nil, err
+		}
+	}
 
+	ethHeader.Bloom, ethHeader.GasLimit, ethHeader.GasUsed = GetBlockFields(currentBlock, res)
 	return ethHeader, nil
 }
 
-func (m *Server) GetBlockResults(height uint64) ([]*evm.TxResult, error) {
-	currentBlock, err := m.db.GetBlock(height)
-	if err != nil {
-		return nil, err
-	}
-
-	if currentBlock == nil {
+func (m *Server) GetBlockInfo(block *machine.BlockInfo) (*evm.BlockInfo, error) {
+	if block == nil {
 		// No arbitrum block at this height
 		return nil, nil
 	}
 
-	res, err := evm.NewBlockResultFromValue(currentBlock.BlockLog)
-	if err != nil {
-		return nil, err
+	return evm.NewBlockResultFromValue(block.BlockLog)
+}
+
+func (m *Server) GetBlockResults(res *evm.BlockInfo) ([]*evm.TxResult, error) {
+	if res == nil {
+		return nil, nil
 	}
 	txCount := res.BlockStats.TxCount.Uint64()
 	startLog := res.FirstAVMLog().Uint64()
@@ -216,7 +219,17 @@ func (m *Server) GetBlock(ctx context.Context, height uint64) (*types.Block, err
 		return nil, err
 	}
 
-	results, err := m.GetBlockResults(height)
+	block, err := m.BlockInfo(height)
+	if err != nil {
+		return nil, err
+	}
+
+	blockInfo, err := m.GetBlockInfo(block)
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := m.GetBlockResults(blockInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -258,14 +271,14 @@ func (m *Server) AdjustGas(msg message.ContractTransaction) message.ContractTran
 	return msg
 }
 
-// Call takes a request from a client to process in a temporary context
+// Call takes a request from a Client to process in a temporary context
 // and return the result
 func (m *Server) Call(msg message.ContractTransaction, sender ethcommon.Address) (*evm.TxResult, error) {
 	msg = m.AdjustGas(msg)
 	return m.db.LatestSnapshot().Call(msg, common.NewAddressFromEth(sender))
 }
 
-// PendingCall takes a request from a client to process in a temporary context
+// PendingCall takes a request from a Client to process in a temporary context
 // and return the result
 func (m *Server) PendingCall(msg message.ContractTransaction, sender ethcommon.Address) (*evm.TxResult, error) {
 	return m.Call(msg, sender)
@@ -273,7 +286,7 @@ func (m *Server) PendingCall(msg message.ContractTransaction, sender ethcommon.A
 
 func (m *Server) GetSnapshot(ctx context.Context, blockHeight uint64) (*snapshot.Snapshot, error) {
 	height := new(big.Int).SetUint64(blockHeight)
-	header, err := m.client.HeaderByNumber(ctx, height)
+	header, err := m.Client.HeaderByNumber(ctx, height)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/arb-validator/go.mod
+++ b/packages/arb-validator/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/offchainlabs/arbitrum/packages/arb-avm-cpp v0.7.1
 	github.com/offchainlabs/arbitrum/packages/arb-checkpointer v0.7.1
+	github.com/offchainlabs/arbitrum/packages/arb-tx-aggregator v0.7.1 // indirect
 	github.com/offchainlabs/arbitrum/packages/arb-util v0.7.1
 	github.com/offchainlabs/arbitrum/packages/arb-validator-core v0.7.1
 	github.com/pkg/errors v0.9.1

--- a/packages/arb-validator/go.sum
+++ b/packages/arb-validator/go.sum
@@ -64,6 +64,8 @@ github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c h1:JHHhtb9XWJrGNMcr
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa h1:XKAhUk/dtp+CV0VO6mhG2V7jA9vbcGcnYF/Ay9NjZrY=
 github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
+github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
+github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum/go-ethereum v1.9.14/go.mod h1:oP8FC5+TbICUyftkTWs+8JryntjIJLJvWvApK3z2AYw=
@@ -115,6 +117,10 @@ github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/rpc v1.2.0 h1:WvvdC2lNeT1SP32zrIce5l0ECBfbAlmrmSBsuc57wfk=
+github.com/gorilla/rpc v1.2.0/go.mod h1:V4h9r+4sF5HnzqbwIez0fKSpANP0zlYd3qR7p36jkTQ=
 github.com/gorilla/websocket v1.4.1-0.20190629185528-ae1634f6a989 h1:giknQ4mEuDFmmHSrGcbargOuLHQGtywqo4mheITex54=
 github.com/gorilla/websocket v1.4.1-0.20190629185528-ae1634f6a989/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
@@ -142,6 +148,7 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -158,6 +165,11 @@ github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
+github.com/offchainlabs/arbitrum v0.7.1 h1:JBkSbMZFObg/2rqIiXiLrKLxN7WelEtBOGRY6jalmoc=
+github.com/offchainlabs/arbitrum/packages/arb-evm v0.7.1 h1:Heo6Sq3JuZSsvPuQccjcqGK5dsdNcvUHWwaUa2j6nm8=
+github.com/offchainlabs/arbitrum/packages/arb-evm v0.7.1/go.mod h1:4XbYeQDzNKgK4YA0b4wxF5XcaOIAo11RTClyfagDZRI=
+github.com/offchainlabs/arbitrum/packages/arb-tx-aggregator v0.7.1 h1:tjNbbHa3mpmaGrwQN07ihWEDri3hwCk8Hezz/dyKsW0=
+github.com/offchainlabs/arbitrum/packages/arb-tx-aggregator v0.7.1/go.mod h1:qJjvnJjDg33KWxiVj+6IU9kxmbSRzheyGt+fsJZHrfc=
 github.com/offchainlabs/go-solidity-sha3 v0.1.2 h1:IJ/KUv8zW5+Rtq/VvhNjq/Q7MDXjDx1ArAvkJhBRQAs=
 github.com/offchainlabs/go-solidity-sha3 v0.1.2/go.mod h1:WYAU7UTm1wXzEhnsTt843T77fKfR9x/rqqzjm8NJ3Mc=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -291,6 +303,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=


### PR DESCRIPTION
- Update the behavior of eth_getBlockByHash and eth_getBlockByNumber to use the same hash and parent hash as Ethereum. The previous behavior led to block hashes (which were calculated after modifying some header fields) not matching parent hashes.

Note that at some point we may run into an issue from our block hashes not matching the contents of our blocks served via RPC, but that issue already existed and is no worse with this PR. Also it appears that clients take the hash from the RPC result rather than recalculating it