### PR TITLE
Deduplicate Values when deserializing Machine type - Alternate implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "homepage": "https://offchainlabs.com/",
   "scripts": {
     "install:deps": "./scripts/install-deps",
-    "install:ci": "./scripts/install-ci",
     "install:validator": "./scripts/install-validator",
     "update-abi": "yarn go:generate && yarn workspace arb-provider-ethers update-abi",
     "build": "yarn workspace arb-provider-ethers build",

--- a/packages/arb-avm-cpp/app/main.cpp
+++ b/packages/arb-avm-cpp/app/main.cpp
@@ -69,7 +69,8 @@ int main(int argc, char* argv[]) {
         storage.initialize(filename);
     }
 
-    auto mach = storage.getInitialMachine();
+    ValueCache value_cache{};
+    auto mach = storage.getInitialMachine(value_cache);
 
     std::vector<Tuple> inbox_messages;
     if (argc == 5) {
@@ -115,7 +116,7 @@ int main(int argc, char* argv[]) {
     saveMachine(*tx, mach);
     tx->commit();
 
-    auto mach2 = storage.getMachine(mach.hash());
+    auto mach2 = storage.getMachine(mach.hash(), value_cache);
     mach2.run(0, {}, std::chrono::seconds(0));
     return 0;
 }

--- a/packages/arb-avm-cpp/avm_values/include/avm_values/tuple.hpp
+++ b/packages/arb-avm-cpp/avm_values/include/avm_values/tuple.hpp
@@ -26,6 +26,7 @@
 
 HashPreImage zeroPreimage();
 struct BasicValChecker;
+struct ValueBeingParsed;
 
 class Tuple {
    private:
@@ -33,8 +34,17 @@ class Tuple {
 
     void calculateHashPreImage() const;
 
+    void unsafe_set_element(uint64_t pos, value&& newval) {
+        if (pos >= tuple_size()) {
+            throw bad_tuple_index{};
+        }
+        tpl->data[pos] = std::move(newval);
+        tpl->deferredHashing = true;
+    }
+
     friend BasicValChecker;
     friend RawTuple;
+    friend ValueBeingParsed;
 
    public:
     Tuple() : tpl(nullptr) {}

--- a/packages/arb-avm-cpp/cavm/ccheckpointstorage.cpp
+++ b/packages/arb-avm-cpp/cavm/ccheckpointstorage.cpp
@@ -78,8 +78,9 @@ CAggregatorStore* createAggregatorStore(CCheckpointStorage* storage_ptr) {
 
 CMachine* getInitialMachine(const CCheckpointStorage* storage_ptr) {
     auto storage = static_cast<const CheckpointStorage*>(storage_ptr);
+    ValueCache value_cache{};
     try {
-        return new Machine(storage->getInitialMachine());
+        return new Machine(storage->getInitialMachine(value_cache));
     } catch (const std::exception&) {
         return nullptr;
     }
@@ -89,8 +90,9 @@ CMachine* getMachine(const CCheckpointStorage* storage_ptr,
                      const void* machine_hash) {
     auto storage = static_cast<const CheckpointStorage*>(storage_ptr);
     auto hash = receiveUint256(machine_hash);
+    ValueCache value_cache{};
     try {
-        return new Machine(storage->getMachine(hash));
+        return new Machine(storage->getMachine(hash, value_cache));
     } catch (const std::exception&) {
         return nullptr;
     }
@@ -127,7 +129,8 @@ ByteSlice getValue(const CCheckpointStorage* storage_ptr,
                    const void* hash_key) {
     auto storage = static_cast<const CheckpointStorage*>(storage_ptr);
     auto hash = receiveUint256(hash_key);
-    return returnValueResult(storage->getValue(hash));
+    ValueCache value_cache{};
+    return returnValueResult(storage->getValue(hash, value_cache));
 }
 
 int deleteValue(CCheckpointStorage* storage_ptr, const void* hash_key) {

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/checkpointstorage.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/checkpointstorage.hpp
@@ -19,6 +19,7 @@
 
 #include <avm_values/vmValueParser.hpp>
 #include <data_storage/datastorage.hpp>
+#include <data_storage/value/value.hpp>
 
 #include <memory>
 #include <string>
@@ -38,7 +39,7 @@ class CheckpointStorage {
     std::shared_ptr<Code> code;
 
    public:
-    CheckpointStorage(const std::string& db_path);
+    explicit CheckpointStorage(const std::string& db_path);
     bool closeCheckpointStorage();
     void initialize(LoadedExecutable executable);
     void initialize(const std::string& executable_path);
@@ -50,9 +51,10 @@ class CheckpointStorage {
     std::unique_ptr<BlockStore> getBlockStore() const;
     std::unique_ptr<AggregatorStore> getAggregatorStore() const;
 
-    Machine getInitialMachine() const;
-    Machine getMachine(uint256_t machineHash) const;
-    DbResult<value> getValue(uint256_t value_hash) const;
+    Machine getInitialMachine(ValueCache& value_cache) const;
+    Machine getMachine(uint256_t machineHash, ValueCache& value_cache) const;
+    DbResult<value> getValue(uint256_t value_hash,
+                             ValueCache& value_cache) const;
 };
 
 #endif /* checkpointstorage_hpp */

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/value/code.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/value/code.hpp
@@ -18,6 +18,7 @@
 #define checkpoint_code_hpp
 
 #include <cstdint>
+#include <data_storage/value/value.hpp>
 #include <map>
 #include <memory>
 #include <set>
@@ -30,7 +31,8 @@ uint64_t getNextSegmentID(const Transaction& transaction);
 
 std::shared_ptr<CodeSegment> getCodeSegment(const Transaction& transaction,
                                             uint64_t segment_id,
-                                            std::set<uint64_t>& segment_ids);
+                                            std::set<uint64_t>& segment_ids,
+                                            ValueCache& value_cache);
 void saveCode(Transaction& transaction,
               const Code& code,
               std::map<uint64_t, uint64_t>& segment_counts);

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/value/value.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/value/value.hpp
@@ -29,6 +29,14 @@ class Transaction;
 template <typename T>
 struct DbResult;
 
+struct ValueCacheHasher {
+    std::size_t operator()(const uint256_t& v) const noexcept {
+        return intx::narrow_cast<std::size_t>(v);
+    }
+};
+
+using ValueCache = std::unordered_map<uint256_t, value, ValueCacheHasher>;
+
 SaveResults saveValueImpl(Transaction& transaction,
                           const value& val,
                           std::map<uint64_t, uint64_t>& segment_counts);
@@ -37,9 +45,12 @@ DeleteResults deleteValueImpl(Transaction& transaction,
                               std::map<uint64_t, uint64_t>& segment_counts);
 DbResult<value> getValueImpl(const Transaction& transaction,
                              uint256_t value_hash,
-                             std::set<uint64_t>& segment_ids);
+                             std::set<uint64_t>& segment_ids,
+                             ValueCache& value_cache);
 
-DbResult<value> getValue(const Transaction& transaction, uint256_t value_hash);
+DbResult<value> getValue(const Transaction& transaction,
+                         uint256_t value_hash,
+                         ValueCache& value_cache);
 SaveResults saveValue(Transaction& transaction, const value& val);
 DeleteResults deleteValue(Transaction& transaction, uint256_t value_hash);
 

--- a/packages/arb-avm-cpp/data_storage/src/checkpointstorage.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/checkpointstorage.cpp
@@ -21,7 +21,6 @@
 #include <data_storage/storageresult.hpp>
 #include <data_storage/value/code.hpp>
 #include <data_storage/value/machine.hpp>
-#include <data_storage/value/value.hpp>
 
 #include <avm/machine.hpp>
 
@@ -31,10 +30,9 @@
 
 #include <rocksdb/options.h>
 #include <rocksdb/utilities/transaction.h>
-#include <rocksdb/utilities/transaction_db.h>
 
 namespace {
-const std::string initial_slice_label = "initial";
+constexpr auto initial_slice_label = "initial";
 }
 
 CheckpointStorage::CheckpointStorage(const std::string& db_path)
@@ -111,7 +109,7 @@ std::unique_ptr<AggregatorStore> CheckpointStorage::getAggregatorStore() const {
     return std::make_unique<AggregatorStore>(datastorage);
 }
 
-Machine CheckpointStorage::getInitialMachine() const {
+Machine CheckpointStorage::getInitialMachine(ValueCache& value_cache) const {
     auto tx = makeConstTransaction();
     std::string initial_raw;
     auto s =
@@ -123,10 +121,11 @@ Machine CheckpointStorage::getInitialMachine() const {
 
     auto machine_hash = intx::be::unsafe::load<uint256_t>(
         reinterpret_cast<const unsigned char*>(initial_raw.data()));
-    return getMachine(machine_hash);
+    return getMachine(machine_hash, value_cache);
 }
 
-Machine CheckpointStorage::getMachine(uint256_t machineHash) const {
+Machine CheckpointStorage::getMachine(uint256_t machineHash,
+                                      ValueCache& value_cache) const {
     std::set<uint64_t> segment_ids;
     auto transaction = makeConstTransaction();
     auto results = getMachineState(*transaction, machineHash);
@@ -136,34 +135,34 @@ Machine CheckpointStorage::getMachine(uint256_t machineHash) const {
 
     auto state_data = results.data;
 
-    auto static_results =
-        ::getValueImpl(*transaction, state_data.static_hash, segment_ids);
+    auto static_results = ::getValueImpl(*transaction, state_data.static_hash,
+                                         segment_ids, value_cache);
     if (!static_results.status.ok()) {
         throw std::runtime_error("failed loaded core machine static");
     }
 
-    auto register_results =
-        ::getValueImpl(*transaction, state_data.register_hash, segment_ids);
+    auto register_results = ::getValueImpl(
+        *transaction, state_data.register_hash, segment_ids, value_cache);
     if (!register_results.status.ok()) {
         throw std::runtime_error("failed to load machine register");
     }
 
-    auto stack_results =
-        ::getValueImpl(*transaction, state_data.datastack_hash, segment_ids);
+    auto stack_results = ::getValueImpl(*transaction, state_data.datastack_hash,
+                                        segment_ids, value_cache);
     if (!stack_results.status.ok() ||
         !nonstd::holds_alternative<Tuple>(stack_results.data)) {
         throw std::runtime_error("failed to load machine stack");
     }
 
-    auto auxstack_results =
-        ::getValueImpl(*transaction, state_data.auxstack_hash, segment_ids);
+    auto auxstack_results = ::getValueImpl(
+        *transaction, state_data.auxstack_hash, segment_ids, value_cache);
     if (!auxstack_results.status.ok() ||
         !nonstd::holds_alternative<Tuple>(auxstack_results.data)) {
         throw std::runtime_error("failed to load machine auxstack");
     }
 
     auto staged_message_results = ::getValueImpl(
-        *transaction, state_data.staged_message_hash, segment_ids);
+        *transaction, state_data.staged_message_hash, segment_ids, value_cache);
     if (!staged_message_results.status.ok()) {
         throw std::runtime_error("failed to load machine saved message");
     }
@@ -180,7 +179,8 @@ Machine CheckpointStorage::getMachine(uint256_t machineHash) const {
                 // If the segment is already loaded, no need to restore it
                 continue;
             }
-            auto segment = getCodeSegment(*transaction, *it, next_segment_ids);
+            auto segment = getCodeSegment(*transaction, *it, next_segment_ids,
+                                          value_cache);
             code->restoreExistingSegment(std::move(segment));
             loaded_segment = true;
         }
@@ -199,7 +199,8 @@ Machine CheckpointStorage::getMachine(uint256_t machineHash) const {
                         std::move(staged_message_results.data.get<Tuple>())};
 }
 
-DbResult<value> CheckpointStorage::getValue(uint256_t value_hash) const {
+DbResult<value> CheckpointStorage::getValue(uint256_t value_hash,
+                                            ValueCache& value_cache) const {
     auto tx = makeConstTransaction();
-    return ::getValue(*tx, value_hash);
+    return ::getValue(*tx, value_hash, value_cache);
 }

--- a/packages/arb-avm-cpp/data_storage/src/value/code.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/value/code.cpp
@@ -21,7 +21,6 @@
 
 #include <data_storage/datastorage.hpp>
 #include <data_storage/storageresult.hpp>
-#include <data_storage/value/value.hpp>
 
 #include <avm_values/code.hpp>
 
@@ -31,12 +30,12 @@
 
 namespace {
 
-const std::string max_code_segment_key = "max_code_segment";
+constexpr auto max_code_segment_key = "max_code_segment";
 constexpr auto segment_key_prefix = std::array<char, 1>{87};
 constexpr auto segment_key_size = segment_key_prefix.size() + sizeof(uint64_t);
 
 std::array<unsigned char, segment_key_size> segment_key(uint64_t segment_id) {
-    std::array<unsigned char, segment_key_size> key;
+    std::array<unsigned char, segment_key_size> key{};
     auto it = std::copy(segment_key_prefix.begin(), segment_key_prefix.end(),
                         key.begin());
     auto big_id = boost::endian::native_to_big(segment_id);
@@ -54,7 +53,7 @@ struct RawCodePoint {
 RawCodePoint extractRawCodePoint(const char*& ptr) {
     bool is_immediate = static_cast<bool>(*ptr);
     ++ptr;
-    OpCode opcode = static_cast<OpCode>(*ptr);
+    auto opcode = static_cast<OpCode>(*ptr);
     ++ptr;
     uint256_t next_hash = deserializeUint256t(ptr);
     if (!is_immediate) {
@@ -65,7 +64,7 @@ RawCodePoint extractRawCodePoint(const char*& ptr) {
 }
 
 std::vector<RawCodePoint> extractRawCodeSegment(
-    const std::vector<unsigned char> stored_value) {
+    const std::vector<unsigned char>& stored_value) {
     auto iter = stored_value.begin();
     auto ptr = reinterpret_cast<const char*>(&*iter);
     auto cp_count = deserialize_uint64_t(ptr);
@@ -133,7 +132,8 @@ std::vector<unsigned char> prepareToSaveCodeSegment(
 
 std::shared_ptr<CodeSegment> getCodeSegment(const Transaction& transaction,
                                             uint64_t segment_id,
-                                            std::set<uint64_t>& segment_ids) {
+                                            std::set<uint64_t>& segment_ids,
+                                            ValueCache& value_cache) {
     auto key_vec = segment_key(segment_id);
     auto key = vecToSlice(key_vec);
     auto results = getRefCountedData(*transaction.transaction, key);
@@ -149,8 +149,8 @@ std::shared_ptr<CodeSegment> getCodeSegment(const Transaction& transaction,
         if (!raw_cp.immediateHash) {
             cps.emplace_back(Operation{raw_cp.opcode}, raw_cp.next_hash);
         } else {
-            auto imm =
-                getValueImpl(transaction, *raw_cp.immediateHash, segment_ids);
+            auto imm = getValueImpl(transaction, *raw_cp.immediateHash,
+                                    segment_ids, value_cache);
             if (!imm.status.ok()) {
                 throw std::runtime_error("failed to load immediate value");
             }
@@ -191,7 +191,7 @@ template <typename Func>
 std::unordered_map<uint64_t, uint64_t> breadthFirstSearch(
     std::map<uint64_t, uint64_t>& segment_counts,
     Func&& func) {
-    std::unordered_map<uint64_t, uint64_t> total_segment_counts;
+    std::unordered_map<uint64_t, uint64_t> total_segment_counts{};
     auto current_segment_counts = segment_counts;
 
     bool found = true;
@@ -214,7 +214,7 @@ std::unordered_map<uint64_t, uint64_t> breadthFirstSearch(
 
 void deleteCode(Transaction& transaction,
                 std::map<uint64_t, uint64_t>& segment_counts) {
-    std::unordered_map<uint64_t, GetResults> current_values;
+    std::unordered_map<uint64_t, GetResults> current_values{};
     auto current_segment_counts = segment_counts;
 
     auto total_deleted_segment_references = breadthFirstSearch(
@@ -264,7 +264,7 @@ void saveCode(Transaction& transaction,
     saveNextSegmentID(transaction, snapshots.op_count);
 
     std::unordered_map<uint64_t, std::vector<unsigned char>>
-        code_segments_to_save;
+        code_segments_to_save{};
 
     auto total_segment_counts = breadthFirstSearch(
         segment_counts, [&](uint64_t segment_id, uint64_t total_reference_count,

--- a/packages/arb-avm-cpp/data_storage/src/value/value.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/value/value.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <data_storage/value/value.hpp>
+#include <utility>
 
 #include "referencecount.hpp"
 #include "utils.hpp"
@@ -23,12 +24,12 @@
 #include <data_storage/storageresult.hpp>
 
 #include <avm_values/tuple.hpp>
+#include <cstdint>
+#include <vector>
 
 constexpr int TUP_TUPLE_LENGTH = 33;
 constexpr int TUP_NUM_LENGTH = 33;
 constexpr int TUP_CODEPT_LENGTH = 49;
-
-namespace {
 
 struct ValueHash {
     uint256_t hash;
@@ -39,8 +40,25 @@ using ParsedTupVal = nonstd::variant<uint256_t, CodePointStub, ValueHash>;
 using ParsedSerializedVal =
     nonstd::variant<uint256_t, CodePointStub, std::vector<ParsedTupVal>>;
 
+struct ValueBeingParsed {
+    value val;
+    uint32_t reference_count;
+    std::vector<ParsedTupVal> raw_vals;
+
+    ValueBeingParsed(value&& v, uint32_t count)
+        : val{std::move(v)}, reference_count{count}, raw_vals{} {}
+
+    void setTupleElement(uint64_t pos, value&& newval) {
+        if (nonstd::holds_alternative<Tuple>(val)) {
+            val.get<Tuple>().unsafe_set_element(pos, std::move(newval));
+        }
+    }
+};
+
+namespace {
+
 std::vector<ParsedTupVal> parseTuple(const std::vector<unsigned char>& data) {
-    std::vector<ParsedTupVal> return_vector;
+    std::vector<ParsedTupVal> return_vector{};
 
     auto iter = data.begin();
     uint8_t count = *iter - TUPLE;
@@ -53,12 +71,12 @@ std::vector<ParsedTupVal> parseTuple(const std::vector<unsigned char>& data) {
 
         switch (value_type) {
             case NUM: {
-                return_vector.push_back(deserializeUint256t(buf));
+                return_vector.emplace_back(deserializeUint256t(buf));
                 iter += TUP_NUM_LENGTH;
                 break;
             }
             case CODE_POINT_STUB: {
-                return_vector.push_back(deserializeCodePointStub(buf));
+                return_vector.emplace_back(deserializeCodePointStub(buf));
                 iter += TUP_CODEPT_LENGTH;
                 break;
             }
@@ -66,14 +84,13 @@ std::vector<ParsedTupVal> parseTuple(const std::vector<unsigned char>& data) {
                 throw std::runtime_error("HASH_ONLY item");
             }
             case TUPLE: {
-                return_vector.push_back(ValueHash{deserializeUint256t(buf)});
+                return_vector.emplace_back(ValueHash{deserializeUint256t(buf)});
                 iter += TUP_TUPLE_LENGTH;
                 break;
             }
             default: {
                 throw std::runtime_error(
                     "tried to parse tuple value with invalid typecode");
-                break;
             }
         }
     }
@@ -127,7 +144,7 @@ std::vector<value> serializeValue(
     const Tuple& val,
     std::vector<unsigned char>& value_vector,
     std::map<uint64_t, uint64_t>& segment_counts) {
-    std::vector<value> ret;
+    std::vector<value> ret{};
     value_vector.push_back(TUPLE + val.tuple_size());
     for (uint64_t i = 0; i < val.tuple_size(); i++) {
         auto nested = val.get_element_unsafe(i);
@@ -179,104 +196,240 @@ void deleteParsedValue(const std::vector<ParsedTupVal>& tup,
 }
 }  // namespace
 
-GetResults processVal(const Transaction& transaction,
-                      const ValueHash& val_hash,
-                      std::vector<DeserializedValue>& vals,
-                      std::vector<ParsedTupVal>& raw_vals,
-                      std::set<uint64_t>& segment_ids);
+GetResults applyValue(value&& val,
+                      uint32_t reference_count,
+                      std::vector<ValueBeingParsed>& val_stack) {
+    auto& current = val_stack.back();
 
-GetResults processVal(const Transaction&,
-                      const uint256_t& val,
-                      std::vector<DeserializedValue>& vals,
-                      std::vector<ParsedTupVal>&,
-                      std::set<uint64_t>&) {
-    vals.push_back(value{val});
-    return GetResults{1, rocksdb::Status::OK(), {}};
-}
+    // This function is only called when populating an existing tuple
+    auto tuple_size = current.val.get<Tuple>().tuple_size();
+    uint64_t tuple_index = tuple_size - current.raw_vals.size() - 1;
+    if (tuple_index >= tuple_size) {
+        throw std::runtime_error("Tuple and raw_vals size mismatch");
+    }
 
-GetResults processVal(const Transaction&,
-                      const CodePointStub& val,
-                      std::vector<DeserializedValue>& vals,
-                      std::vector<ParsedTupVal>&,
-                      std::set<uint64_t>& segment_ids) {
-    segment_ids.insert(val.pc.segment);
-    vals.push_back(value{val});
-    return GetResults{1, rocksdb::Status::OK(), {}};
-}
-
-GetResults processVal(const Transaction&,
-                      const std::vector<ParsedTupVal>& val,
-                      std::vector<DeserializedValue>& vals,
-                      std::vector<ParsedTupVal>& raw_vals,
-                      std::set<uint64_t>&) {
-    vals.push_back(TuplePlaceholder{static_cast<uint8_t>(val.size())});
-    raw_vals.insert(raw_vals.end(), val.rbegin(), val.rend());
-    return GetResults{1, rocksdb::Status::OK(), {}};
+    //  Add value to Tuple that is currently being populated
+    current.setTupleElement(tuple_index, std::move(val));
+    return GetResults{reference_count, rocksdb::Status::OK(), {}};
 }
 
 GetResults processVal(const Transaction& transaction,
                       const ValueHash& val_hash,
-                      std::vector<DeserializedValue>& vals,
-                      std::vector<ParsedTupVal>& raw_vals,
-                      std::set<uint64_t>& segment_ids) {
+                      std::vector<ValueBeingParsed>& val_stack,
+                      std::set<uint64_t>& segment_ids,
+                      uint32_t,
+                      ValueCache& val_cache);
+
+GetResults getStoredValue(const Transaction& transaction,
+                          const ValueHash& val_hash) {
     std::vector<unsigned char> hash_key;
     marshal_uint256_t(val_hash.hash, hash_key);
     auto key = vecToSlice(hash_key);
     auto results = getRefCountedData(*transaction.transaction, key);
+    return results;
+}
+
+GetResults processVal(const Transaction&,
+                      const uint256_t& val,
+                      std::vector<ValueBeingParsed>& val_stack,
+                      std::set<uint64_t>&,
+                      uint32_t reference_count,
+                      ValueCache&) {
+    return applyValue(val, reference_count, val_stack);
+}
+
+GetResults processFirstVal(const Transaction&,
+                           const uint256_t& val,
+                           std::vector<ValueBeingParsed>& val_stack,
+                           std::set<uint64_t>&,
+                           uint32_t reference_count,
+                           ValueCache&) {
+    // Single number requested
+    val_stack.emplace_back(val, reference_count);
+
+    return GetResults{reference_count, rocksdb::Status::OK(), {}};
+}
+
+GetResults processVal(const Transaction&,
+                      const CodePointStub& val,
+                      std::vector<ValueBeingParsed>& val_stack,
+                      std::set<uint64_t>& segment_ids,
+                      uint32_t reference_count,
+                      ValueCache&) {
+    segment_ids.insert(val.pc.segment);
+
+    return applyValue(val, reference_count, val_stack);
+}
+
+GetResults processFirstVal(const Transaction&,
+                           const CodePointStub& val,
+                           std::vector<ValueBeingParsed>& val_stack,
+                           std::set<uint64_t>& segment_ids,
+                           uint32_t reference_count,
+                           ValueCache&) {
+    // Single segment requested
+    segment_ids.insert(val.pc.segment);
+
+    val_stack.emplace_back(val, reference_count);
+
+    return GetResults{reference_count, rocksdb::Status::OK(), {}};
+}
+
+GetResults processVal(const Transaction&,
+                      const std::vector<ParsedTupVal>& val,
+                      std::vector<ValueBeingParsed>& val_stack,
+                      std::set<uint64_t>&,
+                      uint32_t reference_count,
+                      ValueCache&) {
+    // Add empty tuple to stack, will be filled in as values are processed
+    val_stack.emplace_back(Tuple(val.size()), reference_count);
+
+    // Fill new vector with list of elements that will populate tuple
+    val_stack.back().raw_vals.insert(val_stack.back().raw_vals.end(),
+                                     val.rbegin(), val.rend());
+
+    return GetResults{reference_count, rocksdb::Status::OK(), {}};
+}
+
+GetResults processFirstVal(const Transaction& transaction,
+                           const std::vector<ParsedTupVal>& val,
+                           std::vector<ValueBeingParsed>& val_stack,
+                           std::set<uint64_t>& segment_ids,
+                           uint32_t reference_count,
+                           ValueCache& value_cache) {
+    return processVal(transaction, val, val_stack, segment_ids, reference_count,
+                      value_cache);
+}
+
+GetResults processVal(const Transaction& transaction,
+                      const ValueHash& val_hash,
+                      std::vector<ValueBeingParsed>& val_stack,
+                      std::set<uint64_t>& segment_ids,
+                      uint32_t,
+                      ValueCache& val_cache) {
+    auto cached_value = val_cache.find(val_hash.hash);
+    if (cached_value != val_cache.end()) {
+        // Use cached value
+        return applyValue(value(cached_value->second), 0, val_stack);
+    }
+
+    // Value not in cache, so need to load from database
+    auto results = getStoredValue(transaction, val_hash);
     if (!results.status.ok()) {
         return results;
     }
 
     auto record = parseRecord(results.stored_value);
-    auto nested_ret = nonstd::visit(
+
+    return nonstd::visit(
         [&](const auto& val) {
-            return processVal(transaction, val, vals, raw_vals, segment_ids);
+            return processVal(transaction, val, val_stack, segment_ids,
+                              results.reference_count, val_cache);
         },
         record);
-    if (!nested_ret.status.ok()) {
-        return nested_ret;
+}
+
+GetResults processFirstVal(const Transaction& transaction,
+                           const ValueHash& val_hash,
+                           std::vector<ValueBeingParsed>& val_stack,
+                           std::set<uint64_t>& segment_ids,
+                           uint32_t,
+                           ValueCache& val_cache) {
+    auto cached_value = val_cache.find(val_hash.hash);
+    if (cached_value != val_cache.end()) {
+        // Use cached value
+        val_stack.emplace_back(value(cached_value->second), 0);
+        return GetResults{0, rocksdb::Status::OK(), {}};
     }
-    return results;
+
+    // Value not in cache, so need to load from database
+    auto results = getStoredValue(transaction, val_hash);
+    if (!results.status.ok()) {
+        return results;
+    }
+
+    auto record = parseRecord(results.stored_value);
+
+    return nonstd::visit(
+        [&](const auto& val) {
+            return processFirstVal(transaction, val, val_stack, segment_ids,
+                                   results.reference_count, val_cache);
+        },
+        record);
 }
 
 DbResult<value> getValueImpl(const Transaction& transaction,
                              uint256_t value_hash,
-                             std::set<uint64_t>& segment_ids) {
-    std::vector<DeserializedValue> vals;
-    std::vector<ParsedTupVal> raw_vals{ValueHash{value_hash}};
-    bool first = true;
-    GetResults ret;
-    while (!raw_vals.empty()) {
-        auto next = std::move(raw_vals.back());
-        raw_vals.pop_back();
-        auto results = nonstd::visit(
-            [&](const auto& val) {
-                return processVal(transaction, val, vals, raw_vals,
-                                  segment_ids);
-            },
-            next);
-        if (!results.status.ok()) {
-            return {results.status, 0, Tuple()};
-        }
-        if (first) {
-            ret = results;
-            first = false;
+                             std::set<uint64_t>& segment_ids,
+                             ValueCache& value_cache) {
+    std::vector<ValueBeingParsed> val_stack{};
+
+    // Initialize val_stack with first value from database
+    auto result = processFirstVal(transaction, ValueHash{value_hash}, val_stack,
+                                  segment_ids, 0, value_cache);
+    if (!result.status.ok()) {
+        return {result.status, result.reference_count, Tuple()};
+    }
+
+    if (val_stack[0].raw_vals.empty()) {
+        // First value has no child values, so just return single value without
+        // populating cache
+        return {rocksdb::Status::OK(), result.reference_count,
+                std::move(val_stack[0].val)};
+    }
+
+    // This should always be true
+    while (!val_stack.empty()) {
+        auto& current = val_stack.back();
+        if (!current.raw_vals.empty()) {
+            // Take next value to process
+            auto next = std::move(current.raw_vals.back());
+            current.raw_vals.pop_back();
+
+            auto results = nonstd::visit(
+                [&](const auto& val) {
+                    return processVal(transaction, val, val_stack, segment_ids,
+                                      0, value_cache);
+                },
+                next);
+            if (!results.status.ok()) {
+                return {results.status, 0, Tuple()};
+            }
+        } else {
+            // All child values have been resolved
+            auto val = std::move(current.val);
+            auto reference_count = current.reference_count;
+            val_stack.pop_back();
+
+            if (reference_count > 1) {
+                value_cache[hash_value(val)] = val;
+            }
+
+            if (val_stack.empty()) {
+                // All values resolved
+                value_cache[hash_value(val)] = val;
+                return {rocksdb::Status::OK(), reference_count, std::move(val)};
+            }
+
+            applyValue(std::move(val), reference_count, val_stack);
         }
     }
-    return {ret.status, ret.reference_count,
-            assembleValueFromDeserialized(std::move(vals))};
+
+    throw std::runtime_error("val_stack loop should never finish");
 }
 
-DbResult<value> getValue(const Transaction& transaction, uint256_t value_hash) {
-    std::set<uint64_t> segment_ids;
-    return getValueImpl(transaction, value_hash, segment_ids);
+DbResult<value> getValue(const Transaction& transaction,
+                         uint256_t value_hash,
+                         ValueCache& value_cache) {
+    std::set<uint64_t> segment_ids{};
+    return getValueImpl(transaction, value_hash, segment_ids, value_cache);
 }
 
 SaveResults saveValueImpl(Transaction& transaction,
                           const value& val,
                           std::map<uint64_t, uint64_t>& segment_counts) {
     bool first = true;
-    SaveResults ret;
+    SaveResults ret{};
     std::vector<value> items_to_save{val};
     while (!items_to_save.empty()) {
         auto next_item = std::move(items_to_save.back());
@@ -290,7 +443,7 @@ SaveResults saveValueImpl(Transaction& transaction,
         if (results.status.ok() && results.reference_count > 0) {
             save_ret = incrementReference(*transaction.transaction, key);
         } else {
-            std::vector<unsigned char> value_vector;
+            std::vector<unsigned char> value_vector{};
             auto new_items_to_save =
                 serializeValue(next_item, value_vector, segment_counts);
             items_to_save.insert(items_to_save.end(), new_items_to_save.begin(),
@@ -307,7 +460,7 @@ SaveResults saveValueImpl(Transaction& transaction,
 }
 
 SaveResults saveValue(Transaction& transaction, const value& val) {
-    std::map<uint64_t, uint64_t> segment_counts;
+    std::map<uint64_t, uint64_t> segment_counts{};
     return saveValueImpl(transaction, val, segment_counts);
 }
 
@@ -315,10 +468,10 @@ DeleteResults deleteValueImpl(Transaction& transaction,
                               const uint256_t& value_hash,
                               std::map<uint64_t, uint64_t>& segment_counts) {
     bool first = true;
-    DeleteResults ret;
+    DeleteResults ret{};
     std::vector<uint256_t> items_to_delete{value_hash};
     while (!items_to_delete.empty()) {
-        auto next_item = std::move(items_to_delete.back());
+        auto next_item = items_to_delete.back();
         items_to_delete.pop_back();
         std::vector<unsigned char> hash_key;
         marshal_uint256_t(next_item, hash_key);
@@ -340,6 +493,6 @@ DeleteResults deleteValueImpl(Transaction& transaction,
 }
 
 DeleteResults deleteValue(Transaction& transaction, uint256_t value_hash) {
-    std::map<uint64_t, uint64_t> segment_counts;
+    std::map<uint64_t, uint64_t> segment_counts{};
     return deleteValueImpl(transaction, value_hash, segment_counts);
 }

--- a/packages/arb-avm-cpp/tests/arbos.cpp
+++ b/packages/arb-avm-cpp/tests/arbos.cpp
@@ -31,6 +31,7 @@
 
 TEST_CASE("ARBOS test vectors") {
     DBDeleter deleter;
+    ValueCache value_cache{};
 
     std::vector<std::string> files = {
         "evm_direct_deploy_add", "evm_direct_deploy_and_call_add",
@@ -60,7 +61,7 @@ TEST_CASE("ARBOS test vectors") {
 
             CheckpointStorage storage(dbpath);
             storage.initialize(arb_os_path);
-            auto mach = storage.getInitialMachine();
+            auto mach = storage.getInitialMachine(value_cache);
             mach.machine_state.stack.push(uint256_t{0});
             auto assertion =
                 mach.run(1000000000, messages, std::chrono::seconds{0});
@@ -76,12 +77,12 @@ TEST_CASE("ARBOS test vectors") {
                 tx->commit();
             }
             auto mach_hash = mach.hash();
-            auto mach2 = storage.getMachine(mach_hash);
+            auto mach2 = storage.getMachine(mach_hash, value_cache);
             REQUIRE(mach_hash == mach2.hash());
             storage.closeCheckpointStorage();
 
             CheckpointStorage storage2(dbpath);
-            auto mach3 = storage2.getMachine(mach_hash);
+            auto mach3 = storage2.getMachine(mach_hash, value_cache);
             REQUIRE(mach_hash == mach3.hash());
 
             {

--- a/packages/arb-avm-cpp/tests/code.cpp
+++ b/packages/arb-avm-cpp/tests/code.cpp
@@ -79,11 +79,12 @@ TEST_CASE("Code serialization") {
     CheckpointStorage storage(dbpath);
     auto mach = generateTestMachine();
     auto tx = storage.makeTransaction();
+    ValueCache value_cache{};
 
     SECTION("Save and load") {
         saveMachine(*tx, mach);
         REQUIRE(tx->commit().ok());
-        auto mach2 = storage.getMachine(mach.hash());
+        auto mach2 = storage.getMachine(mach.hash(), value_cache);
         checkRun(mach2);
     }
 
@@ -96,14 +97,14 @@ TEST_CASE("Code serialization") {
         SECTION("Delete first") {
             deleteMachine(*tx, mach.hash());
             REQUIRE(tx->commit().ok());
-            auto mach3 = storage.getMachine(mach2.hash());
+            auto mach3 = storage.getMachine(mach2.hash(), value_cache);
             checkRun(mach3, 4);
         }
 
         SECTION("Delete second") {
             deleteMachine(*tx, mach2.hash());
             REQUIRE(tx->commit().ok());
-            auto mach3 = storage.getMachine(mach.hash());
+            auto mach3 = storage.getMachine(mach.hash(), value_cache);
             checkRun(mach3);
         }
     }
@@ -113,7 +114,7 @@ TEST_CASE("Code serialization") {
         saveMachine(*tx, mach);
         deleteMachine(*tx, mach.hash());
         REQUIRE(tx->commit().ok());
-        auto mach2 = storage.getMachine(mach.hash());
+        auto mach2 = storage.getMachine(mach.hash(), value_cache);
         checkRun(mach2);
     }
 }

--- a/packages/arb-avm-cpp/tests/machine.cpp
+++ b/packages/arb-avm-cpp/tests/machine.cpp
@@ -25,6 +25,7 @@
 #include <avm/machine.hpp>
 #include <avm/machinestate/ecops.hpp>
 
+#define CATCH_CONFIG_ENABLE_BENCHMARKING 1
 #include <catch2/catch.hpp>
 
 #include <boost/filesystem.hpp>
@@ -59,8 +60,10 @@ void deleteCheckpoint(Transaction& transaction, Machine& machine) {
     REQUIRE(results.reference_count == 0);
 }
 
-void restoreCheckpoint(CheckpointStorage& storage, Machine& expected_machine) {
-    auto mach = storage.getMachine(expected_machine.hash());
+void restoreCheckpoint(CheckpointStorage& storage,
+                       Machine& expected_machine,
+                       ValueCache& value_cache) {
+    auto mach = storage.getMachine(expected_machine.hash(), value_cache);
     REQUIRE(mach.hash() == expected_machine.hash());
 }
 
@@ -68,8 +71,9 @@ TEST_CASE("Checkpoint State") {
     DBDeleter deleter;
     CheckpointStorage storage(dbpath);
     storage.initialize(test_contract_path);
+    ValueCache value_cache{};
 
-    auto machine = storage.getInitialMachine();
+    auto machine = storage.getInitialMachine(value_cache);
     machine.run(1, {}, std::chrono::seconds{0});
 
     SECTION("default") { checkpointState(storage, machine); }
@@ -80,7 +84,7 @@ TEST_CASE("Checkpoint State") {
         auto results = saveMachine(*transaction, machine);
         REQUIRE(results.status.ok());
         REQUIRE(transaction->commit().ok());
-        auto machine2 = storage.getMachine(hash1);
+        auto machine2 = storage.getMachine(hash1, value_cache);
         auto hash2 = machine2.hash();
         REQUIRE(hash2 == hash1);
     }
@@ -90,12 +94,15 @@ TEST_CASE("Delete machine checkpoint") {
     DBDeleter deleter;
     CheckpointStorage storage(dbpath);
     storage.initialize(test_contract_path);
+    ValueCache value_cache{};
 
     SECTION("default") {
-        auto machine = storage.getInitialMachine();
+        auto machine = storage.getInitialMachine(value_cache);
         machine.run(1, {}, std::chrono::seconds{0});
         auto transaction = storage.makeTransaction();
-        auto results = saveMachine(*transaction, machine);
+        saveMachine(*transaction, machine);
+        machine.run(100, {}, std::chrono::seconds{0});
+        saveMachine(*transaction, machine);
         deleteCheckpoint(*transaction, machine);
         REQUIRE(transaction->commit().ok());
     }
@@ -105,14 +112,15 @@ TEST_CASE("Restore checkpoint") {
     DBDeleter deleter;
     CheckpointStorage storage(dbpath);
     storage.initialize(test_contract_path);
+    ValueCache value_cache{};
 
     SECTION("default") {
-        auto machine = storage.getInitialMachine();
+        auto machine = storage.getInitialMachine(value_cache);
         auto transaction = storage.makeTransaction();
         auto results = saveMachine(*transaction, machine);
         REQUIRE(results.status.ok());
         REQUIRE(transaction->commit().ok());
-        restoreCheckpoint(storage, machine);
+        restoreCheckpoint(storage, machine, value_cache);
     }
 }
 
@@ -137,8 +145,7 @@ TEST_CASE("Clone") {
     }
 
     for (int i = 0; i < 1000; i++) {
-        Machine m = machine;
-        REQUIRE(m.hash() != 3242);
+        REQUIRE(machine.hash() != 3242);
     }
 }
 


### PR DESCRIPTION
This version populates Tuples as processing proceeds instead of collecting values in vector of vectors and populating each tuple all at once.