### PR TITLE
Ignore duplicate tx receipts

### DIFF
--- a/packages/arb-tx-aggregator/txdb/txdb.go
+++ b/packages/arb-tx-aggregator/txdb/txdb.go
@@ -318,6 +318,14 @@ func saveAssertion(
 		}
 
 		for i, txRes := range txResults {
+			if txRes.ResultCode == evm.BadSequenceCode {
+				// If this log failed with incorrect sequence number, only save the request if it hasn't been saved before
+				_, err := as.GetPossibleRequestInfo(txRes.IncomingRequest.MessageID)
+				if err == nil {
+					continue
+				}
+			}
+
 			if err := as.SaveRequest(txRes.IncomingRequest.MessageID, startLog+uint64(i)); err != nil {
 				return err
 			}


### PR DESCRIPTION
It's possible for the same transaction to be submitted to the arbitrum chain multiple times. Currently when this occurs the aggregator responds to requests for the receipt associated with the given request id by returning the most recently output log matching that request. In fact, the aggregator should return the version of the request that had a correct sequence number if one exists.

This PR adjusts the behavior of the aggregator so only save a request that had an invalid sequence number, if no request matching that ID already exists.