### PR TITLE
Update ethereumjs-abi version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "resolutions": {
     "arb-provider-ethers/ethers": "~4.0.47",
-    "eth-sig-util/ethereumjs-abi": "^0.6.8",
+    "eth-sig-util/ethereumjs-abi": "^0.6.8-1",
     "typechain/truffle-v4/truffle": "^4.0.0",
     "typechain/truffle-v5/truffle": "^5.0.0",
     "typechain/web3-v1/web3": "^1.0.0"


### PR DESCRIPTION
eth-sig-util wants to use `latest` version of ethereumjs-abi, but this causes problems with other packages that use a specific version.  The other packages have now updated to a new version, so need to update `resolutions` so that eth-sig-util stays in sync.