### PR TITLE
Aggregator redirect mode

### DIFF
--- a/packages/arb-bridge-eth/test/globalInbox.ts
+++ b/packages/arb-bridge-eth/test/globalInbox.ts
@@ -297,6 +297,13 @@ describe('GlobalInbox', () => {
     await globalInbox.sendL2Message(chainAddress, data)
   })
 
+  it('should make an empty L2 message', async () => {
+    const data = '0x'
+    const tx = await globalInbox.sendL2Message(chainAddress, data)
+    const receipt = await tx.wait()
+    console.log('Empty batch gas:', receipt.gasUsed?.toNumber())
+  })
+
   it('tradeable-exits: initial', async () => {
     await expect(
       globalInbox.getPaymentOwner(originalOwner, messageIndex),

--- a/packages/arb-evm/message/data.go
+++ b/packages/arb-evm/message/data.go
@@ -245,8 +245,8 @@ func decodeCompressedTx(r io.Reader) (CompressedTx, error) {
 
 func encodeECDSASig(v byte, r, s *big.Int) []byte {
 	data := make([]byte, 0, 65)
-	data = append(data, ethmath.U256Bytes(r)...)
-	data = append(data, ethmath.U256Bytes(s)...)
+	data = append(data, ethmath.U256Bytes(new(big.Int).Set(r))...)
+	data = append(data, ethmath.U256Bytes(new(big.Int).Set(s))...)
 	data = append(data, v)
 	return data
 }

--- a/packages/arb-tx-aggregator/aggregator/aggregator.go
+++ b/packages/arb-tx-aggregator/aggregator/aggregator.go
@@ -43,7 +43,7 @@ import (
 type Server struct {
 	Client      ethutils.EthClient
 	chain       common.Address
-	batch       *batcher.Batcher
+	batch       batcher.TransactionBatcher
 	db          *txdb.TxDB
 	maxCallTime time.Duration
 	maxCallGas  *big.Int
@@ -52,7 +52,7 @@ type Server struct {
 // NewServer returns a new instance of the Server class
 func NewServer(
 	client ethutils.EthClient,
-	batch *batcher.Batcher,
+	batch batcher.TransactionBatcher,
 	rollupAddress common.Address,
 	db *txdb.TxDB,
 ) *Server {
@@ -68,8 +68,8 @@ func NewServer(
 
 // SendTransaction takes a request signed transaction l2message from a Client
 // and puts it in a queue to be included in the next transaction batch
-func (m *Server) SendTransaction(tx *types.Transaction) (common.Hash, error) {
-	return m.batch.SendTransaction(tx)
+func (m *Server) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	return m.batch.SendTransaction(ctx, tx)
 }
 
 //FindLogs takes a set of parameters and return the list of all logs that match
@@ -325,6 +325,6 @@ func (m *Server) PendingSnapshot() *snapshot.Snapshot {
 	return pending
 }
 
-func (m *Server) PendingTransactionCount(account common.Address) *uint64 {
-	return m.batch.PendingTransactionCount(account)
+func (m *Server) PendingTransactionCount(ctx context.Context, account common.Address) *uint64 {
+	return m.batch.PendingTransactionCount(ctx, account)
 }

--- a/packages/arb-tx-aggregator/aggregator/server.go
+++ b/packages/arb-tx-aggregator/aggregator/server.go
@@ -45,7 +45,7 @@ func NewRPCServer(srv *Server) *RPCServer {
 
 // SendTransaction takes a request signed transaction l2message from a client
 // and puts it in a queue to be included in the next transaction batch
-func (m *RPCServer) SendTransaction(_ *http.Request, args *evm.SendTransactionArgs, reply *evm.SendTransactionReply) error {
+func (m *RPCServer) SendTransaction(r *http.Request, args *evm.SendTransactionArgs, reply *evm.SendTransactionReply) error {
 	encodedTx, err := hexutil.Decode(args.SignedTransaction)
 	if err != nil {
 		return errors2.Wrap(err, "error decoding signed transaction")
@@ -55,11 +55,10 @@ func (m *RPCServer) SendTransaction(_ *http.Request, args *evm.SendTransactionAr
 	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
 		return err
 	}
-	hash, err := m.srv.SendTransaction(tx)
-	if err != nil {
+	if err := m.srv.SendTransaction(r.Context(), tx); err != nil {
 		return err
 	}
-	reply.TransactionHash = hash.String()
+	reply.TransactionHash = tx.Hash().Hex()
 	return nil
 }
 

--- a/packages/arb-tx-aggregator/batcher/batcher_test.go
+++ b/packages/arb-tx-aggregator/batcher/batcher_test.go
@@ -153,8 +153,7 @@ func TestStatelessBatcher(t *testing.T) {
 	)
 
 	for _, tx := range txes {
-		_, err := batcher.SendTransaction(tx)
-		if err != nil {
+		if err := batcher.SendTransaction(context.Background(), tx); err != nil {
 			t.Fatal(err)
 		}
 		<-time.After(time.Millisecond * 20)

--- a/packages/arb-tx-aggregator/batcher/forwardingBatcher.go
+++ b/packages/arb-tx-aggregator/batcher/forwardingBatcher.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package batcher
+
+import (
+	"context"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/offchainlabs/arbitrum/packages/arb-tx-aggregator/snapshot"
+	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
+	"log"
+)
+
+type Forwarder struct {
+	client *ethclient.Client
+}
+
+func NewForwarder(client *ethclient.Client) *Forwarder {
+	return &Forwarder{client: client}
+}
+
+// Return nil if no pending transaction count is available
+func (b *Forwarder) PendingTransactionCount(ctx context.Context, account common.Address) *uint64 {
+	nonce, err := b.client.PendingNonceAt(ctx, account.ToEthAddress())
+	if err != nil {
+		log.Println("Error fetching pending nice")
+		return nil
+	}
+	return &nonce
+}
+
+func (b *Forwarder) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	return b.client.SendTransaction(ctx, tx)
+}
+
+func (b *Forwarder) PendingSnapshot() *snapshot.Snapshot {
+	return nil
+}

--- a/packages/arb-tx-aggregator/cmd/arb-tx-aggregator/arb-tx-aggregator.go
+++ b/packages/arb-tx-aggregator/cmd/arb-tx-aggregator/arb-tx-aggregator.go
@@ -50,6 +50,16 @@ func main() {
 		"maxBatchTime=NumSeconds",
 	)
 
+	forwardTxURL := fs.String("forward-url", "", "url of another aggregator to send transactions through")
+	var batcherMode rpc.BatcherMode
+	if *forwardTxURL != "" {
+		batcherMode = rpc.ForwarderBatcherMode{NodeURL: *forwardTxURL}
+	} else if *keepPendingState {
+		batcherMode = rpc.StatefulBatcherMode{}
+	} else {
+		batcherMode = rpc.StatelessBatcherMode{}
+	}
+
 	//go http.ListenAndServe("localhost:6060", nil)
 
 	err := fs.Parse(os.Args[1:])
@@ -103,7 +113,7 @@ func main() {
 		"8548",
 		rpcVars,
 		time.Duration(*maxBatchTime)*time.Second,
-		*keepPendingState,
+		batcherMode,
 	); err != nil {
 		log.Fatal(err)
 	}

--- a/packages/arb-tx-aggregator/web3/eth.go
+++ b/packages/arb-tx-aggregator/web3/eth.go
@@ -76,7 +76,7 @@ func (s *Server) GetStorageAt(ctx context.Context, address *common.Address, inde
 func (s *Server) GetTransactionCount(ctx context.Context, address *common.Address, blockNum *rpc.BlockNumber) (hexutil.Uint64, error) {
 	account := arbcommon.NewAddressFromEth(*address)
 	if blockNum == nil || *blockNum == rpc.PendingBlockNumber {
-		count := s.srv.PendingTransactionCount(account)
+		count := s.srv.PendingTransactionCount(ctx, account)
 		if count != nil {
 			return hexutil.Uint64(*count), nil
 		}
@@ -121,16 +121,16 @@ func (s *Server) GetCode(ctx context.Context, address *common.Address, blockNum 
 	return code, nil
 }
 
-func (s *Server) SendRawTransaction(data hexutil.Bytes) (hexutil.Bytes, error) {
+func (s *Server) SendRawTransaction(ctx context.Context, data hexutil.Bytes) (hexutil.Bytes, error) {
 	tx := new(types.Transaction)
 	if err := rlp.DecodeBytes(data, tx); err != nil {
 		return nil, err
 	}
-	txHash, err := s.srv.SendTransaction(tx)
+	err := s.srv.SendTransaction(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
-	return txHash[:], nil
+	return tx.Hash().Bytes(), nil
 }
 
 func (s *Server) Call(ctx context.Context, callArgs CallTxArgs, blockNum *rpc.BlockNumber) (hexutil.Bytes, error) {

--- a/packages/arb-validator-core/ethbridge/chain.go
+++ b/packages/arb-validator-core/ethbridge/chain.go
@@ -20,6 +20,7 @@ import (
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/arbbridge"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
+	"log"
 
 	ethereum "github.com/ethereum/go-ethereum"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -28,7 +29,6 @@ import (
 
 	"context"
 	"fmt"
-	"log"
 	"math/big"
 	"time"
 )
@@ -36,6 +36,9 @@ import (
 type ArbAddresses struct {
 	ArbFactory string `json:"ArbFactory"`
 }
+
+var parityErr = "Block information is incomplete while ancient block sync is still in progress, before it's finished we can't determine the existence of requested item."
+var parityErr2 = "missing required field 'transactionHash' for Log"
 
 func (a ArbAddresses) ArbFactoryAddress() common.Address {
 	return common.NewAddressFromEth(ethcommon.HexToAddress(a.ArbFactory))
@@ -76,10 +79,15 @@ func WaitForReceiptWithResultsSimple(ctx context.Context, client ethutils.Receip
 				continue
 			}
 			if err != nil {
-				if err.Error() == ethereum.NotFound.Error() {
+				if err.Error() == ethereum.NotFound.Error() || err.Error() == parityErr {
 					continue
 				}
-				log.Println("ERROR getting receipt", err)
+
+				if err.Error() == parityErr2 {
+					log.Printf("WARNING: issue getting receipt for %v: %v", txHash.Hex(), err)
+					continue
+				}
+				log.Printf("ERROR getting receipt for %v: %v", txHash.Hex(), err)
 				return nil, err
 			}
 			return receipt, nil

--- a/packages/arb-validator.Dockerfile
+++ b/packages/arb-validator.Dockerfile
@@ -56,6 +56,8 @@ COPY --chown=user --from=arb-validator-builder /home/user/go/bin /home/user/go/b
 # Build cache
 COPY --chown=user --from=arb-validator-builder /home/user/.cache/go-build /build
 COPY --from=arb-avm-cpp /home/user/build /cpp-build
+COPY --from=arb-avm-cpp /home/user/build /cpp-build
+COPY --chown=user arbos.mexe /home/user
 
 ENTRYPOINT ["/home/user/go/bin/arb-validator"]
 EXPOSE 1235 1236

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -144,6 +144,24 @@ func launchAggregator(client ethutils.EthClient, auth *bind.TransactOpts, rollup
 			"9547",
 			utils2.RPCFlags{},
 			time.Second,
+			rpc.ForwarderBatcherMode{NodeURL: "http://localhost:9548"},
+		); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	go func() {
+		if err := rpc.LaunchAggregator(
+			context.Background(),
+			client,
+			rollupAddress,
+			contract,
+			db+"/aggregator2",
+			"2236",
+			"9548",
+			"9549",
+			utils2.RPCFlags{},
+			time.Second,
 			rpc.StatelessBatcherMode{Auth: auth},
 		); err != nil {
 			log.Fatal(err)
@@ -305,9 +323,9 @@ func TestFib(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := setupValidators(rollupAddress, l1Client, pks[3:5]); err != nil {
-		t.Fatalf("Validator setup error %v", err)
-	}
+	//if err := setupValidators(rollupAddress, l1Client, pks[3:5]); err != nil {
+	//	t.Fatalf("Validator setup error %v", err)
+	//}
 
 	if err := launchAggregator(
 		l1Client,

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -136,7 +136,6 @@ func launchAggregator(client ethutils.EthClient, auth *bind.TransactOpts, rollup
 		if err := rpc.LaunchAggregator(
 			context.Background(),
 			client,
-			auth,
 			rollupAddress,
 			contract,
 			db+"/aggregator",
@@ -145,7 +144,7 @@ func launchAggregator(client ethutils.EthClient, auth *bind.TransactOpts, rollup
 			"9547",
 			utils2.RPCFlags{},
 			time.Second,
-			rpc.StatelessBatcherMode{},
+			rpc.StatelessBatcherMode{Auth: auth},
 		); err != nil {
 			log.Fatal(err)
 		}

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -424,35 +424,34 @@ func TestFib(t *testing.T) {
 		)
 	}
 
-	t.Run("TestEvent", func(t *testing.T) {
-		eventChan := make(chan interface{}, 2)
-		startFibTestEventListener(t, session.Contract, eventChan, time.Second*20)
-		testEventRcvd := false
+	t.Log("testing events and log fetching")
 
-		fibsize := 15
-		time.Sleep(5 * time.Second)
-		_, err := session.GenerateFib(big.NewInt(int64(fibsize)))
-		if err != nil {
-			t.Errorf("GenerateFib error %v", err)
-			return
-		}
+	eventChan := make(chan interface{}, 2)
+	startFibTestEventListener(t, session.Contract, eventChan, time.Second*20)
+	testEventRcvd := false
 
-	Loop:
-		for ev := range eventChan {
-			switch event := ev.(type) {
-			case *arbostestcontracts.FibonacciTestEvent:
-				testEventRcvd = true
-				break Loop
-			case ListenerError:
-				t.Errorf("errorEvent %v %v", event.ListenerName, event.Err)
-				break Loop
-			default:
-				t.Error("eventLoop: unknown event type", ev)
-				break Loop
-			}
+	time.Sleep(5 * time.Second)
+	_, err = session.GenerateFib(big.NewInt(int64(fibsize)))
+	if err != nil {
+		t.Errorf("GenerateFib error %v", err)
+		return
+	}
+
+Loop:
+	for ev := range eventChan {
+		switch event := ev.(type) {
+		case *arbostestcontracts.FibonacciTestEvent:
+			testEventRcvd = true
+			break Loop
+		case ListenerError:
+			t.Errorf("errorEvent %v %v", event.ListenerName, event.Err)
+			break Loop
+		default:
+			t.Error("eventLoop: unknown event type", ev)
+			break Loop
 		}
-		if testEventRcvd != true {
-			t.Error("eventLoop: FibonacciTestEvent not received")
-		}
-	})
+	}
+	if testEventRcvd != true {
+		t.Error("eventLoop: FibonacciTestEvent not received")
+	}
 }

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -323,9 +323,9 @@ func TestFib(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//if err := setupValidators(rollupAddress, l1Client, pks[3:5]); err != nil {
-	//	t.Fatalf("Validator setup error %v", err)
-	//}
+	if err := setupValidators(rollupAddress, l1Client, pks[3:5]); err != nil {
+		t.Fatalf("Validator setup error %v", err)
+	}
 
 	if err := launchAggregator(
 		l1Client,

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -195,6 +195,17 @@ func launchAggregator(client ethutils.EthClient, auth *bind.TransactOpts, rollup
 			if err := conn.Close(); err != nil {
 				return err
 			}
+			conn, err = net.DialTimeout(
+				"tcp",
+				net.JoinHostPort("127.0.0.1", "9548"),
+				time.Second,
+			)
+			if err != nil || conn == nil {
+				break
+			}
+			if err := conn.Close(); err != nil {
+				return err
+			}
 			// Wait for the validator to catch up to head
 			time.Sleep(time.Second * 2)
 			return nil

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -145,7 +145,7 @@ func launchAggregator(client ethutils.EthClient, auth *bind.TransactOpts, rollup
 			"9547",
 			utils2.RPCFlags{},
 			time.Second,
-			true,
+			rpc.StatelessBatcherMode{},
 		); err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
This PR adds a `--forward-url=[URL]` parameter to the aggregator which enables it to forward transactions to another aggregator rather that submitting them directly to the chain

If this parameter is used, the aggregator doesn't need to be funded or have a wallet