### PR TITLE
Rpc fixes

### DIFF
--- a/packages/arb-tx-aggregator/web3/eth.go
+++ b/packages/arb-tx-aggregator/web3/eth.go
@@ -347,6 +347,10 @@ func (s *Server) getTransactionByBlockAndIndex(height uint64, index hexutil.Uint
 }
 
 func (s *Server) getBlock(header *types.Header, blockHash common.Hash, includeTxData bool) (*GetBlockResult, error) {
+	// If the db hasn't yet processed the requested block, don't return a header
+	if header.Number.Cmp(new(big.Int).SetUint64(s.srv.GetBlockCount())) > 0 {
+		return nil, nil
+	}
 	block, err := s.srv.BlockInfo(header.Number.Uint64())
 	if err != nil {
 		return nil, err

--- a/packages/arb-tx-aggregator/web3/eth.go
+++ b/packages/arb-tx-aggregator/web3/eth.go
@@ -247,6 +247,11 @@ func (s *Server) GetTransactionReceipt(txHash hexutil.Bytes) (*GetTransactionRec
 
 	receipt := result.ToEthReceipt(blockInfo.Hash)
 
+	tx, err := aggregator.GetTransaction(result.IncomingRequest)
+	if err != nil {
+		return nil, err
+	}
+
 	var contractAddress *common.Address
 	emptyAddress := common.Address{}
 	if receipt.ContractAddress != emptyAddress {
@@ -254,18 +259,21 @@ func (s *Server) GetTransactionReceipt(txHash hexutil.Bytes) (*GetTransactionRec
 	}
 
 	return &GetTransactionReceiptResult{
-		Status:            hexutil.Uint64(receipt.Status),
-		CumulativeGasUsed: hexutil.Uint64(receipt.CumulativeGasUsed),
-		Bloom:             receipt.Bloom.Bytes(),
-		Logs:              receipt.Logs,
-		TxHash:            receipt.TxHash,
-		ContractAddress:   contractAddress,
-		GasUsed:           hexutil.Uint64(receipt.GasUsed),
+		TransactionHash:   receipt.TxHash,
+		TransactionIndex:  hexutil.Uint64(receipt.TransactionIndex),
 		BlockHash:         receipt.BlockHash,
 		BlockNumber:       (*hexutil.Big)(receipt.BlockNumber),
-		TransactionIndex:  hexutil.Uint64(receipt.TransactionIndex),
-		ReturnCode:        hexutil.Uint64(result.ResultCode),
-		ReturnData:        result.ReturnData,
+		From:              result.IncomingRequest.Sender.ToEthAddress(),
+		To:                tx.Tx.To(),
+		CumulativeGasUsed: hexutil.Uint64(receipt.CumulativeGasUsed),
+		GasUsed:           hexutil.Uint64(receipt.GasUsed),
+		ContractAddress:   contractAddress,
+		Logs:              receipt.Logs,
+		LogsBloom:         receipt.Bloom.Bytes(),
+		Status:            hexutil.Uint64(receipt.Status),
+
+		ReturnCode: hexutil.Uint64(result.ResultCode),
+		ReturnData: result.ReturnData,
 	}, nil
 }
 

--- a/packages/arb-tx-aggregator/web3/interface.go
+++ b/packages/arb-tx-aggregator/web3/interface.go
@@ -40,20 +40,18 @@ type CallTxArgs struct {
 
 // Receipt represents the results of a transaction.
 type GetTransactionReceiptResult struct {
-	Status            hexutil.Uint64 `json:"status"`
-	CumulativeGasUsed hexutil.Uint64 `json:"cumulativeGasUsed"`
-	Bloom             hexutil.Bytes  `json:"logsBloom"`
-	Logs              []*types.Log   `json:"logs"`
-	// They are stored in the chain database.
-	TxHash          common.Hash     `json:"transactionHash"`
-	ContractAddress *common.Address `json:"contractAddress"`
-	GasUsed         hexutil.Uint64  `json:"gasUsed"`
-
-	// Inclusion information: These fields provide information about the inclusion of the
-	// transaction corresponding to this receipt.
-	BlockHash        common.Hash    `json:"blockHash"`
-	BlockNumber      *hexutil.Big   `json:"blockNumber"`
-	TransactionIndex hexutil.Uint64 `json:"transactionIndex"`
+	TransactionHash   common.Hash     `json:"transactionHash"`
+	TransactionIndex  hexutil.Uint64  `json:"transactionIndex"`
+	BlockHash         common.Hash     `json:"blockHash"`
+	BlockNumber       *hexutil.Big    `json:"blockNumber"`
+	From              common.Address  `json:"from"`
+	To                *common.Address `json:"to"`
+	CumulativeGasUsed hexutil.Uint64  `json:"cumulativeGasUsed"`
+	GasUsed           hexutil.Uint64  `json:"gasUsed"`
+	ContractAddress   *common.Address `json:"contractAddress"`
+	Logs              []*types.Log    `json:"logs"`
+	LogsBloom         hexutil.Bytes   `json:"logsBloom"`
+	Status            hexutil.Uint64  `json:"status"`
 
 	// Arbitrum Specific Fields
 	ReturnCode hexutil.Uint64 `json:"returnCode"`


### PR DESCRIPTION
- Add `from` and `to` field to transaction receipt
- Make `getBlock` RPC calls return nil if L2 block has not been processed yet