### PR TITLE
Add Kovan Support

### DIFF
--- a/packages/arb-checkpointer/checkpointing/indexedCheckpointer_test.go
+++ b/packages/arb-checkpointer/checkpointing/indexedCheckpointer_test.go
@@ -67,10 +67,6 @@ type TimeGetterMock struct {
 	blockIdFunc func(ctx context.Context, height *common.TimeBlocks) (*common.BlockId, error)
 }
 
-func (m *TimeGetterMock) CurrentBlockId(context.Context) (*common.BlockId, error) {
-	return nil, errors.New("unsupported method")
-}
-
 func (m *TimeGetterMock) BlockIdForHeight(ctx context.Context, height *common.TimeBlocks) (*common.BlockId, error) {
 	return m.blockIdFunc(ctx, height)
 }

--- a/packages/arb-tx-aggregator/aggregator/aggregator.go
+++ b/packages/arb-tx-aggregator/aggregator/aggregator.go
@@ -227,6 +227,10 @@ func (m *Server) GetTxInBlockAtIndexResults(res *evm.BlockInfo, index uint64) (*
 }
 
 func (m *Server) GetBlock(ctx context.Context, height uint64) (*types.Block, error) {
+	l1BlockInfo, err := m.Client.BlockInfoByNumber(ctx, new(big.Int).SetUint64(height))
+	if err != nil {
+		return nil, err
+	}
 	header, err := m.GetBlockHeaderByNumber(ctx, height)
 	if err != nil {
 		return nil, err
@@ -250,7 +254,7 @@ func (m *Server) GetBlock(ctx context.Context, height uint64) (*types.Block, err
 	transactions := make([]*types.Transaction, 0, len(results))
 	receipts := make([]*types.Receipt, 0, len(results))
 	for _, res := range results {
-		receipt := res.ToEthReceipt(common.NewHashFromEth(header.Hash()))
+		receipt := res.ToEthReceipt(common.NewHashFromEth(l1BlockInfo.Hash))
 		receipts = append(receipts, receipt)
 		tx, err := GetTransaction(res.IncomingRequest)
 		if err != nil {

--- a/packages/arb-tx-aggregator/aggregator/server.go
+++ b/packages/arb-tx-aggregator/aggregator/server.go
@@ -19,6 +19,7 @@ package aggregator
 import (
 	"bytes"
 	errors2 "github.com/pkg/errors"
+	"math/big"
 	"net/http"
 	"strconv"
 
@@ -195,11 +196,11 @@ func (m *RPCServer) BlockHash(
 	args *evm.BlockHashArgs,
 	reply *evm.BlockHashReply,
 ) error {
-	header, err := m.srv.GetBlockHeaderByNumber(r.Context(), args.Height)
+	blockInfo, err := m.srv.Client.BlockInfoByNumber(r.Context(), new(big.Int).SetUint64(args.Height))
 	if err != nil {
 		return err
 	}
-	reply.Hash = hexutil.Encode(header.Hash().Bytes())
+	reply.Hash = hexutil.Encode(blockInfo.Hash.Bytes())
 	return nil
 }
 

--- a/packages/arb-tx-aggregator/cmd/arb-test-case/arb-test-case.go
+++ b/packages/arb-tx-aggregator/cmd/arb-test-case/arb-test-case.go
@@ -18,9 +18,8 @@ package main
 
 import (
 	"context"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"log"
-
-	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/offchainlabs/arbitrum/packages/arb-avm-cpp/cmachine"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/arbos"
@@ -42,7 +41,7 @@ func main() {
 func generateTestCase(ethURL string, rollupAddress common.Address, contract string) error {
 	ctx := context.Background()
 
-	ethclint, err := ethclient.Dial(ethURL)
+	ethclint, err := ethutils.NewRPCEthClient(ethURL)
 	if err != nil {
 		return err
 	}

--- a/packages/arb-tx-aggregator/cmd/arb-tx-aggregator/arb-tx-aggregator.go
+++ b/packages/arb-tx-aggregator/cmd/arb-tx-aggregator/arb-tx-aggregator.go
@@ -20,12 +20,11 @@ import (
 	"context"
 	"flag"
 	"github.com/offchainlabs/arbitrum/packages/arb-tx-aggregator/rpc"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"log"
 	"os"
 	"path/filepath"
 	"time"
-
-	"github.com/ethereum/go-ethereum/ethclient"
 
 	utils2 "github.com/offchainlabs/arbitrum/packages/arb-tx-aggregator/utils"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
@@ -69,7 +68,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	ethclint, err := ethclient.Dial(rollupArgs.EthURL)
+	ethclint, err := ethutils.NewRPCEthClient(rollupArgs.EthURL)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/packages/arb-tx-aggregator/cmd/arb-tx-aggregator/arb-tx-aggregator.go
+++ b/packages/arb-tx-aggregator/cmd/arb-tx-aggregator/arb-tx-aggregator.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"github.com/offchainlabs/arbitrum/packages/arb-evm/message"
 	"github.com/offchainlabs/arbitrum/packages/arb-tx-aggregator/rpc"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"log"
@@ -84,6 +85,8 @@ func main() {
 
 	contractFile := filepath.Join(rollupArgs.ValidatorFolder, "contract.mexe")
 	dbPath := filepath.Join(rollupArgs.ValidatorFolder, "checkpoint_db")
+
+	log.Println("Launching aggregator for chain", rollupArgs.Address, "with chain id", message.ChainAddressToID(rollupArgs.Address))
 
 	if err := rpc.LaunchAggregator(
 		context.Background(),

--- a/packages/arb-validator-core/arbbridge/arbClient.go
+++ b/packages/arb-validator-core/arbbridge/arbClient.go
@@ -30,7 +30,6 @@ type MaybeBlockId struct {
 }
 
 type ChainTimeGetter interface {
-	CurrentBlockId(ctx context.Context) (*common.BlockId, error)
 	BlockIdForHeight(ctx context.Context, height *common.TimeBlocks) (*common.BlockId, error)
 	TimestampForBlockHash(ctx context.Context, hash common.Hash) (*big.Int, error)
 }

--- a/packages/arb-validator-core/ethbridge/arbClient.go
+++ b/packages/arb-validator-core/ethbridge/arbClient.go
@@ -167,7 +167,7 @@ func (c *EthArbClient) BlockIdForHeight(ctx context.Context, height *common.Time
 		return nil, err
 	}
 	return &common.BlockId{
-		Height:     height.Clone(),
+		Height:     common.NewTimeBlocks((*big.Int)(blockInfo.Number)),
 		HeaderHash: common.NewHashFromEth(blockInfo.Hash),
 	}, nil
 }

--- a/packages/arb-validator-core/ethbridge/arbClient.go
+++ b/packages/arb-validator-core/ethbridge/arbClient.go
@@ -123,7 +123,7 @@ func (c *EthArbClient) subscribeBlockHeadersAfter(ctx context.Context, prevBlock
 				Height:     common.NewTimeBlocks(targetHeight),
 				HeaderHash: common.NewHashFromEth(blockInfo.Hash),
 			}
-			blockIdChan <- arbbridge.MaybeBlockId{BlockId: prevBlockId, Timestamp: new(big.Int).SetUint64(blockInfo.Time)}
+			blockIdChan <- arbbridge.MaybeBlockId{BlockId: prevBlockId, Timestamp: new(big.Int).SetUint64(uint64(blockInfo.Time))}
 		}
 	}()
 	return nil

--- a/packages/arb-validator-core/ethbridge/arbClient.go
+++ b/packages/arb-validator-core/ethbridge/arbClient.go
@@ -18,12 +18,8 @@ package ethbridge
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	errors2 "github.com/pkg/errors"
 	"log"
@@ -33,7 +29,6 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/arbbridge"
 )
@@ -87,13 +82,13 @@ func (c *EthArbClient) subscribeBlockHeadersAfter(ctx context.Context, prevBlock
 		defer close(blockIdChan)
 
 		for {
-			var nextHeader *types.Header
+			var blockInfo *ethutils.BlockInfo
 			fetchErrorCount := 0
+			targetHeight := new(big.Int).Add(prevBlockId.Height.AsInt(), big.NewInt(1))
 			for {
 				var err error
-				targetHeight := new(big.Int).Add(prevBlockId.Height.AsInt(), big.NewInt(1))
-				nextHeader, err = c.client.HeaderByNumber(ctx, targetHeight)
-				if err == nil && nextHeader.Number.Cmp(targetHeight) == 0 {
+				blockInfo, err = c.client.BlockInfoByNumber(ctx, targetHeight)
+				if err == nil {
 					// Got next header
 					break
 				}
@@ -119,13 +114,16 @@ func (c *EthArbClient) subscribeBlockHeadersAfter(ctx context.Context, prevBlock
 				time.Sleep(headerRetryDelay)
 			}
 
-			if nextHeader.ParentHash != prevBlockId.HeaderHash.ToEthHash() {
+			if blockInfo.ParentHash != prevBlockId.HeaderHash.ToEthHash() {
 				blockIdChan <- arbbridge.MaybeBlockId{Err: reorgError}
 				return
 			}
 
-			prevBlockId = getBlockID(nextHeader)
-			blockIdChan <- arbbridge.MaybeBlockId{BlockId: prevBlockId, Timestamp: new(big.Int).SetUint64(nextHeader.Time)}
+			prevBlockId = &common.BlockId{
+				Height:     common.NewTimeBlocks(targetHeight),
+				HeaderHash: common.NewHashFromEth(blockInfo.Hash),
+			}
+			blockIdChan <- arbbridge.MaybeBlockId{BlockId: prevBlockId, Timestamp: new(big.Int).SetUint64(blockInfo.Time)}
 		}
 	}()
 	return nil
@@ -159,42 +157,19 @@ func (c *EthArbClient) GetBalance(ctx context.Context, account common.Address) (
 	return c.client.BalanceAt(ctx, account.ToEthAddress(), nil)
 }
 
-func (c *EthArbClient) CurrentBlockId(ctx context.Context) (*common.BlockId, error) {
-	header, err := c.client.HeaderByNumber(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	return getBlockID(header), nil
-}
-
-type blockHashRPC struct {
-	Hash ethcommon.Hash `json:"hash"`
-}
-
 func (c *EthArbClient) BlockIdForHeight(ctx context.Context, height *common.TimeBlocks) (*common.BlockId, error) {
-	cl, err := rpc.DialContext(context.Background(), "https://kovan.infura.io/v3/8838d00c028a46449be87e666387c71a")
+	var num *big.Int
+	if height != nil {
+		num = height.AsInt()
+	}
+	blockInfo, err := c.client.BlockInfoByNumber(ctx, num)
 	if err != nil {
 		return nil, err
 	}
-	var raw json.RawMessage
-	if err := cl.CallContext(ctx, &raw, "eth_getBlockByNumber", hexutil.EncodeBig(height.AsInt()), false); err != nil {
-		return nil, err
-	}
-	var ret blockHashRPC
-	if err := json.Unmarshal(raw, &ret); err != nil {
-		return nil, err
-	}
-
-	log.Println("Got block hash", height.AsInt(), ret.Hash.Hex())
-
-	header, err := c.client.HeaderByNumber(ctx, height.AsInt())
-	if err != nil {
-		return nil, err
-	}
-	if header == nil {
-		return nil, errors.New("couldn't get header at height")
-	}
-	return getBlockID(header), nil
+	return &common.BlockId{
+		Height:     height.Clone(),
+		HeaderHash: common.NewHashFromEth(blockInfo.Hash),
+	}, nil
 }
 
 func (c *EthArbClient) TimestampForBlockHash(ctx context.Context, hash common.Hash) (*big.Int, error) {

--- a/packages/arb-validator-core/ethbridge/arbClient.go
+++ b/packages/arb-validator-core/ethbridge/arbClient.go
@@ -84,11 +84,11 @@ func (c *EthArbClient) subscribeBlockHeadersAfter(ctx context.Context, prevBlock
 		for {
 			var blockInfo *ethutils.BlockInfo
 			fetchErrorCount := 0
-			targetHeight := new(big.Int).Add(prevBlockId.Height.AsInt(), big.NewInt(1))
 			for {
 				var err error
+				targetHeight := new(big.Int).Add(prevBlockId.Height.AsInt(), big.NewInt(1))
 				blockInfo, err = c.client.BlockInfoByNumber(ctx, targetHeight)
-				if err == nil {
+				if err == nil && (*big.Int)(blockInfo.Number).Cmp(targetHeight) == 0 {
 					// Got next header
 					break
 				}
@@ -120,7 +120,7 @@ func (c *EthArbClient) subscribeBlockHeadersAfter(ctx context.Context, prevBlock
 			}
 
 			prevBlockId = &common.BlockId{
-				Height:     common.NewTimeBlocks(targetHeight),
+				Height:     common.NewTimeBlocks((*big.Int)(blockInfo.Number)),
 				HeaderHash: common.NewHashFromEth(blockInfo.Hash),
 			}
 			blockIdChan <- arbbridge.MaybeBlockId{BlockId: prevBlockId, Timestamp: new(big.Int).SetUint64(uint64(blockInfo.Time))}

--- a/packages/arb-validator-core/ethbridge/arbClient.go
+++ b/packages/arb-validator-core/ethbridge/arbClient.go
@@ -177,7 +177,7 @@ func (c *EthArbClient) BlockIdForHeight(ctx context.Context, height *common.Time
 		return nil, err
 	}
 	var raw json.RawMessage
-	if err := cl.CallContext(ctx, &raw, "eth_getBlockByNumber", hexutil.EncodeBig(height.AsInt())); err != nil {
+	if err := cl.CallContext(ctx, &raw, "eth_getBlockByNumber", hexutil.EncodeBig(height.AsInt()), false); err != nil {
 		return nil, err
 	}
 	var ret blockHashRPC

--- a/packages/arb-validator-core/ethbridge/chain.go
+++ b/packages/arb-validator-core/ethbridge/chain.go
@@ -42,13 +42,6 @@ func (a ArbAddresses) ArbFactoryAddress() common.Address {
 	return common.NewAddressFromEth(ethcommon.HexToAddress(a.ArbFactory))
 }
 
-func getBlockID(header *types.Header) *common.BlockId {
-	return &common.BlockId{
-		Height:     common.NewTimeBlocks(header.Number),
-		HeaderHash: common.NewHashFromEth(header.Hash()),
-	}
-}
-
 func getLogBlockID(ethLog types.Log) *common.BlockId {
 	return &common.BlockId{
 		Height:     common.NewTimeBlocks(new(big.Int).SetUint64(ethLog.BlockNumber)),

--- a/packages/arb-validator-core/ethutils/client.go
+++ b/packages/arb-validator-core/ethutils/client.go
@@ -49,9 +49,9 @@ type RPCEthClient struct {
 }
 
 type BlockInfo struct {
-	Hash       common.Hash `json:"hash"`
-	ParentHash common.Hash `json:"parentHash"`
-	Time       uint64      `json:"timestamp"`
+	Hash       common.Hash    `json:"hash"`
+	ParentHash common.Hash    `json:"parentHash"`
+	Time       hexutil.Uint64 `json:"timestamp"`
 }
 
 func NewRPCEthClient(url string) (*RPCEthClient, error) {
@@ -104,6 +104,6 @@ func (r *SimulatedEthClient) BlockInfoByNumber(ctx context.Context, number *big.
 	return &BlockInfo{
 		Hash:       header.Hash(),
 		ParentHash: header.ParentHash,
-		Time:       header.Time,
+		Time:       hexutil.Uint64(header.Time),
 	}, nil
 }

--- a/packages/arb-validator-core/ethutils/client.go
+++ b/packages/arb-validator-core/ethutils/client.go
@@ -18,6 +18,11 @@ package ethutils
 
 import (
 	"context"
+	"encoding/json"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -31,8 +36,74 @@ type EthClient interface {
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 
 	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
+	BlockInfoByNumber(ctx context.Context, number *big.Int) (*BlockInfo, error)
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error)
 	PendingCallContract(ctx context.Context, msg ethereum.CallMsg) ([]byte, error)
 	BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
+}
+
+type RPCEthClient struct {
+	*ethclient.Client
+	rpc *rpc.Client
+}
+
+type BlockInfo struct {
+	Hash       common.Hash `json:"hash"`
+	ParentHash common.Hash `json:"parentHash"`
+	Time       uint64      `json:"timestamp"`
+}
+
+func NewRPCEthClient(url string) (*RPCEthClient, error) {
+	ethcl, err := ethclient.Dial(url)
+	if err != nil {
+		return nil, err
+	}
+
+	rpccl, err := rpc.Dial(url)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RPCEthClient{
+		Client: ethcl,
+		rpc:    rpccl,
+	}, nil
+}
+
+func (r *RPCEthClient) BlockInfoByNumber(ctx context.Context, number *big.Int) (*BlockInfo, error) {
+	var raw json.RawMessage
+	var numParam string
+	if number != nil {
+		numParam = hexutil.EncodeBig(number)
+	} else {
+		numParam = "latest"
+	}
+	if err := r.rpc.CallContext(ctx, &raw, "eth_getBlockByNumber", numParam, false); err != nil {
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return nil, ethereum.NotFound
+	}
+	var ret BlockInfo
+	if err := json.Unmarshal(raw, &ret); err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+type SimulatedEthClient struct {
+	*backends.SimulatedBackend
+}
+
+func (r *SimulatedEthClient) BlockInfoByNumber(ctx context.Context, number *big.Int) (*BlockInfo, error) {
+	header, err := r.SimulatedBackend.HeaderByNumber(ctx, number)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockInfo{
+		Hash:       header.Hash(),
+		ParentHash: header.ParentHash,
+		Time:       header.Time,
+	}, nil
 }

--- a/packages/arb-validator-core/ethutils/client.go
+++ b/packages/arb-validator-core/ethutils/client.go
@@ -52,6 +52,7 @@ type BlockInfo struct {
 	Hash       common.Hash    `json:"hash"`
 	ParentHash common.Hash    `json:"parentHash"`
 	Time       hexutil.Uint64 `json:"timestamp"`
+	Number     *hexutil.Big   `json:"number"`
 }
 
 func NewRPCEthClient(url string) (*RPCEthClient, error) {
@@ -105,5 +106,6 @@ func (r *SimulatedEthClient) BlockInfoByNumber(ctx context.Context, number *big.
 		Hash:       header.Hash(),
 		ParentHash: header.ParentHash,
 		Time:       hexutil.Uint64(header.Time),
+		Number:     (*hexutil.Big)(header.Number),
 	}, nil
 }

--- a/packages/arb-validator-core/observer/observer.go
+++ b/packages/arb-validator-core/observer/observer.go
@@ -24,7 +24,7 @@ import (
 
 func CalculateCatchupFetch(ctx context.Context, start *big.Int, clnt arbbridge.ChainTimeGetter, maxReorg *big.Int) (*big.Int, error) {
 	currentLocalHeight := start
-	currentOnChain, err := clnt.CurrentBlockId(ctx)
+	currentOnChain, err := clnt.BlockIdForHeight(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/arb-validator/chainlistener/validatorChainListener.go
+++ b/packages/arb-validator/chainlistener/validatorChainListener.go
@@ -196,7 +196,7 @@ func (lis *ValidatorChainListener) AssertionPrepared(
 			continue
 		}
 		lis.Lock()
-		currentTime, err := stakingKey.client.CurrentBlockId(ctx)
+		currentTime, err := stakingKey.client.BlockIdForHeight(ctx, nil)
 		if err != nil {
 			log.Println("Validator couldn't get time")
 			break

--- a/packages/arb-validator/chainobserver/chainObserver.go
+++ b/packages/arb-validator/chainobserver/chainObserver.go
@@ -357,7 +357,7 @@ func (chain *ChainObserver) HandleNotification(ctx context.Context, event arbbri
 }
 
 func (chain *ChainObserver) UpdateAssumedValidBlock(ctx context.Context, clnt arbbridge.ChainTimeGetter, assumedValidDepth int64) error {
-	latestL1BlockId, err := clnt.CurrentBlockId(ctx)
+	latestL1BlockId, err := clnt.BlockIdForHeight(ctx, nil)
 	if err != nil {
 		return errors2.Wrap(err, "Getting current block header")
 	}

--- a/packages/arb-validator/chainobserver/rollupEthBridge_test.go
+++ b/packages/arb-validator/chainobserver/rollupEthBridge_test.go
@@ -19,6 +19,7 @@ package chainobserver
 import (
 	"context"
 	"errors"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"log"
 	"math/big"
 	"math/rand"
@@ -42,7 +43,8 @@ import (
 var tester *ethbridgetestcontracts.RollupTester
 
 func TestMainSetup(m *testing.T) {
-	client, pks := test.SimulatedBackend()
+	clnt, pks := test.SimulatedBackend()
+	client := &ethutils.SimulatedEthClient{SimulatedBackend: clnt}
 	auth := bind.NewKeyedTransactor(pks[0])
 
 	_, machineTx, deployedArbRollup, err := ethbridgetestcontracts.DeployRollupTester(

--- a/packages/arb-validator/challenges/challenge.go
+++ b/packages/arb-validator/challenges/challenge.go
@@ -87,7 +87,7 @@ func getNextEventWithTimeout(
 		case <-ctx.Done():
 			return nil, 0, errors.New("context cancelled while waiting for event")
 		case <-ticker.C:
-			blockId, err := client.CurrentBlockId(ctx)
+			blockId, err := client.BlockIdForHeight(ctx, nil)
 			if err != nil {
 				return nil, 0, err
 			}

--- a/packages/arb-validator/challenges/challenges_test.go
+++ b/packages/arb-validator/challenges/challenges_test.go
@@ -21,6 +21,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridge"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridgetestcontracts"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/test"
 	"testing"
 	"time"
@@ -29,7 +30,8 @@ import (
 var testerAddress ethcommon.Address
 
 func TestChallenges(t *testing.T) {
-	client, pks := test.SimulatedBackend()
+	clnt, pks := test.SimulatedBackend()
+	client := &ethutils.SimulatedEthClient{SimulatedBackend: clnt}
 
 	auths := make([]*bind.TransactOpts, 0)
 	for _, pk := range pks {

--- a/packages/arb-validator/challenges/testHelper_test.go
+++ b/packages/arb-validator/challenges/testHelper_test.go
@@ -52,14 +52,6 @@ func testChallengerCatchUp(
 	challengerFuncStop ChallengeFunc,
 	testerAddress ethcommon.Address,
 ) {
-	current, err := client.HeaderByNumber(context.Background(), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	blockId := &common.BlockId{
-		Height:     common.NewTimeBlocks(current.Number),
-		HeaderHash: common.NewHashFromEth(current.Hash()),
-	}
 	asserterClient, challengerClient, challengeAddress, _, err := getChallengeInfo(
 		client,
 		asserter,
@@ -70,6 +62,11 @@ func testChallengerCatchUp(
 	)
 	if err != nil {
 		t.Fatal("Error starting challenge", err)
+	}
+
+	blockId, err := asserterClient.BlockIdForHeight(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	asserterEndChan := make(chan ChallengeState)
@@ -152,14 +149,6 @@ func testChallenge(
 	challengerFunc ChallengeFunc,
 	testerAddress ethcommon.Address,
 ) {
-	current, err := client.HeaderByNumber(context.Background(), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	blockId := &common.BlockId{
-		Height:     common.NewTimeBlocks(current.Number),
-		HeaderHash: common.NewHashFromEth(current.Hash()),
-	}
 	asserterClient, challengerClient, challengeAddress, _, err := getChallengeInfo(
 		client,
 		asserter,
@@ -170,6 +159,11 @@ func testChallenge(
 	)
 	if err != nil {
 		t.Fatal("Error starting challenge", err)
+	}
+
+	blockId, err := asserterClient.BlockIdForHeight(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	asserterEndChan := make(chan ChallengeState)

--- a/packages/arb-validator/cmd/arb-validator/arb-validator.go
+++ b/packages/arb-validator/cmd/arb-validator/arb-validator.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"log"
 	"math/big"
 	"os"
@@ -29,8 +30,6 @@ import (
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/utils"
 
 	errors2 "github.com/pkg/errors"
-
-	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/arbbridge"
@@ -88,7 +87,7 @@ func createRollupChain() error {
 		return err
 	}
 
-	ethclint, err := ethclient.Dial(ethURL)
+	ethclint, err := ethutils.NewRPCEthClient(ethURL)
 	if err != nil {
 		return err
 	}

--- a/packages/arb-validator/cmdhelper/cmdhelper.go
+++ b/packages/arb-validator/cmdhelper/cmdhelper.go
@@ -20,11 +20,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"os"
 	"path/filepath"
 	"time"
-
-	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/arbbridge"
@@ -84,7 +83,7 @@ func ValidateRollupChain(
 	}
 
 	// Rollup creation
-	ethclint, err := ethclient.Dial(rollupArgs.EthURL)
+	ethclint, err := ethutils.NewRPCEthClient(rollupArgs.EthURL)
 	if err != nil {
 		return err
 	}

--- a/packages/arb-validator/ethbridgemachine/machine_test.go
+++ b/packages/arb-validator/ethbridgemachine/machine_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/offchainlabs/arbitrum/packages/arb-util/value"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridge"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridgetestcontracts"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/test"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator/loader"
 	"math/big"
@@ -34,7 +35,8 @@ import (
 )
 
 func getTester(t *testing.T) *ethbridgetestcontracts.MachineTester {
-	client, pks := test.SimulatedBackend()
+	clnt, pks := test.SimulatedBackend()
+	client := &ethutils.SimulatedEthClient{SimulatedBackend: clnt}
 	auth := bind.NewKeyedTransactor(pks[0])
 
 	_, machineTx, deployedMachineTester, err := ethbridgetestcontracts.DeployMachineTester(

--- a/packages/arb-validator/ethbridgemachine/proofmachine_test.go
+++ b/packages/arb-validator/ethbridgemachine/proofmachine_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridgecontracts"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"strconv"
 
 	"encoding/json"
@@ -120,8 +121,8 @@ func runTestValidateProof(t *testing.T, contract string, osp *ethbridgecontracts
 
 func TestValidateProof(t *testing.T) {
 	testMachines := gotest.OpCodeTestFiles()
-
-	client, pks := test.SimulatedBackend()
+	clnt, pks := test.SimulatedBackend()
+	client := &ethutils.SimulatedEthClient{SimulatedBackend: clnt}
 	auth := bind.NewKeyedTransactor(pks[0])
 	_, tx, osp, err := ethbridgecontracts.DeployOneStepProof(auth, client)
 	if err != nil {

--- a/packages/arb-validator/go.mod
+++ b/packages/arb-validator/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/offchainlabs/arbitrum/packages/arb-avm-cpp v0.7.2
 	github.com/offchainlabs/arbitrum/packages/arb-checkpointer v0.7.2
+	github.com/offchainlabs/arbitrum/packages/arb-provider-go v0.7.1 // indirect
+	github.com/offchainlabs/arbitrum/packages/arb-tx-aggregator v0.7.1 // indirect
 	github.com/offchainlabs/arbitrum/packages/arb-util v0.7.2
 	github.com/offchainlabs/arbitrum/packages/arb-validator-core v0.7.2
 	github.com/pkg/errors v0.9.1

--- a/packages/arb-validator/go.sum
+++ b/packages/arb-validator/go.sum
@@ -67,9 +67,12 @@ github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c h1:JHHhtb9XWJrGNMcr
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa h1:XKAhUk/dtp+CV0VO6mhG2V7jA9vbcGcnYF/Ay9NjZrY=
 github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
+github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
+github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum/go-ethereum v1.9.14/go.mod h1:oP8FC5+TbICUyftkTWs+8JryntjIJLJvWvApK3z2AYw=
+github.com/ethereum/go-ethereum v1.9.20/go.mod h1:JSSTypSMTkGZtAdAChH2wP5dZEvPGh3nUTuDpH+hNrg=
 github.com/ethereum/go-ethereum v1.9.22 h1:/Fea9n2EWJuNJ9oahMq9luqjRBcbW7QWdThbcJl13ek=
 github.com/ethereum/go-ethereum v1.9.22/go.mod h1:FQjK3ZwD8C5DYn7ukTmFee36rq1dOMESiUfXr5RUc1w=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -121,6 +124,12 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
+github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/rpc v1.2.0 h1:WvvdC2lNeT1SP32zrIce5l0ECBfbAlmrmSBsuc57wfk=
+github.com/gorilla/rpc v1.2.0/go.mod h1:V4h9r+4sF5HnzqbwIez0fKSpANP0zlYd3qR7p36jkTQ=
 github.com/gorilla/websocket v1.4.1-0.20190629185528-ae1634f6a989 h1:giknQ4mEuDFmmHSrGcbargOuLHQGtywqo4mheITex54=
 github.com/gorilla/websocket v1.4.1-0.20190629185528-ae1634f6a989/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
@@ -168,6 +177,13 @@ github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/offchainlabs/arbitrum v0.7.1 h1:JBkSbMZFObg/2rqIiXiLrKLxN7WelEtBOGRY6jalmoc=
+github.com/offchainlabs/arbitrum/packages/arb-evm v0.7.1 h1:Heo6Sq3JuZSsvPuQccjcqGK5dsdNcvUHWwaUa2j6nm8=
+github.com/offchainlabs/arbitrum/packages/arb-evm v0.7.1/go.mod h1:4XbYeQDzNKgK4YA0b4wxF5XcaOIAo11RTClyfagDZRI=
+github.com/offchainlabs/arbitrum/packages/arb-provider-go v0.7.1 h1:6fysrPTjQlUFaYfQ05McjEmSfNpUUwv7VbEY68nJm7w=
+github.com/offchainlabs/arbitrum/packages/arb-provider-go v0.7.1/go.mod h1:DtCRF5PKzE0cY7Vxd9UOrFHIitI2btg4svU93H3bQaE=
+github.com/offchainlabs/arbitrum/packages/arb-tx-aggregator v0.7.1 h1:tjNbbHa3mpmaGrwQN07ihWEDri3hwCk8Hezz/dyKsW0=
+github.com/offchainlabs/arbitrum/packages/arb-tx-aggregator v0.7.1/go.mod h1:qJjvnJjDg33KWxiVj+6IU9kxmbSRzheyGt+fsJZHrfc=
 github.com/offchainlabs/go-solidity-sha3 v0.1.2 h1:IJ/KUv8zW5+Rtq/VvhNjq/Q7MDXjDx1ArAvkJhBRQAs=
 github.com/offchainlabs/go-solidity-sha3 v0.1.2/go.mod h1:WYAU7UTm1wXzEhnsTt843T77fKfR9x/rqqzjm8NJ3Mc=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -269,6 +285,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 h1:Jcxah/M+oLZ/R4/z5RzfPzGbPXnVDPkEDtf2JnuxN+U=
 golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=

--- a/packages/arb-validator/rollupmanager/manager.go
+++ b/packages/arb-validator/rollupmanager/manager.go
@@ -235,7 +235,7 @@ func CreateManagerAdvanced(
 					blockId := maybeBlockId.BlockId
 					timestamp := maybeBlockId.Timestamp
 
-					currentOnChain, err := clnt.CurrentBlockId(runCtx)
+					currentOnChain, err := clnt.BlockIdForHeight(runCtx, nil)
 					if err != nil {
 						return err
 					}

--- a/packages/arb-validator/structures/ethbridge_test.go
+++ b/packages/arb-validator/structures/ethbridge_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"log"
 	"math/big"
 	"testing"
@@ -35,7 +36,8 @@ import (
 var tester *ethbridgetestcontracts.RollupTester
 
 func TestMainSetup(m *testing.T) {
-	client, pks := test.SimulatedBackend()
+	clnt, pks := test.SimulatedBackend()
+	client := &ethutils.SimulatedEthClient{SimulatedBackend: clnt}
 	auth := bind.NewKeyedTransactor(pks[0])
 
 	_, machineTx, deployedArbRollup, err := ethbridgetestcontracts.DeployRollupTester(

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -281,7 +281,8 @@ func TestFib(t *testing.T) {
 		}
 	}()
 
-	l1Client, pks := test.SimulatedBackend()
+	clnt, pks := test.SimulatedBackend()
+	l1Client := &ethutils.SimulatedEthClient{SimulatedBackend: clnt}
 	go func() {
 		t := time.NewTicker(time.Second * 2)
 		for range t.C {


### PR DESCRIPTION
- This adds support in the aggregator and validator for Kovan by removing local block hash calculations and instead relying on the hash provided through the RPC interface