### PR TITLE
Only use a single context.Background()

### DIFF
--- a/packages/arb-tx-aggregator/cmd/arb-tx-aggregator/arb-tx-aggregator.go
+++ b/packages/arb-tx-aggregator/cmd/arb-tx-aggregator/arb-tx-aggregator.go
@@ -39,6 +39,7 @@ func main() {
 	// Enable line numbers in logging
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
+	ctx := context.Background()
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	walletArgs := utils.AddWalletFlags(fs)
 	rpcVars := utils2.AddRPCFlags(fs)
@@ -89,7 +90,7 @@ func main() {
 		log.Println("Aggregator submitting batches from address", auth.From)
 
 		if err := arbbridge.WaitForBalance(
-			context.Background(),
+			ctx,
 			ethbridge.NewEthClient(ethclint),
 			common.Address{},
 			common.NewAddressFromEth(auth.From),
@@ -108,7 +109,7 @@ func main() {
 	dbPath := filepath.Join(rollupArgs.ValidatorFolder, "checkpoint_db")
 
 	if err := rpc.LaunchAggregator(
-		context.Background(),
+		ctx,
 		ethclint,
 		rollupArgs.Address,
 		contractFile,

--- a/packages/arb-tx-aggregator/rpc/launch.go
+++ b/packages/arb-tx-aggregator/rpc/launch.go
@@ -76,7 +76,7 @@ func LaunchAggregator(
 	if err != nil {
 		return err
 	}
-	inboxAddress, err := rollupContract.InboxAddress(context.Background())
+	inboxAddress, err := rollupContract.InboxAddress(ctx)
 	if err != nil {
 		return err
 	}

--- a/packages/arb-validator/cmd/arb-validator/arb-validator.go
+++ b/packages/arb-validator/cmd/arb-validator/arb-validator.go
@@ -64,6 +64,7 @@ func main() {
 }
 
 func createRollupChain() error {
+	ctx := context.Background()
 	createCmd := flag.NewFlagSet("validate", flag.ExitOnError)
 	walletVars := utils.AddWalletFlags(createCmd)
 	tokenAddressString := createCmd.String("staketoken", "", "staketoken=TokenAddress")
@@ -102,7 +103,7 @@ func createRollupChain() error {
 	// Rollup creation
 	client := ethbridge.NewEthAuthClient(ethclint, auth)
 
-	if err := arbbridge.WaitForBalance(context.Background(), client, common.Address{}, common.NewAddressFromEth(auth.From)); err != nil {
+	if err := arbbridge.WaitForBalance(ctx, client, common.Address{}, common.NewAddressFromEth(auth.From)); err != nil {
 		return err
 	}
 
@@ -126,7 +127,7 @@ func createRollupChain() error {
 	}
 
 	address, _, err := factory.CreateRollup(
-		context.Background(),
+		ctx,
 		mach.Hash(),
 		params,
 		common.Address{},

--- a/packages/arb-validator/cmdhelper/cmdhelper.go
+++ b/packages/arb-validator/cmdhelper/cmdhelper.go
@@ -46,6 +46,7 @@ func ValidateRollupChain(
 		contractFile string, dbPath string,
 	) (*rollupmanager.Manager, error),
 ) error {
+	ctx := context.Background()
 	// Check number of args
 
 	validateCmd := flag.NewFlagSet("validate", flag.ExitOnError)
@@ -94,17 +95,17 @@ func ValidateRollupChain(
 		return err
 	}
 
-	params, err := rollup.GetParams(context.Background())
+	params, err := rollup.GetParams(ctx)
 	if err != nil {
 		return err
 	}
 
-	if err := arbbridge.WaitForBalance(context.Background(), client, params.StakeToken, common.NewAddressFromEth(auth.From)); err != nil {
+	if err := arbbridge.WaitForBalance(ctx, client, params.StakeToken, common.NewAddressFromEth(auth.From)); err != nil {
 		return err
 	}
 
 	validatorListener := chainlistener.NewValidatorChainListener(
-		context.Background(),
+		ctx,
 		rollupArgs.Address,
 		rollup,
 	)
@@ -126,8 +127,8 @@ func ValidateRollupChain(
 	if err != nil {
 		return err
 	}
-	manager.AddListener(&chainlistener.AnnouncerListener{})
-	manager.AddListener(validatorListener)
+	manager.AddListener(ctx, &chainlistener.AnnouncerListener{})
+	manager.AddListener(ctx, validatorListener)
 
 	wait := make(chan bool)
 	<-wait
@@ -145,6 +146,7 @@ func ObserveRollupChain(
 		contractFile string, dbPath string,
 	) (*rollupmanager.Manager, error),
 ) error {
+	ctx := context.Background()
 	// Check number of args
 	validateCmd := flag.NewFlagSet("observe", flag.ExitOnError)
 	quietFlag := validateCmd.Bool(
@@ -188,7 +190,7 @@ func ObserveRollupChain(
 		return err
 	}
 	if !*quietFlag {
-		manager.AddListener(&chainlistener.AnnouncerListener{})
+		manager.AddListener(ctx, &chainlistener.AnnouncerListener{})
 	}
 
 	wait := make(chan bool)

--- a/packages/arb-validator/rollupmanager/manager.go
+++ b/packages/arb-validator/rollupmanager/manager.go
@@ -324,12 +324,12 @@ func CreateManagerAdvanced(
 	return man, nil
 }
 
-func (man *Manager) AddListener(listener chainlistener.ChainListener) {
+func (man *Manager) AddListener(ctx context.Context, listener chainlistener.ChainListener) {
 	man.Lock()
 	defer man.Unlock()
 	man.listeners = append(man.listeners, listener)
 	if man.activeChain != nil {
-		man.activeChain.AddListener(context.Background(), listener)
+		man.activeChain.AddListener(ctx, listener)
 	}
 }
 

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -111,7 +111,7 @@ func setupValidators(
 			return err
 		}
 
-		manager.AddListener(&chainlistener.AnnouncerListener{Prefix: "validator " + client.Address().String() + ": "})
+		manager.AddListener(ctx, &chainlistener.AnnouncerListener{Prefix: "validator " + client.Address().String() + ": "})
 
 		validatorListener := chainlistener.NewValidatorChainListener(
 			context.Background(),
@@ -122,7 +122,7 @@ func setupValidators(
 		if err != nil {
 			return err
 		}
-		manager.AddListener(validatorListener)
+		manager.AddListener(ctx, validatorListener)
 		managers = append(managers, manager)
 	}
 


### PR DESCRIPTION
If multiple context.Background() objects are used there is a chance that transactions with multiple nonces will be created.  To prevent this from happening, ensure only a single context.Background() is passed throughout the program.