### PR TITLE
Value caching and deduplication

### DIFF
--- a/packages/arb-avm-cpp/cavm/CMakeLists.txt
+++ b/packages/arb-avm-cpp/cavm/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIB_HEADERS
   cblockstore.h
   cmachine.h
   ccheckpointstorage.h
+  cvaluecache.h
   utils.hpp
   ctypes.h
 )
@@ -33,6 +34,7 @@ set(LIB_SOURCES
   cblockstore.cpp
   cmachine.cpp
   ccheckpointstorage.cpp
+  cvaluecache.cpp
 )
 
 add_library(cavm STATIC ${LIB_HEADERS} ${LIB_SOURCES})

--- a/packages/arb-avm-cpp/cavm/caggregator.h
+++ b/packages/arb-avm-cpp/cavm/caggregator.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef caggregator_hpp
-#define caggregator_hpp
+#ifndef caggregator_h
+#define caggregator_h
 
 #include "ctypes.h"
 
@@ -84,4 +84,4 @@ int aggregatorSaveRequest(CAggregatorStore* agg,
 }
 #endif
 
-#endif /* caggregator_hpp */
+#endif /* caggregator_h */

--- a/packages/arb-avm-cpp/cavm/ccheckpointstorage.cpp
+++ b/packages/arb-avm-cpp/cavm/ccheckpointstorage.cpp
@@ -76,23 +76,35 @@ CAggregatorStore* createAggregatorStore(CCheckpointStorage* storage_ptr) {
     return storage->getAggregatorStore().release();
 }
 
-CMachine* getInitialMachine(const CCheckpointStorage* storage_ptr) {
+CMachine* getInitialMachine(const CCheckpointStorage* storage_ptr,
+                            CValueCache* value_cache_ptr) {
     auto storage = static_cast<const CheckpointStorage*>(storage_ptr);
-    ValueCache value_cache{};
+    auto value_cache = static_cast<ValueCache*>(value_cache_ptr);
     try {
-        return new Machine(storage->getInitialMachine(value_cache));
+        if (value_cache == nullptr) {
+            ValueCache cache;
+            return new Machine(storage->getInitialMachine(cache));
+        }
+
+        return new Machine(storage->getInitialMachine(*value_cache));
     } catch (const std::exception&) {
         return nullptr;
     }
 }
 
 CMachine* getMachine(const CCheckpointStorage* storage_ptr,
-                     const void* machine_hash) {
+                     const void* machine_hash,
+                     CValueCache* value_cache_ptr) {
     auto storage = static_cast<const CheckpointStorage*>(storage_ptr);
     auto hash = receiveUint256(machine_hash);
-    ValueCache value_cache{};
+    auto value_cache = static_cast<ValueCache*>(value_cache_ptr);
     try {
-        return new Machine(storage->getMachine(hash, value_cache));
+        if (value_cache == nullptr) {
+            ValueCache cache;
+            return new Machine(storage->getMachine(hash, cache));
+        }
+
+        return new Machine(storage->getMachine(hash, *value_cache));
     } catch (const std::exception&) {
         return nullptr;
     }
@@ -126,11 +138,18 @@ int saveValue(CCheckpointStorage* storage_ptr, const void* value_data) {
 }
 
 ByteSlice getValue(const CCheckpointStorage* storage_ptr,
-                   const void* hash_key) {
+                   const void* hash_key,
+                   CValueCache* value_cache_ptr) {
     auto storage = static_cast<const CheckpointStorage*>(storage_ptr);
     auto hash = receiveUint256(hash_key);
-    ValueCache value_cache{};
-    return returnValueResult(storage->getValue(hash, value_cache));
+    auto value_cache = static_cast<ValueCache*>(value_cache_ptr);
+
+    if (value_cache == nullptr) {
+        ValueCache cache;
+        return returnValueResult(storage->getValue(hash, cache));
+    }
+
+    return returnValueResult(storage->getValue(hash, *value_cache));
 }
 
 int deleteValue(CCheckpointStorage* storage_ptr, const void* hash_key) {

--- a/packages/arb-avm-cpp/cavm/ccheckpointstorage.h
+++ b/packages/arb-avm-cpp/cavm/ccheckpointstorage.h
@@ -29,13 +29,17 @@ int initializeCheckpointStorage(CCheckpointStorage* storage_ptr,
                                 const char* executable_path);
 int checkpointStorageInitialized(CCheckpointStorage* storage_ptr);
 void destroyCheckpointStorage(CCheckpointStorage* storage);
-CMachine* getInitialMachine(const CCheckpointStorage* storage_ptr);
+CMachine* getInitialMachine(const CCheckpointStorage* storage_ptr,
+                            CValueCache* value_cache_ptr);
 CMachine* getMachine(const CCheckpointStorage* storage_ptr,
-                     const void* machine_hash);
+                     const void* machine_hash,
+                     CValueCache* value_cache_ptr);
 int closeCheckpointStorage(CCheckpointStorage* storage_ptr);
 int deleteCheckpoint(CCheckpointStorage* storage_ptr, const void* machine_hash);
 int saveValue(CCheckpointStorage* storage_ptr, const void* value_data);
-ByteSlice getValue(const CCheckpointStorage* storage_ptr, const void* hash_key);
+ByteSlice getValue(const CCheckpointStorage* storage_ptr,
+                   const void* hash_key,
+                   CValueCache* value_cache_ptr);
 int deleteValue(CCheckpointStorage* storage_ptr, const void* hash_key);
 int saveData(CCheckpointStorage* storage_ptr,
              const void* key,

--- a/packages/arb-avm-cpp/cavm/cmachine.h
+++ b/packages/arb-avm-cpp/cavm/cmachine.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef Machine_h
-#define Machine_h
+#ifndef cmachine_h
+#define cmachine_h
 
 #include <stdint.h>
 #include "ccheckpointstorage.h"
@@ -101,4 +101,4 @@ int checkpointMachine(CMachine* m, CCheckpointStorage* storage);
 }
 #endif
 
-#endif /* Machine_h */
+#endif /* cmachine_h */

--- a/packages/arb-avm-cpp/cavm/ctypes.h
+++ b/packages/arb-avm-cpp/cavm/ctypes.h
@@ -62,6 +62,7 @@ typedef void CMachine;
 typedef void CCheckpointStorage;
 typedef void CBlockStore;
 typedef void CAggregatorStore;
+typedef void CValueCache;
 
 #ifdef __cplusplus
 }

--- a/packages/arb-avm-cpp/cavm/cvaluecache.cpp
+++ b/packages/arb-avm-cpp/cavm/cvaluecache.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cvaluecache.h"
+#include "utils.hpp"
+
+#include <data_storage/value/valuecache.hpp>
+
+// cvaluecache_t *valuecache_create()
+CValueCache* createValueCache() {
+    return static_cast<void*>(new ValueCache);
+}
+
+void destroyValueCache(CValueCache* c) {
+    if (c == nullptr) {
+        return;
+    }
+    delete static_cast<ValueCache*>(c);
+}
+
+void clearValueCache(CValueCache* c) {
+    auto valuecache = static_cast<ValueCache*>(c);
+    if (valuecache == nullptr) {
+        return;
+    }
+
+    valuecache->clear();
+}

--- a/packages/arb-avm-cpp/cavm/cvaluecache.h
+++ b/packages/arb-avm-cpp/cavm/cvaluecache.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef cvaluecache_h
+#define cvaluecache_h
+
+#include "ctypes.h"
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+CValueCache* createValueCache();
+void destroyValueCache(CValueCache* c);
+void clearValueCache(CValueCache* c);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* cvaluecache_h */

--- a/packages/arb-avm-cpp/cmachine/checkpoint.go
+++ b/packages/arb-avm-cpp/cmachine/checkpoint.go
@@ -81,7 +81,7 @@ func cDestroyCheckpointStorage(cCheckpointStorage *CheckpointStorage) {
 }
 
 func (checkpoint *CheckpointStorage) GetInitialMachine(valueCache machine.ValueCache) (machine.Machine, error) {
-	cMachine := C.getInitialMachine(checkpoint.c, valueCache.UnsafePointer())
+	cMachine := C.getInitialMachine(checkpoint.c, valueCache.(*ValueCache).c)
 
 	if cMachine == nil {
 		return nil, fmt.Errorf("error getting initial machine from checkpointstorage")
@@ -93,7 +93,7 @@ func (checkpoint *CheckpointStorage) GetInitialMachine(valueCache machine.ValueC
 }
 
 func (checkpoint *CheckpointStorage) GetMachine(machineHash common.Hash, valueCache machine.ValueCache) (machine.Machine, error) {
-	cMachine := C.getMachine(checkpoint.c, unsafe.Pointer(&machineHash[0]), valueCache.UnsafePointer())
+	cMachine := C.getMachine(checkpoint.c, unsafe.Pointer(&machineHash[0]), valueCache.(*ValueCache).c)
 
 	if cMachine == nil {
 		return nil, fmt.Errorf("error getting machine from checkpointstorage")
@@ -125,7 +125,7 @@ func (checkpoint *CheckpointStorage) SaveValue(val value.Value) bool {
 }
 
 func (checkpoint *CheckpointStorage) GetValue(hashValue common.Hash, valueCache machine.ValueCache) value.Value {
-	cData := C.getValue(checkpoint.c, unsafe.Pointer(&hashValue[0]), valueCache.UnsafePointer())
+	cData := C.getValue(checkpoint.c, unsafe.Pointer(&hashValue[0]), valueCache.(*ValueCache).c)
 	if cData.data == nil {
 		return nil
 	}

--- a/packages/arb-avm-cpp/cmachine/checkpoint.go
+++ b/packages/arb-avm-cpp/cmachine/checkpoint.go
@@ -20,6 +20,7 @@ package cmachine
 #cgo CFLAGS: -I.
 #cgo LDFLAGS: -L. -L../build/rocksdb -lcavm -lavm -ldata_storage -lavm_values -lstdc++ -lm -lrocksdb -lkeccak -ldl
 #include "../cavm/ccheckpointstorage.h"
+#include "../cavm/cvaluecache.h"
 #include <stdio.h>
 #include <stdlib.h>
 */
@@ -79,8 +80,8 @@ func cDestroyCheckpointStorage(cCheckpointStorage *CheckpointStorage) {
 	C.destroyCheckpointStorage(cCheckpointStorage.c)
 }
 
-func (checkpoint *CheckpointStorage) GetInitialMachine() (machine.Machine, error) {
-	cMachine := C.getInitialMachine(checkpoint.c)
+func (checkpoint *CheckpointStorage) GetInitialMachine(valueCache machine.ValueCache) (machine.Machine, error) {
+	cMachine := C.getInitialMachine(checkpoint.c, valueCache.UnsafePointer())
 
 	if cMachine == nil {
 		return nil, fmt.Errorf("error getting initial machine from checkpointstorage")
@@ -91,8 +92,8 @@ func (checkpoint *CheckpointStorage) GetInitialMachine() (machine.Machine, error
 	return ret, nil
 }
 
-func (checkpoint *CheckpointStorage) GetMachine(machineHash common.Hash) (machine.Machine, error) {
-	cMachine := C.getMachine(checkpoint.c, unsafe.Pointer(&machineHash[0]))
+func (checkpoint *CheckpointStorage) GetMachine(machineHash common.Hash, valueCache machine.ValueCache) (machine.Machine, error) {
+	cMachine := C.getMachine(checkpoint.c, unsafe.Pointer(&machineHash[0]), valueCache.UnsafePointer())
 
 	if cMachine == nil {
 		return nil, fmt.Errorf("error getting machine from checkpointstorage")
@@ -123,8 +124,8 @@ func (checkpoint *CheckpointStorage) SaveValue(val value.Value) bool {
 	return success == 1
 }
 
-func (checkpoint *CheckpointStorage) GetValue(hashValue common.Hash) value.Value {
-	cData := C.getValue(checkpoint.c, unsafe.Pointer(&hashValue[0]))
+func (checkpoint *CheckpointStorage) GetValue(hashValue common.Hash, valueCache machine.ValueCache) value.Value {
+	cData := C.getValue(checkpoint.c, unsafe.Pointer(&hashValue[0]), valueCache.UnsafePointer())
 	if cData.data == nil {
 		return nil
 	}

--- a/packages/arb-avm-cpp/cmachine/checkpoint_test.go
+++ b/packages/arb-avm-cpp/cmachine/checkpoint_test.go
@@ -52,6 +52,12 @@ func TestCheckpoint(t *testing.T) {
 func TestCheckpointMachine(t *testing.T) {
 	dePath := "dbPath2"
 
+	valueCache, err := NewValueCache()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer DestroyValueCache(valueCache)
+
 	checkpointStorage, err := NewCheckpoint(dePath)
 	if err != nil {
 		t.Fatal(err)
@@ -61,7 +67,7 @@ func TestCheckpointMachine(t *testing.T) {
 	}
 	defer checkpointStorage.CloseCheckpointStorage()
 
-	mach, err := checkpointStorage.GetInitialMachine()
+	mach, err := checkpointStorage.GetInitialMachine(valueCache)
 	if err != nil {
 		t.Error(err)
 	}
@@ -80,7 +86,7 @@ func TestCheckpointMachine(t *testing.T) {
 		t.Error("Failed to checkpoint machine")
 	}
 
-	loadedMach, err := checkpointStorage.GetMachine(mach.Hash())
+	loadedMach, err := checkpointStorage.GetMachine(mach.Hash(), valueCache)
 	if err != nil {
 		t.Error(err)
 	}

--- a/packages/arb-avm-cpp/cmachine/checkpoint_test.go
+++ b/packages/arb-avm-cpp/cmachine/checkpoint_test.go
@@ -56,7 +56,6 @@ func TestCheckpointMachine(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer DestroyValueCache(valueCache)
 
 	checkpointStorage, err := NewCheckpoint(dePath)
 	if err != nil {

--- a/packages/arb-avm-cpp/cmachine/cmachine_test.go
+++ b/packages/arb-avm-cpp/cmachine/cmachine_test.go
@@ -29,6 +29,12 @@ func TestMachineCreation(t *testing.T) {
 		log.Fatal(err)
 	}
 
+	valueCache, err := NewValueCache()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer DestroyValueCache(valueCache)
+
 	mach1, err := New(codeFile)
 	if err != nil {
 		t.Fatal(err)
@@ -42,7 +48,7 @@ func TestMachineCreation(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer checkpointStorage.CloseCheckpointStorage()
-	mach2, err := checkpointStorage.GetInitialMachine()
+	mach2, err := checkpointStorage.GetInitialMachine(valueCache)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/packages/arb-avm-cpp/cmachine/cmachine_test.go
+++ b/packages/arb-avm-cpp/cmachine/cmachine_test.go
@@ -33,7 +33,6 @@ func TestMachineCreation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer DestroyValueCache(valueCache)
 
 	mach1, err := New(codeFile)
 	if err != nil {

--- a/packages/arb-avm-cpp/cmachine/valuecache.go
+++ b/packages/arb-avm-cpp/cmachine/valuecache.go
@@ -26,6 +26,7 @@ package cmachine
 import "C"
 import (
 	"fmt"
+	"runtime"
 	"unsafe"
 )
 
@@ -40,6 +41,7 @@ func NewValueCache() (*ValueCache, error) {
 		return nil, fmt.Errorf("error loading value cache")
 	}
 	ret := &ValueCache{cValueCache}
+	runtime.SetFinalizer(ret, DestroyValueCache)
 	return ret, nil
 }
 
@@ -49,8 +51,4 @@ func DestroyValueCache(cValueCache *ValueCache) {
 
 func (valueCache *ValueCache) Clear() {
 	C.clearValueCache(valueCache.c)
-}
-
-func (valueCache *ValueCache) UnsafePointer() unsafe.Pointer {
-	return valueCache.c
 }

--- a/packages/arb-avm-cpp/cmachine/valuecache.go
+++ b/packages/arb-avm-cpp/cmachine/valuecache.go
@@ -41,11 +41,11 @@ func NewValueCache() (*ValueCache, error) {
 		return nil, fmt.Errorf("error loading value cache")
 	}
 	ret := &ValueCache{cValueCache}
-	runtime.SetFinalizer(ret, DestroyValueCache)
+	runtime.SetFinalizer(ret, destroyValueCache)
 	return ret, nil
 }
 
-func DestroyValueCache(cValueCache *ValueCache) {
+func destroyValueCache(cValueCache *ValueCache) {
 	C.destroyValueCache(cValueCache.c)
 }
 

--- a/packages/arb-avm-cpp/cmachine/valuecache.go
+++ b/packages/arb-avm-cpp/cmachine/valuecache.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmachine
+
+/*
+#cgo CFLAGS: -I.
+#cgo LDFLAGS: -L. -L../build/rocksdb -lcavm -lavm -ldata_storage -lavm_values -lstdc++ -lm -lrocksdb -ldl
+#include "../cavm/cvaluecache.h"
+#include <stdio.h>
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+type ValueCache struct {
+	c unsafe.Pointer
+}
+
+func NewValueCache() (*ValueCache, error) {
+	cValueCache := C.createValueCache()
+
+	if cValueCache == nil {
+		return nil, fmt.Errorf("error loading value cache")
+	}
+	ret := &ValueCache{cValueCache}
+	return ret, nil
+}
+
+func DestroyValueCache(cValueCache *ValueCache) {
+	C.destroyValueCache(cValueCache.c)
+}
+
+func (valueCache *ValueCache) Clear() {
+	C.clearValueCache(valueCache.c)
+}
+
+func (valueCache *ValueCache) UnsafePointer() unsafe.Pointer {
+	return valueCache.c
+}

--- a/packages/arb-avm-cpp/data_storage/CMakeLists.txt
+++ b/packages/arb-avm-cpp/data_storage/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LIB_HEADERS
   include/data_storage/value/code.hpp
   include/data_storage/value/machine.hpp
   include/data_storage/value/value.hpp
+  include/data_storage/value/valuecache.hpp
 )
 
 set(LIB_PRIVATE_HEADERS
@@ -47,6 +48,7 @@ set(LIB_SOURCES
   src/value/machine.cpp
   src/value/referencecount.cpp
   src/value/value.cpp
+  src/value/valuecache.cpp
 )
 
 add_library(data_storage STATIC ${LIB_HEADERS} ${LIB_PRIVATE_HEADERS} ${LIB_SOURCES})

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/value/value.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/value/value.hpp
@@ -18,6 +18,7 @@
 #define checkpoint_value_hpp
 
 #include <avm_values/value.hpp>
+#include <data_storage/value/valuecache.hpp>
 
 #include <map>
 #include <set>
@@ -28,14 +29,6 @@ class Transaction;
 
 template <typename T>
 struct DbResult;
-
-struct ValueCacheHasher {
-    std::size_t operator()(const uint256_t& v) const noexcept {
-        return intx::narrow_cast<std::size_t>(v);
-    }
-};
-
-using ValueCache = std::unordered_map<uint256_t, value, ValueCacheHasher>;
 
 SaveResults saveValueImpl(Transaction& transaction,
                           const value& val,

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/value/valuecache.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/value/valuecache.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019-2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef valuecache_hpp
+#define valuecache_hpp
+
+#include <avm_values/code.hpp>
+#include <avm_values/codepointstub.hpp>
+#include <avm_values/pool.hpp>
+#include <avm_values/tuple.hpp>
+#include <avm_values/value.hpp>
+
+#include <optional>
+#include <vector>
+
+class ValueCache {
+   private:
+    struct ValueCacheHasher {
+        std::size_t operator()(const uint256_t& hash) const noexcept {
+            return intx::narrow_cast<std::size_t>(hash);
+        }
+    };
+
+    std::unordered_map<uint256_t, value, ValueCacheHasher> cache;
+
+   public:
+    void clear();
+    void maybeSave(value val);
+    nonstd::optional<value> loadIfExists(const uint256_t& hash);
+};
+
+#endif /* valuecache_hpp */

--- a/packages/arb-avm-cpp/data_storage/src/value/valuecache.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/value/valuecache.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019-2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <data_storage/value/valuecache.hpp>
+
+void ValueCache::clear() {
+    cache.clear();
+}
+
+void ValueCache::maybeSave(value val) {
+    cache.emplace(hash_value(val), std::move(val));
+}
+
+nonstd::optional<value> ValueCache::loadIfExists(const uint256_t& hash) {
+    auto iter = cache.find(hash);
+    if (iter == cache.end()) {
+        return nonstd::nullopt;
+    }
+
+    return iter->second;
+}

--- a/packages/arb-avm-cpp/data_storage/src/value/valuecache.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/value/valuecache.cpp
@@ -21,7 +21,8 @@ void ValueCache::clear() {
 }
 
 void ValueCache::maybeSave(value val) {
-    cache.emplace(hash_value(val), std::move(val));
+    auto value_hash = hash_value(val);
+    cache.emplace(value_hash, std::move(val));
 }
 
 nonstd::optional<value> ValueCache::loadIfExists(const uint256_t& hash) {

--- a/packages/arb-avm-cpp/speedtest/speed_test.go
+++ b/packages/arb-avm-cpp/speedtest/speed_test.go
@@ -49,6 +49,12 @@ func runExecutableFile(b *testing.B, filePath string) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	valueCache, err := cmachine.NewValueCache()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cmachine.DestroyValueCache(valueCache)
+
 	ckp, err := cmachine.NewCheckpoint(ckpDir)
 	if err != nil {
 		b.Fatal(err)
@@ -56,7 +62,7 @@ func runExecutableFile(b *testing.B, filePath string) {
 	if err := ckp.Initialize(filePath); err != nil {
 		b.Fatal(err)
 	}
-	mach, err := ckp.GetInitialMachine()
+	mach, err := ckp.GetInitialMachine(valueCache)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/packages/arb-avm-cpp/speedtest/speed_test.go
+++ b/packages/arb-avm-cpp/speedtest/speed_test.go
@@ -53,7 +53,6 @@ func runExecutableFile(b *testing.B, filePath string) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer cmachine.DestroyValueCache(valueCache)
 
 	ckp, err := cmachine.NewCheckpoint(ckpDir)
 	if err != nil {

--- a/packages/arb-checkpointer/checkpointing/checkpointing.go
+++ b/packages/arb-checkpointer/checkpointing/checkpointing.go
@@ -30,7 +30,7 @@ type RollupCheckpointer interface {
 	Initialized() bool
 	HasCheckpointedState() bool
 	RestoreLatestState(context.Context, arbbridge.ChainTimeGetter, func([]byte, ckptcontext.RestoreContext, *common.BlockId) error) error
-	GetInitialMachine() (machine.Machine, error)
+	GetInitialMachine(valueCache machine.ValueCache) (machine.Machine, error)
 	AsyncSaveCheckpoint(blockId *common.BlockId, contents []byte, cpCtx *ckptcontext.CheckpointContext) <-chan error
 
 	MaxReorgHeight() *big.Int

--- a/packages/arb-checkpointer/checkpointing/indexedCheckpointer.go
+++ b/packages/arb-checkpointer/checkpointing/indexedCheckpointer.go
@@ -312,7 +312,6 @@ func newRestoreContextLocked(db machine.CheckpointStorage, manifest *ckptcontext
 	if err != nil {
 		return nil, err
 	}
-	defer cmachine.DestroyValueCache(valueCache)
 
 	for _, valHash := range manifest.GetValues() {
 		hash := valHash.Unmarshal()

--- a/packages/arb-checkpointer/checkpointing/indexedCheckpointer.go
+++ b/packages/arb-checkpointer/checkpointing/indexedCheckpointer.go
@@ -19,6 +19,7 @@ package checkpointing
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"math/big"
 	"os"
@@ -122,8 +123,8 @@ func (cp *IndexedCheckpointer) HasCheckpointedState() bool {
 	return !cp.bs.IsBlockStoreEmpty()
 }
 
-func (cp *IndexedCheckpointer) GetInitialMachine() (machine.Machine, error) {
-	return cp.db.GetInitialMachine()
+func (cp *IndexedCheckpointer) GetInitialMachine(vc machine.ValueCache) (machine.Machine, error) {
+	return cp.db.GetInitialMachine(vc)
 }
 
 type writableCheckpoint struct {
@@ -191,7 +192,13 @@ func restoreLatestState(
 			// If something went wrong, try the next block
 			continue
 		}
-		if err := unmarshalFunc(ckpWithMan.Contents, &restoreContextLocked{db}, onchainId); err != nil {
+
+		rcl, err := newRestoreContextLocked(db, ckpWithMan.Manifest)
+		if err != nil {
+			log.Println("Failed load manifest data at height", height, "with error", err)
+			continue
+		}
+		if err := unmarshalFunc(ckpWithMan.Contents, rcl, onchainId); err != nil {
 			log.Println("Failed load checkpoint at height", height, "with error", err)
 			continue
 		}
@@ -293,15 +300,57 @@ func deleteCheckpointForKey(bs machine.BlockStore, db machine.CheckpointStorage,
 }
 
 type restoreContextLocked struct {
-	db machine.CheckpointStorage
+	db       machine.CheckpointStorage
+	values   map[common.Hash]value.Value
+	machines map[common.Hash]machine.Machine
 }
 
-func (rcl *restoreContextLocked) GetValue(h common.Hash) value.Value {
-	return rcl.db.GetValue(h)
+func newRestoreContextLocked(db machine.CheckpointStorage, manifest *ckptcontext.CheckpointManifest) (*restoreContextLocked, error) {
+	rcl := restoreContextLocked{db, map[common.Hash]value.Value{}, map[common.Hash]machine.Machine{}}
+
+	valueCache, err := cmachine.NewValueCache()
+	if err != nil {
+		return nil, err
+	}
+	defer cmachine.DestroyValueCache(valueCache)
+
+	for _, valHash := range manifest.GetValues() {
+		hash := valHash.Unmarshal()
+		val := rcl.db.GetValue(hash, valueCache)
+		if val == nil {
+			return nil, fmt.Errorf("unable to find the value hash: %s", hash.String())
+		}
+
+		rcl.values[hash] = val
+	}
+
+	for _, machHash := range manifest.GetMachines() {
+		hash := machHash.Unmarshal()
+		mach, err := rcl.db.GetMachine(hash, valueCache)
+		if err != nil {
+			return nil, err
+		}
+
+		rcl.machines[hash] = mach
+	}
+
+	return &rcl, nil
 }
 
-func (rcl *restoreContextLocked) GetMachine(h common.Hash) machine.Machine {
-	ret, err := rcl.db.GetMachine(h)
+func (rcl *restoreContextLocked) GetValue(h common.Hash, vc machine.ValueCache) value.Value {
+	if val, ok := rcl.values[h]; ok {
+		return val
+	}
+
+	return rcl.db.GetValue(h, vc)
+}
+
+func (rcl *restoreContextLocked) GetMachine(h common.Hash, vc machine.ValueCache) machine.Machine {
+	if mach, ok := rcl.machines[h]; ok {
+		return mach
+	}
+
+	ret, err := rcl.db.GetMachine(h, vc)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/packages/arb-checkpointer/ckptcontext/context.go
+++ b/packages/arb-checkpointer/ckptcontext/context.go
@@ -21,12 +21,11 @@ import (
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/machine"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/value"
-	"log"
 )
 
 type RestoreContext interface {
-	GetValue(common.Hash, machine.ValueCache) value.Value
-	GetMachine(common.Hash, machine.ValueCache) machine.Machine
+	GetValue(common.Hash) value.Value
+	GetMachine(common.Hash) machine.Machine
 }
 
 type CheckpointContext struct {
@@ -71,11 +70,11 @@ func (ctx *CheckpointContext) Machines() map[common.Hash]machine.Machine {
 	return ctx.machines
 }
 
-func (ctx *CheckpointContext) GetValue(h common.Hash, vc machine.ValueCache) value.Value {
+func (ctx *CheckpointContext) GetValue(h common.Hash) value.Value {
 	return ctx.values[h]
 }
 
-func (ctx *CheckpointContext) GetMachine(h common.Hash, vc machine.ValueCache) machine.Machine {
+func (ctx *CheckpointContext) GetMachine(h common.Hash) machine.Machine {
 	return ctx.machines[h]
 }
 
@@ -91,24 +90,4 @@ func SaveCheckpointContext(db machine.CheckpointStorage, ckpCtx *CheckpointConte
 		}
 	}
 	return nil
-}
-
-type SimpleRestore struct {
-	db machine.CheckpointStorage
-}
-
-func NewSimpleRestore(db machine.CheckpointStorage) *SimpleRestore {
-	return &SimpleRestore{db: db}
-}
-
-func (sr *SimpleRestore) GetValue(h common.Hash, v machine.ValueCache) value.Value {
-	return sr.db.GetValue(h, v)
-}
-
-func (sr *SimpleRestore) GetMachine(h common.Hash, v machine.ValueCache) machine.Machine {
-	ret, err := sr.db.GetMachine(h, v)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return ret
 }

--- a/packages/arb-checkpointer/ckptcontext/context.go
+++ b/packages/arb-checkpointer/ckptcontext/context.go
@@ -25,8 +25,8 @@ import (
 )
 
 type RestoreContext interface {
-	GetValue(common.Hash) value.Value
-	GetMachine(common.Hash) machine.Machine
+	GetValue(common.Hash, machine.ValueCache) value.Value
+	GetMachine(common.Hash, machine.ValueCache) machine.Machine
 }
 
 type CheckpointContext struct {
@@ -71,11 +71,11 @@ func (ctx *CheckpointContext) Machines() map[common.Hash]machine.Machine {
 	return ctx.machines
 }
 
-func (ctx *CheckpointContext) GetValue(h common.Hash) value.Value {
+func (ctx *CheckpointContext) GetValue(h common.Hash, vc machine.ValueCache) value.Value {
 	return ctx.values[h]
 }
 
-func (ctx *CheckpointContext) GetMachine(h common.Hash) machine.Machine {
+func (ctx *CheckpointContext) GetMachine(h common.Hash, vc machine.ValueCache) machine.Machine {
 	return ctx.machines[h]
 }
 
@@ -101,12 +101,12 @@ func NewSimpleRestore(db machine.CheckpointStorage) *SimpleRestore {
 	return &SimpleRestore{db: db}
 }
 
-func (sr *SimpleRestore) GetValue(h common.Hash) value.Value {
-	return sr.db.GetValue(h)
+func (sr *SimpleRestore) GetValue(h common.Hash, v machine.ValueCache) value.Value {
+	return sr.db.GetValue(h, v)
 }
 
-func (sr *SimpleRestore) GetMachine(h common.Hash) machine.Machine {
-	ret, err := sr.db.GetMachine(h)
+func (sr *SimpleRestore) GetMachine(h common.Hash, v machine.ValueCache) machine.Machine {
+	ret, err := sr.db.GetMachine(h, v)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/packages/arb-tx-aggregator/machineobserver/observermanager.go
+++ b/packages/arb-tx-aggregator/machineobserver/observermanager.go
@@ -18,16 +18,17 @@ package machineobserver
 
 import (
 	"context"
-	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/observer"
 	errors2 "github.com/pkg/errors"
 	"log"
 	"math/big"
 	"time"
 
+	"github.com/offchainlabs/arbitrum/packages/arb-avm-cpp/cmachine"
 	"github.com/offchainlabs/arbitrum/packages/arb-checkpointer/checkpointing"
 	"github.com/offchainlabs/arbitrum/packages/arb-tx-aggregator/txdb"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/arbbridge"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/observer"
 )
 
 const defaultMaxReorgDepth = 100
@@ -64,7 +65,13 @@ func ensureInitialized(
 		return err
 	}
 
-	initialMachine, err := cp.GetInitialMachine()
+	valueCache, err := cmachine.NewValueCache()
+	if err != nil {
+		return err
+	}
+	defer cmachine.DestroyValueCache(valueCache)
+
+	initialMachine, err := cp.GetInitialMachine(valueCache)
 	if err != nil {
 		return err
 	}

--- a/packages/arb-tx-aggregator/machineobserver/observermanager.go
+++ b/packages/arb-tx-aggregator/machineobserver/observermanager.go
@@ -69,7 +69,6 @@ func ensureInitialized(
 	if err != nil {
 		return err
 	}
-	defer cmachine.DestroyValueCache(valueCache)
 
 	initialMachine, err := cp.GetInitialMachine(valueCache)
 	if err != nil {

--- a/packages/arb-tx-aggregator/txdb/txdb.go
+++ b/packages/arb-tx-aggregator/txdb/txdb.go
@@ -113,11 +113,7 @@ func (txdb *TxDB) restoreFromCheckpoint(ctx context.Context) error {
 		var machineHash common.Hash
 		copy(machineHash[:], chainObserverBytes)
 		lastInboxSeq = new(big.Int).SetBytes(chainObserverBytes[32:])
-		valueCache, err := cmachine.NewValueCache()
-		if err != nil {
-			return err
-		}
-		mach = restoreCtx.GetMachine(machineHash, valueCache)
+		mach = restoreCtx.GetMachine(machineHash)
 		blockId = restoreBlockId
 		return nil
 	}); err != nil {

--- a/packages/arb-tx-aggregator/txdb/txdb.go
+++ b/packages/arb-tx-aggregator/txdb/txdb.go
@@ -81,7 +81,6 @@ func (txdb *TxDB) Load(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer cmachine.DestroyValueCache(valueCache)
 
 	mach, err := txdb.checkpointer.GetInitialMachine(valueCache)
 	if err != nil {
@@ -118,7 +117,6 @@ func (txdb *TxDB) restoreFromCheckpoint(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		defer cmachine.DestroyValueCache(valueCache)
 		mach = restoreCtx.GetMachine(machineHash, valueCache)
 		blockId = restoreBlockId
 		return nil

--- a/packages/arb-util/machine/checkpoint.go
+++ b/packages/arb-util/machine/checkpoint.go
@@ -26,10 +26,10 @@ type CheckpointStorage interface {
 	Initialize(contractPath string) error
 	Initialized() bool
 	CloseCheckpointStorage() bool
-	GetInitialMachine() (Machine, error)
-	GetMachine(machineHash common.Hash) (Machine, error)
+	GetInitialMachine(valueCache ValueCache) (Machine, error)
+	GetMachine(machineHash common.Hash, valueCache ValueCache) (Machine, error)
 	SaveValue(val value.Value) bool
-	GetValue(hashValue common.Hash) value.Value
+	GetValue(hashValue common.Hash, valueCache ValueCache) value.Value
 	DeleteValue(hashValue common.Hash) bool
 	SaveData(key []byte, serializedValue []byte) bool
 	GetData(key []byte) []byte

--- a/packages/arb-util/machine/valuecache.go
+++ b/packages/arb-util/machine/valuecache.go
@@ -16,9 +16,6 @@
 
 package machine
 
-import "unsafe"
-
 type ValueCache interface {
 	Clear()
-	UnsafePointer() unsafe.Pointer
 }

--- a/packages/arb-util/machine/valuecache.go
+++ b/packages/arb-util/machine/valuecache.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019-2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package machine
+
+import "unsafe"
+
+type ValueCache interface {
+	Clear()
+	UnsafePointer() unsafe.Pointer
+}

--- a/packages/arb-validator/chainobserver/chainObserver.go
+++ b/packages/arb-validator/chainobserver/chainObserver.go
@@ -28,6 +28,7 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"github.com/offchainlabs/arbitrum/packages/arb-avm-cpp/cmachine"
 	"github.com/offchainlabs/arbitrum/packages/arb-checkpointer/checkpointing"
 	"github.com/offchainlabs/arbitrum/packages/arb-checkpointer/ckptcontext"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
@@ -298,7 +299,13 @@ func newChain(
 	checkpointer checkpointing.RollupCheckpointer,
 	vmParams valprotocol.ChainParams,
 ) (*ChainObserver, error) {
-	mach, err := checkpointer.GetInitialMachine()
+	valueCache, err := cmachine.NewValueCache()
+	if err != nil {
+		return nil, err
+	}
+	defer cmachine.DestroyValueCache(valueCache)
+
+	mach, err := checkpointer.GetInitialMachine(valueCache)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/arb-validator/chainobserver/chainObserver.go
+++ b/packages/arb-validator/chainobserver/chainObserver.go
@@ -303,7 +303,6 @@ func newChain(
 	if err != nil {
 		return nil, err
 	}
-	defer cmachine.DestroyValueCache(valueCache)
 
 	mach, err := checkpointer.GetInitialMachine(valueCache)
 	if err != nil {

--- a/packages/arb-validator/chainobserver/dummyCheckpointing.go
+++ b/packages/arb-validator/chainobserver/dummyCheckpointing.go
@@ -57,7 +57,7 @@ func (dcp *DummyCheckpointer) RestoreLatestState(context.Context, arbbridge.Chai
 	return errors.New("no checkpoints in database")
 }
 
-func (dcp *DummyCheckpointer) GetInitialMachine() (machine.Machine, error) {
+func (dcp *DummyCheckpointer) GetInitialMachine(valueCache machine.ValueCache) (machine.Machine, error) {
 	return dcp.initialMachine.Clone(), nil
 }
 

--- a/packages/arb-validator/rollupmanager/manager.go
+++ b/packages/arb-validator/rollupmanager/manager.go
@@ -18,18 +18,19 @@ package rollupmanager
 
 import (
 	"context"
-	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/observer"
-	"github.com/offchainlabs/arbitrum/packages/arb-validator/chainlistener"
-	"github.com/offchainlabs/arbitrum/packages/arb-validator/chainobserver"
 	errors2 "github.com/pkg/errors"
 	"log"
 	"math/big"
 	"sync"
 	"time"
 
+	"github.com/offchainlabs/arbitrum/packages/arb-avm-cpp/cmachine"
 	"github.com/offchainlabs/arbitrum/packages/arb-checkpointer/checkpointing"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/arbbridge"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/observer"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator/chainlistener"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator/chainobserver"
 )
 
 type Manager struct {
@@ -88,7 +89,14 @@ func CreateManagerAdvanced(
 			return nil, err
 		}
 	}
-	initialMachine, err := checkpointer.GetInitialMachine()
+
+	valueCache, err := cmachine.NewValueCache()
+	if err != nil {
+		return nil, err
+	}
+	defer cmachine.DestroyValueCache(valueCache)
+
+	initialMachine, err := checkpointer.GetInitialMachine(valueCache)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/arb-validator/rollupmanager/manager.go
+++ b/packages/arb-validator/rollupmanager/manager.go
@@ -94,7 +94,6 @@ func CreateManagerAdvanced(
 	if err != nil {
 		return nil, err
 	}
-	defer cmachine.DestroyValueCache(valueCache)
 
 	initialMachine, err := checkpointer.GetInitialMachine(valueCache)
 	if err != nil {

--- a/packages/arb-validator/rolluptest/evilRollupCheckpointer.go
+++ b/packages/arb-validator/rolluptest/evilRollupCheckpointer.go
@@ -56,12 +56,12 @@ func (e *EvilRollupCheckpointer) Initialized() bool {
 	return e.cp.Initialized()
 }
 
-func (e EvilRollupCheckpointer) GetValue(h common.Hash) value.Value {
-	return e.cp.(ckptcontext.RestoreContext).GetValue(h)
+func (e EvilRollupCheckpointer) GetValue(h common.Hash, vc machine.ValueCache) value.Value {
+	return e.cp.(ckptcontext.RestoreContext).GetValue(h, vc)
 }
 
-func (e EvilRollupCheckpointer) GetMachine(h common.Hash) machine.Machine {
-	return NewEvilMachine(e.cp.(ckptcontext.RestoreContext).GetMachine(h).(*cmachine.Machine))
+func (e EvilRollupCheckpointer) GetMachine(h common.Hash, vc machine.ValueCache) machine.Machine {
+	return NewEvilMachine(e.cp.(ckptcontext.RestoreContext).GetMachine(h, vc).(*cmachine.Machine))
 }
 
 func (e EvilRollupCheckpointer) HasCheckpointedState() bool {
@@ -86,16 +86,16 @@ type evilRestoreContext struct {
 	rc ckptcontext.RestoreContext
 }
 
-func (erc *evilRestoreContext) GetValue(h common.Hash) value.Value {
-	return erc.rc.GetValue(h)
+func (erc *evilRestoreContext) GetValue(h common.Hash, vc machine.ValueCache) value.Value {
+	return erc.rc.GetValue(h, vc)
 }
 
-func (erc *evilRestoreContext) GetMachine(h common.Hash) machine.Machine {
-	return NewEvilMachine(erc.rc.GetMachine(h).(*cmachine.Machine))
+func (erc *evilRestoreContext) GetMachine(h common.Hash, vc machine.ValueCache) machine.Machine {
+	return NewEvilMachine(erc.rc.GetMachine(h, vc).(*cmachine.Machine))
 }
 
-func (e EvilRollupCheckpointer) GetInitialMachine() (machine.Machine, error) {
-	m, err := e.cp.GetInitialMachine()
+func (e EvilRollupCheckpointer) GetInitialMachine(vc machine.ValueCache) (machine.Machine, error) {
+	m, err := e.cp.GetInitialMachine(vc)
 	if err != nil {
 		return m, err
 	}

--- a/packages/arb-validator/rolluptest/evilRollupCheckpointer.go
+++ b/packages/arb-validator/rolluptest/evilRollupCheckpointer.go
@@ -56,12 +56,12 @@ func (e *EvilRollupCheckpointer) Initialized() bool {
 	return e.cp.Initialized()
 }
 
-func (e EvilRollupCheckpointer) GetValue(h common.Hash, vc machine.ValueCache) value.Value {
-	return e.cp.(ckptcontext.RestoreContext).GetValue(h, vc)
+func (e EvilRollupCheckpointer) GetValue(h common.Hash) value.Value {
+	return e.cp.(ckptcontext.RestoreContext).GetValue(h)
 }
 
-func (e EvilRollupCheckpointer) GetMachine(h common.Hash, vc machine.ValueCache) machine.Machine {
-	return NewEvilMachine(e.cp.(ckptcontext.RestoreContext).GetMachine(h, vc).(*cmachine.Machine))
+func (e EvilRollupCheckpointer) GetMachine(h common.Hash) machine.Machine {
+	return NewEvilMachine(e.cp.(ckptcontext.RestoreContext).GetMachine(h).(*cmachine.Machine))
 }
 
 func (e EvilRollupCheckpointer) HasCheckpointedState() bool {
@@ -86,12 +86,12 @@ type evilRestoreContext struct {
 	rc ckptcontext.RestoreContext
 }
 
-func (erc *evilRestoreContext) GetValue(h common.Hash, vc machine.ValueCache) value.Value {
-	return erc.rc.GetValue(h, vc)
+func (erc *evilRestoreContext) GetValue(h common.Hash) value.Value {
+	return erc.rc.GetValue(h)
 }
 
-func (erc *evilRestoreContext) GetMachine(h common.Hash, vc machine.ValueCache) machine.Machine {
-	return NewEvilMachine(erc.rc.GetMachine(h, vc).(*cmachine.Machine))
+func (erc *evilRestoreContext) GetMachine(h common.Hash) machine.Machine {
+	return NewEvilMachine(erc.rc.GetMachine(h).(*cmachine.Machine))
 }
 
 func (e EvilRollupCheckpointer) GetInitialMachine(vc machine.ValueCache) (machine.Machine, error) {

--- a/packages/arb-validator/structures/inbox.go
+++ b/packages/arb-validator/structures/inbox.go
@@ -210,7 +210,6 @@ func (x *InboxBuf) UnmarshalFromCheckpoint(ctx ckptcontext.RestoreContext) (*Mes
 	if err != nil {
 		return nil, err
 	}
-	defer cmachine.DestroyValueCache(valueCache)
 
 	for i := len(x.Items) - 1; i >= 0; i = i - 1 {
 		val := ctx.GetValue(x.Items[i].Unmarshal(), valueCache)

--- a/packages/arb-validator/structures/node.go
+++ b/packages/arb-validator/structures/node.go
@@ -23,7 +23,6 @@ import (
 	"math/big"
 	"math/rand"
 
-	"github.com/offchainlabs/arbitrum/packages/arb-avm-cpp/cmachine"
 	"github.com/offchainlabs/arbitrum/packages/arb-checkpointer/ckptcontext"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/hashing"
@@ -413,13 +412,8 @@ func (x *NodeBuf) UnmarshalFromCheckpoint(ctx ckptcontext.RestoreContext) (*Node
 		numStakers:   0,
 	}
 
-	valueCache, err := cmachine.NewValueCache()
-	if err != nil {
-		return nil, err
-	}
-
 	if x.MachineHash != nil {
-		node.machine = ctx.GetMachine(x.MachineHash.Unmarshal(), valueCache)
+		node.machine = ctx.GetMachine(x.MachineHash.Unmarshal())
 	}
 
 	// can't set up prev and successorHash fields yet; caller must do this later

--- a/packages/arb-validator/structures/node.go
+++ b/packages/arb-validator/structures/node.go
@@ -417,7 +417,6 @@ func (x *NodeBuf) UnmarshalFromCheckpoint(ctx ckptcontext.RestoreContext) (*Node
 	if err != nil {
 		return nil, err
 	}
-	defer cmachine.DestroyValueCache(valueCache)
 
 	if x.MachineHash != nil {
 		node.machine = ctx.GetMachine(x.MachineHash.Unmarshal(), valueCache)

--- a/packages/arb-validator/structures/node.go
+++ b/packages/arb-validator/structures/node.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"math/rand"
 
+	"github.com/offchainlabs/arbitrum/packages/arb-avm-cpp/cmachine"
 	"github.com/offchainlabs/arbitrum/packages/arb-checkpointer/ckptcontext"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/hashing"
@@ -412,8 +413,14 @@ func (x *NodeBuf) UnmarshalFromCheckpoint(ctx ckptcontext.RestoreContext) (*Node
 		numStakers:   0,
 	}
 
+	valueCache, err := cmachine.NewValueCache()
+	if err != nil {
+		return nil, err
+	}
+	defer cmachine.DestroyValueCache(valueCache)
+
 	if x.MachineHash != nil {
-		node.machine = ctx.GetMachine(x.MachineHash.Unmarshal())
+		node.machine = ctx.GetMachine(x.MachineHash.Unmarshal(), valueCache)
 	}
 
 	// can't set up prev and successorHash fields yet; caller must do this later


### PR DESCRIPTION
When restoring values and machines from database, cache items with reference count greater than 1 so that value trees shared between machines will no longer be duplicated.  The primary goal of this is to save memory, though there may be some execution speedup as well.