### PR TITLE
Update block header scheme

### DIFF
--- a/packages/arb-avm-cpp/cavm/caggregator.cpp
+++ b/packages/arb-avm-cpp/cavm/caggregator.cpp
@@ -137,12 +137,12 @@ int aggregatorReorg(CAggregatorStore* agg,
 // request_id is 32 bytes long
 Uint64Result aggregatorGetPossibleRequestInfo(const CAggregatorStore* agg,
                                               const void* request_id) {
-    try {
-        auto index =
-            static_cast<const AggregatorStore*>(agg)->getPossibleRequestInfo(
-                receiveUint256(request_id));
-        return {index, true};
-    } catch (const std::exception&) {
+    auto index =
+        static_cast<const AggregatorStore*>(agg)->getPossibleRequestInfo(
+            receiveUint256(request_id));
+    if (index) {
+        return {*index, true};
+    } else {
         return {0, false};
     }
 }
@@ -153,6 +153,30 @@ int aggregatorSaveRequest(CAggregatorStore* agg,
     try {
         static_cast<AggregatorStore*>(agg)->saveRequest(
             receiveUint256(request_id), log_index);
+        return 1;
+    } catch (const std::exception&) {
+        return 0;
+    }
+}
+
+// block_hash is 32 bytes long
+Uint64Result aggregatorGetPossibleBlock(const CAggregatorStore* agg,
+                                        const void* block_hash) {
+    auto index = static_cast<const AggregatorStore*>(agg)->getPossibleBlock(
+        receiveUint256(block_hash));
+    if (index) {
+        return {*index, true};
+    } else {
+        return {0, false};
+    }
+}
+
+int aggregatorSaveBlockHash(CAggregatorStore* agg,
+                            const void* block_hash,
+                            uint64_t block_height) {
+    try {
+        static_cast<AggregatorStore*>(agg)->saveBlockHash(
+            receiveUint256(block_hash), block_height);
         return 1;
     } catch (const std::exception&) {
         return 0;

--- a/packages/arb-avm-cpp/cavm/caggregator.cpp
+++ b/packages/arb-avm-cpp/cavm/caggregator.cpp
@@ -140,7 +140,7 @@ Uint64Result aggregatorGetPossibleRequestInfo(const CAggregatorStore* agg,
     auto index =
         static_cast<const AggregatorStore*>(agg)->getPossibleRequestInfo(
             receiveUint256(request_id));
-    if (index) {
+    if (index != nullptr) {
         return {*index, true};
     } else {
         return {0, false};

--- a/packages/arb-avm-cpp/cavm/caggregator.cpp
+++ b/packages/arb-avm-cpp/cavm/caggregator.cpp
@@ -140,7 +140,7 @@ Uint64Result aggregatorGetPossibleRequestInfo(const CAggregatorStore* agg,
     auto index =
         static_cast<const AggregatorStore*>(agg)->getPossibleRequestInfo(
             receiveUint256(request_id));
-    if (index != nullptr) {
+    if (index) {
         return {*index, true};
     } else {
         return {0, false};

--- a/packages/arb-avm-cpp/cavm/caggregator.h
+++ b/packages/arb-avm-cpp/cavm/caggregator.h
@@ -80,6 +80,13 @@ int aggregatorSaveRequest(CAggregatorStore* agg,
                           const void* request_id,
                           uint64_t log_index);
 
+// block_hash is 32 bytes long
+Uint64Result aggregatorGetPossibleBlock(const CAggregatorStore* agg,
+                                        const void* block_hash);
+int aggregatorSaveBlockHash(CAggregatorStore* agg,
+                            const void* block_hash,
+                            uint64_t block_height);
+
 #ifdef __cplusplus
 }
 #endif

--- a/packages/arb-avm-cpp/cmachine/aggregator.go
+++ b/packages/arb-avm-cpp/cmachine/aggregator.go
@@ -136,7 +136,7 @@ func (as *AggregatorStore) LatestBlock() (*common.BlockId, error) {
 	if result.found == 0 {
 		return nil, errors.New("failed to load block count")
 	}
-	// Last value returned is not an error type
+
 	header, _, err := parseBlockData(toByteSlice(result.data))
 	if err != nil {
 		return nil, err

--- a/packages/arb-avm-cpp/cmachine/aggregator.go
+++ b/packages/arb-avm-cpp/cmachine/aggregator.go
@@ -180,15 +180,16 @@ func (as *AggregatorStore) Reorg(height uint64, messageCount uint64, logCount ui
 	return nil
 }
 
-func (as *AggregatorStore) GetPossibleRequestInfo(requestId common.Hash) (uint64, error) {
+func (as *AggregatorStore) GetPossibleRequestInfo(requestId common.Hash) *uint64 {
 	cHash := hashToData(requestId)
 	defer C.free(cHash)
 
 	result := C.aggregatorGetPossibleRequestInfo(as.c, cHash)
 	if result.found == 0 {
-		return 0, errors.New("failed to get request")
+		return nil
 	}
-	return uint64(result.value), nil
+	index := uint64(result.value)
+	return &index
 }
 
 func (as *AggregatorStore) SaveRequest(requestId common.Hash, logIndex uint64) error {
@@ -196,6 +197,28 @@ func (as *AggregatorStore) SaveRequest(requestId common.Hash, logIndex uint64) e
 	defer C.free(cHash)
 
 	if C.aggregatorSaveRequest(as.c, cHash, C.uint64_t(logIndex)) == 0 {
+		return errors.New("failed to save request")
+	}
+	return nil
+}
+
+func (as *AggregatorStore) GetPossibleBlock(blockHash common.Hash) *uint64 {
+	cHash := hashToData(blockHash)
+	defer C.free(cHash)
+
+	result := C.aggregatorGetPossibleBlock(as.c, cHash)
+	if result.found == 0 {
+		return nil
+	}
+	index := uint64(result.value)
+	return &index
+}
+
+func (as *AggregatorStore) SaveBlockHash(blockHash common.Hash, blockHeight uint64) error {
+	cHash := hashToData(blockHash)
+	defer C.free(cHash)
+
+	if C.aggregatorSaveBlockHash(as.c, cHash, C.uint64_t(blockHeight)) == 0 {
 		return errors.New("failed to save request")
 	}
 	return nil

--- a/packages/arb-avm-cpp/cmachine/aggregator.go
+++ b/packages/arb-avm-cpp/cmachine/aggregator.go
@@ -115,13 +115,20 @@ func (as *AggregatorStore) GetMessage(index uint64) (value.Value, error) {
 	return value.UnmarshalValue(bytes.NewBuffer(logBytes))
 }
 
-func parseBlockData(data []byte) (uint64, common.Hash, types.Bloom) {
-	logIndex := binary.BigEndian.Uint64(data)
-	data = data[8:]
-	var hash common.Hash
-	copy(hash[:], data[:])
-	data = data[32:]
-	return logIndex, hash, types.BytesToBloom(data[:])
+func parseBlockData(data []byte) (*types.Header, *uint64, error) {
+	blockType := data[0]
+	data = data[1:]
+	var logIndex *uint64
+	if blockType == 1 {
+		index := binary.BigEndian.Uint64(data)
+		logIndex = &index
+		data = data[8:]
+	}
+	header := &types.Header{}
+	if err := header.UnmarshalJSON(data); err != nil {
+		return nil, nil, err
+	}
+	return header, logIndex, nil
 }
 
 func (as *AggregatorStore) LatestBlock() (*common.BlockId, error) {
@@ -130,22 +137,48 @@ func (as *AggregatorStore) LatestBlock() (*common.BlockId, error) {
 		return nil, errors.New("failed to load block count")
 	}
 	// Last value returned is not an error type
-	_, hash, _ := parseBlockData(toByteSlice(result.data))
+	header, _, err := parseBlockData(toByteSlice(result.data))
+	if err != nil {
+		return nil, err
+	}
 	return &common.BlockId{
 		Height:     common.NewTimeBlocks(new(big.Int).SetUint64(uint64(result.height))),
-		HeaderHash: hash,
+		HeaderHash: common.NewHashFromEth(header.Hash()),
 	}, nil
 }
 
-func (as *AggregatorStore) SaveBlock(id *common.BlockId, logIndex uint64, logBloom types.Bloom) error {
-	blockData := make([]byte, 8)
-	binary.BigEndian.PutUint64(blockData[:], logIndex)
-	blockData = append(blockData, id.HeaderHash.Bytes()...)
-	blockData = append(blockData, logBloom.Bytes()...)
+func (as *AggregatorStore) SaveBlock(header *types.Header, logIndex uint64) error {
+	blockData := []byte{1}
+
+	logIndexData := make([]byte, 8)
+	binary.BigEndian.PutUint64(logIndexData[:], logIndex)
+	blockData = append(blockData, logIndexData...)
+
+	headerJSON, err := header.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	blockData = append(blockData, headerJSON...)
 	cBlockData := C.CBytes(blockData)
 	defer C.free(cBlockData)
 
-	if C.aggregatorSaveBlock(as.c, C.uint64_t(id.Height.AsInt().Uint64()), cBlockData, C.int(len(blockData))) == 0 {
+	if C.aggregatorSaveBlock(as.c, C.uint64_t(header.Number.Uint64()), cBlockData, C.int(len(blockData))) == 0 {
+		return errors.New("failed to save block")
+	}
+	return nil
+}
+
+func (as *AggregatorStore) SaveEmptyBlock(header *types.Header) error {
+	blockData := []byte{0}
+	headerJSON, err := header.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	blockData = append(blockData, headerJSON...)
+	cBlockData := C.CBytes(blockData)
+	defer C.free(cBlockData)
+
+	if C.aggregatorSaveBlock(as.c, C.uint64_t(header.Number.Uint64()), cBlockData, C.int(len(blockData))) == 0 {
 		return errors.New("failed to save block")
 	}
 	return nil
@@ -156,16 +189,21 @@ func (as *AggregatorStore) GetBlock(height uint64) (*machine.BlockInfo, error) {
 	if blockData.found == 0 {
 		return nil, nil
 	}
-	logIndex, hash, bloom := parseBlockData(toByteSlice(blockData.data))
-	avmLog, err := as.GetLog(logIndex)
+	header, logIndex, err := parseBlockData(toByteSlice(blockData.data))
 	if err != nil {
 		return nil, err
 	}
-	return &machine.BlockInfo{
-		Hash:     hash,
-		BlockLog: avmLog,
-		Bloom:    bloom,
-	}, nil
+	info := &machine.BlockInfo{
+		Header: header,
+	}
+	if logIndex != nil {
+		avmLog, err := as.GetLog(*logIndex)
+		if err != nil {
+			return nil, err
+		}
+		info.BlockLog = avmLog
+	}
+	return info, nil
 }
 
 func (as *AggregatorStore) Reorg(height uint64, messageCount uint64, logCount uint64) error {

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/aggregator.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/aggregator.hpp
@@ -21,6 +21,8 @@
 
 #include <rocksdb/utilities/transaction.h>
 
+#include <nonstd/optional.hpp>
+
 class DataStorage;
 
 struct BlockData {
@@ -52,8 +54,13 @@ class AggregatorStore {
     void saveBlock(uint64_t height, const std::vector<char>& data);
     std::vector<char> getBlock(uint64_t height) const;
 
-    uint64_t getPossibleRequestInfo(const uint256_t& request_id) const;
+    nonstd::optional<uint64_t> getPossibleRequestInfo(
+        const uint256_t& request_id) const;
     void saveRequest(const uint256_t& request_id, uint64_t log_index);
+
+    nonstd::optional<uint64_t> getPossibleBlock(
+        const uint256_t& block_hash) const;
+    void saveBlockHash(const uint256_t& block_hash, uint64_t block_height);
 
     void reorg(uint64_t block_height,
                uint64_t message_count,

--- a/packages/arb-avm-cpp/tests/aggregator.cpp
+++ b/packages/arb-avm-cpp/tests/aggregator.cpp
@@ -48,10 +48,12 @@ TEST_CASE("Aggregator tests") {
     }
 
     SECTION("requests") {
-        CHECK_THROWS(store->getPossibleRequestInfo(10));
+        REQUIRE(!store->getPossibleRequestInfo(10).has_value());
         store->saveRequest(10, 5);
-        REQUIRE(store->getPossibleRequestInfo(10) == 5);
-        CHECK_THROWS(store->getPossibleRequestInfo(8));
+        auto requestIndex = store->getPossibleRequestInfo(10);
+        REQUIRE(requestIndex.has_value());
+        REQUIRE(*requestIndex == 5);
+        REQUIRE(!store->getPossibleRequestInfo(8).has_value());
     }
 
     SECTION("blocks") {

--- a/packages/arb-evm/evm/evm.pb.go
+++ b/packages/arb-evm/evm/evm.pb.go
@@ -1496,7 +1496,7 @@ var file_evm_proto_depIdxs = []int32{
 	4,  // 1: evm.FindLogsArgs.topicGroups:type_name -> evm.TopicGroup
 	1,  // 2: evm.FindLogsReply.logs:type_name -> evm.FullLogBuf
 	5,  // 3: evm.RollupValidator.GetBlockCount:input_type -> evm.BlockCountArgs
-	17, // 4: evm.RollupValidator.BlockInfo:input_type -> evm.BlockInfoArgs
+	17, // 4: evm.RollupValidator.BlockInfoByNumber:input_type -> evm.BlockInfoArgs
 	19, // 5: evm.RollupValidator.BlockHash:input_type -> evm.BlockHashArgs
 	9,  // 6: evm.RollupValidator.GetOutputMessage:input_type -> evm.GetOutputMessageArgs
 	11, // 7: evm.RollupValidator.GetRequestResult:input_type -> evm.GetRequestResultArgs
@@ -1505,7 +1505,7 @@ var file_evm_proto_depIdxs = []int32{
 	13, // 10: evm.RollupValidator.GetChainAddress:input_type -> evm.GetChainAddressArgs
 	21, // 11: evm.RollupValidator.SendTransaction:input_type -> evm.SendTransactionArgs
 	6,  // 12: evm.RollupValidator.GetBlockCount:output_type -> evm.BlockCountReply
-	18, // 13: evm.RollupValidator.BlockInfo:output_type -> evm.BlockInfoReply
+	18, // 13: evm.RollupValidator.BlockInfoByNumber:output_type -> evm.BlockInfoReply
 	20, // 14: evm.RollupValidator.BlockHash:output_type -> evm.BlockHashReply
 	10, // 15: evm.RollupValidator.GetOutputMessage:output_type -> evm.GetOutputMessageReply
 	12, // 16: evm.RollupValidator.GetRequestResult:output_type -> evm.GetRequestResultReply

--- a/packages/arb-evm/evm/incoming.go
+++ b/packages/arb-evm/evm/incoming.go
@@ -1,0 +1,45 @@
+package evm
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/offchainlabs/arbitrum/packages/arb-evm/message"
+	"github.com/offchainlabs/arbitrum/packages/arb-util/inbox"
+)
+
+type ProcessedTx struct {
+	Tx        *types.Transaction
+	Kind      inbox.Type
+	L2Subtype *message.L2SubType
+}
+
+func GetTransaction(msg IncomingRequest) (*ProcessedTx, error) {
+	// Special handling for buddy deploy
+	if msg.Kind == message.L2BuddyDeploy {
+		buddyDeployMessage := message.NewBuddyDeploymentFromData(msg.Data)
+		return &ProcessedTx{
+			Tx:   buddyDeployMessage.AsEthTx(),
+			Kind: msg.Kind,
+		}, nil
+	}
+
+	if msg.Kind != message.L2Type {
+		return nil, errors.New("result is not a transaction")
+	}
+	l2msg, err := message.L2Message{Data: msg.Data}.AbstractMessage()
+	if err != nil {
+		return nil, err
+	}
+	ethMsg, ok := l2msg.(message.EthConvertable)
+	if !ok {
+		return nil, errors.New("message not convertible to receipt")
+	}
+	l2Type := l2msg.L2Type()
+	return &ProcessedTx{
+		Tx:        ethMsg.AsEthTx(),
+		Kind:      msg.Kind,
+		L2Subtype: &l2Type,
+	}, nil
+}

--- a/packages/arb-evm/evm/result.go
+++ b/packages/arb-evm/evm/result.go
@@ -581,7 +581,7 @@ func NewTxResultFromValue(val value.Value) (*TxResult, error) {
 	}
 	txRes, ok := res.(*TxResult)
 	if !ok {
-		return nil, errors.New("unexpected avm result type")
+		return nil, errors.New("got block result but expected transaction")
 	}
 	return txRes, nil
 }
@@ -593,7 +593,7 @@ func NewBlockResultFromValue(val value.Value) (*BlockInfo, error) {
 	}
 	txRes, ok := res.(*BlockInfo)
 	if !ok {
-		return nil, errors.New("unexpected avm result type")
+		return nil, errors.New("got transaction result but expected block")
 	}
 	return txRes, nil
 }

--- a/packages/arb-tx-aggregator/aggregator/aggregator.go
+++ b/packages/arb-tx-aggregator/aggregator/aggregator.go
@@ -225,41 +225,6 @@ func (m *Server) GetTxInBlockAtIndexResults(res *evm.BlockInfo, index uint64) (*
 	return evm.NewTxResultFromValue(avmLog)
 }
 
-type ProcessedTx struct {
-	Tx        *types.Transaction
-	Kind      inbox.Type
-	L2Subtype *message.L2SubType
-}
-
-func GetTransaction(msg evm.IncomingRequest) (*ProcessedTx, error) {
-	// Special handling for buddy deploy
-	if msg.Kind == message.L2BuddyDeploy {
-		buddyDeployMessage := message.NewBuddyDeploymentFromData(msg.Data)
-		return &ProcessedTx{
-			Tx:   buddyDeployMessage.AsEthTx(),
-			Kind: msg.Kind,
-		}, nil
-	}
-
-	if msg.Kind != message.L2Type {
-		return nil, errors.New("result is not a transaction")
-	}
-	l2msg, err := message.L2Message{Data: msg.Data}.AbstractMessage()
-	if err != nil {
-		return nil, err
-	}
-	ethMsg, ok := l2msg.(message.EthConvertable)
-	if !ok {
-		return nil, errors.New("message not convertible to receipt")
-	}
-	l2Type := l2msg.L2Type()
-	return &ProcessedTx{
-		Tx:        ethMsg.AsEthTx(),
-		Kind:      msg.Kind,
-		L2Subtype: &l2Type,
-	}, nil
-}
-
 func (m *Server) AdjustGas(msg message.Call) message.Call {
 	if msg.MaxGas.Cmp(big.NewInt(0)) == 0 || msg.MaxGas.Cmp(m.maxCallGas) > 0 {
 		msg.MaxGas = m.maxCallGas

--- a/packages/arb-tx-aggregator/machineobserver/observermanager.go
+++ b/packages/arb-tx-aggregator/machineobserver/observermanager.go
@@ -84,6 +84,10 @@ func ensureInitialized(
 		return err
 	}
 
+	if err := db.AddInitialBlock(ctx, new(big.Int).Sub(eventCreated.BlockId.Height.AsInt(), big.NewInt(1))); err != nil {
+		return err
+	}
+
 	events, err := inboxWatcher.GetDeliveredEventsInBlock(ctx, eventCreated.BlockId, creationTimestamp)
 	if err != nil {
 		return err
@@ -181,7 +185,11 @@ func RunObserver(
 					if fetchEnd == nil {
 						break
 					}
-					log.Println("Getting events between", start, "and", fetchEnd)
+					currentOnChain, err := clnt.BlockIdForHeight(ctx, nil)
+					if err != nil {
+						return err
+					}
+					log.Println("Getting events between", start, "and", fetchEnd, "with", new(big.Int).Sub(currentOnChain.Height.AsInt(), start), "blocks remaining")
 					inboxDeliveredEvents, err := inboxWatcher.GetDeliveredEvents(runCtx, start, fetchEnd)
 					if err != nil {
 						return errors2.Wrap(err, "Manager hit error doing fast catchup")

--- a/packages/arb-tx-aggregator/rpc/launch.go
+++ b/packages/arb-tx-aggregator/rpc/launch.go
@@ -105,7 +105,7 @@ func LaunchAggregator(
 		batch = batcher.NewStatefulBatcher(ctx, db, rollupAddress, client, globalInbox, maxBatchTime)
 	}
 
-	srv := aggregator.NewServer(client, batch, rollupAddress, db)
+	srv := aggregator.NewServer(batch, rollupAddress, db)
 	errChan := make(chan error, 1)
 
 	web3Server, err := web3.GenerateWeb3Server(srv)

--- a/packages/arb-tx-aggregator/txdb/txdb.go
+++ b/packages/arb-tx-aggregator/txdb/txdb.go
@@ -411,7 +411,7 @@ func (db *TxDB) saveAssertion(ctx context.Context, processed processedAssertion)
 			}
 		}
 
-		if err := db.as.SaveBlockHash(common.NewHashFromEth(header.Hash()), header.Number.Uint64()); err != nil {
+		if err := db.as.SaveBlockHash(common.NewHashFromEth(block.Hash()), block.Number().Uint64()); err != nil {
 			return err
 		}
 	}

--- a/packages/arb-tx-aggregator/txdb/txdb.go
+++ b/packages/arb-tx-aggregator/txdb/txdb.go
@@ -320,8 +320,7 @@ func saveAssertion(
 		for i, txRes := range txResults {
 			if txRes.ResultCode == evm.BadSequenceCode {
 				// If this log failed with incorrect sequence number, only save the request if it hasn't been saved before
-				_, err := as.GetPossibleRequestInfo(txRes.IncomingRequest.MessageID)
-				if err == nil {
+				if as.GetPossibleRequestInfo(txRes.IncomingRequest.MessageID) == nil {
 					continue
 				}
 			}
@@ -340,25 +339,6 @@ func (txdb *TxDB) GetMessage(index uint64) (value.Value, error) {
 
 func (txdb *TxDB) GetLog(index uint64) (value.Value, error) {
 	return txdb.as.GetLog(index)
-}
-
-func (txdb *TxDB) GetRequest(requestId common.Hash) (value.Value, error) {
-	requestCandidate, err := txdb.as.GetPossibleRequestInfo(requestId)
-	if err != nil {
-		return nil, err
-	}
-	logVal, err := txdb.as.GetLog(requestCandidate)
-	if err != nil {
-		return nil, err
-	}
-	res, err := evm.NewTxResultFromValue(logVal)
-	if err != nil {
-		return nil, err
-	}
-	if res.IncomingRequest.MessageID != requestId {
-		return nil, errors.New("request not found")
-	}
-	return logVal, nil
 }
 
 func (txdb *TxDB) GetBlock(height uint64) (*machine.BlockInfo, error) {

--- a/packages/arb-tx-aggregator/txdb/view.go
+++ b/packages/arb-tx-aggregator/txdb/view.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"errors"
 	"github.com/ethereum/go-ethereum/core/types"
-	"math/big"
-
 	"github.com/offchainlabs/arbitrum/packages/arb-avm-cpp/cmachine"
 	"github.com/offchainlabs/arbitrum/packages/arb-evm/evm"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
@@ -58,6 +56,21 @@ func (txdb *View) GetRequest(requestId common.Hash) (value.Value, error) {
 		return nil, nil
 	}
 	return logVal, nil
+}
+
+func (txdb *View) GetBlockWithHash(blockHash common.Hash) (*machine.BlockInfo, error) {
+	blockHeight := txdb.as.GetPossibleBlock(blockHash)
+	if blockHeight == nil {
+		return nil, nil
+	}
+	info, err := txdb.as.GetBlock(*blockHeight)
+	if err != nil {
+		return nil, err
+	}
+	if info.Header.Hash() != blockHash.ToEthHash() {
+		return nil, nil
+	}
+	return info, err
 }
 
 func (txdb *View) GetBlock(height uint64) (*machine.BlockInfo, error) {
@@ -110,7 +123,7 @@ func (txdb *View) FindLogs(
 			// No arbitrum txes in this block
 			continue
 		}
-		if !maybeMatchesLogQuery(blockInfo.Bloom, address, topics) {
+		if !maybeMatchesLogQuery(blockInfo.Header.Bloom, address, topics) {
 			continue
 		}
 
@@ -140,8 +153,8 @@ func (txdb *View) FindLogs(
 						TxHash:  res.IncomingRequest.MessageID,
 						Index:   logIndex,
 						Block: &common.BlockId{
-							Height:     common.NewTimeBlocks(new(big.Int).SetUint64(i)),
-							HeaderHash: blockInfo.Hash,
+							Height:     common.NewTimeBlocks(blockInfo.Header.Number),
+							HeaderHash: common.NewHashFromEth(blockInfo.Header.Hash()),
 						},
 					})
 				}

--- a/packages/arb-tx-aggregator/txdb/view.go
+++ b/packages/arb-tx-aggregator/txdb/view.go
@@ -42,11 +42,11 @@ func (txdb *View) GetLog(index uint64) (value.Value, error) {
 }
 
 func (txdb *View) GetRequest(requestId common.Hash) (value.Value, error) {
-	requestCandidate, err := txdb.as.GetPossibleRequestInfo(requestId)
-	if err != nil {
-		return nil, err
+	requestCandidate := txdb.as.GetPossibleRequestInfo(requestId)
+	if requestCandidate == nil {
+		return nil, nil
 	}
-	logVal, err := txdb.as.GetLog(requestCandidate)
+	logVal, err := txdb.as.GetLog(*requestCandidate)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (txdb *View) GetRequest(requestId common.Hash) (value.Value, error) {
 		return nil, err
 	}
 	if res.IncomingRequest.MessageID != requestId {
-		return nil, errors.New("request not found")
+		return nil, nil
 	}
 	return logVal, nil
 }

--- a/packages/arb-tx-aggregator/web3/eth.go
+++ b/packages/arb-tx-aggregator/web3/eth.go
@@ -195,7 +195,7 @@ func (s *Server) GetTransactionByHash(txHash hexutil.Bytes) (*TransactionResult,
 	if err != nil {
 		return nil, err
 	}
-	tx, err := aggregator.GetTransaction(res.IncomingRequest)
+	tx, err := evm.GetTransaction(res.IncomingRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func (s *Server) GetTransactionReceipt(txHash hexutil.Bytes) (*GetTransactionRec
 
 	receipt := result.ToEthReceipt(blockInfo.Hash)
 
-	tx, err := aggregator.GetTransaction(result.IncomingRequest)
+	tx, err := evm.GetTransaction(result.IncomingRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +344,7 @@ func (s *Server) getTransactionByBlockAndIndex(height uint64, index hexutil.Uint
 	if err != nil {
 		return nil, err
 	}
-	tx, err := aggregator.GetTransaction(txRes.IncomingRequest)
+	tx, err := evm.GetTransaction(txRes.IncomingRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (s *Server) getBlock(header *types.Header, blockHash common.Hash, includeTx
 
 	bloom, gasLimit, gasUsed := aggregator.GetBlockFields(block, blockInfo)
 
-	processedTxes := make([]*aggregator.ProcessedTx, 0, len(results))
+	processedTxes := make([]*evm.ProcessedTx, 0, len(results))
 	safeResults := make([]*evm.TxResult, 0, len(results))
 	for _, res := range results {
 		kind := res.IncomingRequest.Kind
@@ -381,7 +381,7 @@ func (s *Server) getBlock(header *types.Header, blockHash common.Hash, includeTx
 		if kind != message.L2Type && kind != message.L2BuddyDeploy {
 			continue
 		}
-		tx, err := aggregator.GetTransaction(res.IncomingRequest)
+		tx, err := evm.GetTransaction(res.IncomingRequest)
 		if err != nil {
 			log.Println("Couldn't return transaction for request", res.IncomingRequest.MessageID)
 			continue
@@ -442,7 +442,7 @@ func (s *Server) getBlock(header *types.Header, blockHash common.Hash, includeTx
 	}, nil
 }
 
-func makeTransactionResult(processedTx *aggregator.ProcessedTx, res *evm.TxResult, blockHash common.Hash) *TransactionResult {
+func makeTransactionResult(processedTx *evm.ProcessedTx, res *evm.TxResult, blockHash common.Hash) *TransactionResult {
 	tx := processedTx.Tx
 	vVal, rVal, sVal := tx.RawSignatureValues()
 	txIndex := res.TxIndex.Uint64()

--- a/packages/arb-tx-aggregator/web3/eth.go
+++ b/packages/arb-tx-aggregator/web3/eth.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/ethereum/go-ethereum/trie"
+	"github.com/offchainlabs/arbitrum/packages/arb-util/machine"
 	errors2 "github.com/pkg/errors"
 	"log"
 	"math/big"
@@ -50,8 +50,8 @@ func (s *Server) BlockNumber() hexutil.Uint64 {
 	return hexutil.Uint64(s.srv.GetBlockCount())
 }
 
-func (s *Server) GetBalance(ctx context.Context, address *common.Address, blockNum *rpc.BlockNumber) (*hexutil.Big, error) {
-	snap, err := s.getSnapshot(ctx, blockNum)
+func (s *Server) GetBalance(address *common.Address, blockNum *rpc.BlockNumber) (*hexutil.Big, error) {
+	snap, err := s.getSnapshot(blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -62,8 +62,8 @@ func (s *Server) GetBalance(ctx context.Context, address *common.Address, blockN
 	return (*hexutil.Big)(balance), nil
 }
 
-func (s *Server) GetStorageAt(ctx context.Context, address *common.Address, index *hexutil.Big, blockNum *rpc.BlockNumber) (*hexutil.Big, error) {
-	snap, err := s.getSnapshot(ctx, blockNum)
+func (s *Server) GetStorageAt(address *common.Address, index *hexutil.Big, blockNum *rpc.BlockNumber) (*hexutil.Big, error) {
+	snap, err := s.getSnapshot(blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (s *Server) GetTransactionCount(ctx context.Context, address *common.Addres
 			return hexutil.Uint64(*count), nil
 		}
 	}
-	snap, err := s.getSnapshot(ctx, blockNum)
+	snap, err := s.getSnapshot(blockNum)
 	if err != nil {
 		return 0, err
 	}
@@ -93,13 +93,12 @@ func (s *Server) GetTransactionCount(ctx context.Context, address *common.Addres
 	return hexutil.Uint64(txCount.Uint64()), nil
 }
 
-func (s *Server) GetBlockTransactionCountByHash(ctx context.Context, blockHash common.Hash) (*hexutil.Big, error) {
-	header, err := s.srv.Client.HeaderByHash(ctx, blockHash)
-	if err != nil {
-		// If we can't get the header, return nil
-		return nil, nil
+func (s *Server) GetBlockTransactionCountByHash(blockHash common.Hash) (*hexutil.Big, error) {
+	info, err := s.srv.BlockInfoByHash(arbcommon.NewHashFromEth(blockHash))
+	if err != nil || info == nil {
+		return nil, err
 	}
-	return s.getBlockTransactionCount(header.Number.Uint64())
+	return s.getBlockTransactionCount(info)
 }
 
 func (s *Server) GetBlockTransactionCountByNumber(blockNum *rpc.BlockNumber) (*hexutil.Big, error) {
@@ -107,11 +106,15 @@ func (s *Server) GetBlockTransactionCountByNumber(blockNum *rpc.BlockNumber) (*h
 	if err != nil {
 		return nil, err
 	}
-	return s.getBlockTransactionCount(height)
+	info, err := s.srv.BlockInfoByNumber(height)
+	if err != nil || info == nil {
+		return nil, err
+	}
+	return s.getBlockTransactionCount(info)
 }
 
-func (s *Server) GetCode(ctx context.Context, address *common.Address, blockNum *rpc.BlockNumber) (hexutil.Bytes, error) {
-	snap, err := s.getSnapshot(ctx, blockNum)
+func (s *Server) GetCode(address *common.Address, blockNum *rpc.BlockNumber) (hexutil.Bytes, error) {
+	snap, err := s.getSnapshot(blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -134,65 +137,68 @@ func (s *Server) SendRawTransaction(ctx context.Context, data hexutil.Bytes) (he
 	return tx.Hash().Bytes(), nil
 }
 
-func (s *Server) Call(ctx context.Context, callArgs CallTxArgs, blockNum *rpc.BlockNumber) (hexutil.Bytes, error) {
-	res, err := s.executeCall(ctx, callArgs, blockNum)
+func (s *Server) Call(callArgs CallTxArgs, blockNum *rpc.BlockNumber) (hexutil.Bytes, error) {
+	res, err := s.executeCall(callArgs, blockNum)
 	if err != nil {
 		return nil, err
 	}
 	return res.ReturnData, nil
 }
 
-func (s *Server) EstimateGas(ctx context.Context, args CallTxArgs) (hexutil.Uint64, error) {
+func (s *Server) EstimateGas(args CallTxArgs) (hexutil.Uint64, error) {
 	blockNum := rpc.PendingBlockNumber
-	res, err := s.executeCall(ctx, args, &blockNum)
+	res, err := s.executeCall(args, &blockNum)
 	if err != nil {
 		return 0, err
 	}
 	return hexutil.Uint64(res.GasUsed.Uint64() + 1000000), nil
 }
 
-func (s *Server) GetBlockByHash(ctx context.Context, blockHashRaw hexutil.Bytes, includeTxData bool) (*GetBlockResult, error) {
-	var blockHash common.Hash
+func (s *Server) GetBlockByHash(blockHashRaw hexutil.Bytes, includeTxData bool) (*GetBlockResult, error) {
+	var blockHash arbcommon.Hash
 	copy(blockHash[:], blockHashRaw)
-
-	header, err := s.srv.Client.HeaderByHash(ctx, blockHash)
-	if err != nil {
-		// If we can't get the header, return nil
-		return nil, nil
+	info, err := s.srv.BlockInfoByHash(blockHash)
+	if err != nil || info == nil {
+		return nil, err
 	}
-	return s.getBlock(header, blockHash, includeTxData)
+	return s.getBlock(info, includeTxData)
 }
 
-func (s *Server) GetBlockByNumber(ctx context.Context, blockNum *rpc.BlockNumber, includeTxData bool) (*GetBlockResult, error) {
+func (s *Server) GetBlockByNumber(blockNum *rpc.BlockNumber, includeTxData bool) (*GetBlockResult, error) {
 	height, err := s.blockNum(blockNum)
 	if err != nil {
 		return nil, err
 	}
-	header, err := s.srv.Client.HeaderByNumber(ctx, new(big.Int).SetUint64(height))
-	if err != nil {
-		// If we can't get the header, return nil
+	info, err := s.srv.BlockInfoByNumber(height)
+	if err != nil || info == nil {
 		return nil, err
 	}
-	l1BlockInfo, err := s.srv.Client.BlockInfoByNumber(ctx, new(big.Int).SetUint64(height))
-	if err != nil {
-		return nil, err
-	}
-
-	return s.getBlock(header, l1BlockInfo.Hash, includeTxData)
+	return s.getBlock(info, includeTxData)
 }
 
-func (s *Server) GetTransactionByHash(txHash hexutil.Bytes) (*TransactionResult, error) {
+func (s *Server) getTransactionInfoByHash(txHash hexutil.Bytes) (*evm.TxResult, *machine.BlockInfo, error) {
 	var requestId arbcommon.Hash
 	copy(requestId[:], txHash)
 	val, err := s.srv.GetRequestResult(requestId)
-	if err != nil {
-		return nil, err
+	if err != nil || val == nil {
+		return nil, nil, err
 	}
-	if val == nil {
-		return nil, nil
-	}
+
 	res, err := evm.NewTxResultFromValue(val)
 	if err != nil {
+		return nil, nil, err
+	}
+
+	info, err := s.srv.BlockInfoByNumber(res.IncomingRequest.ChainTime.BlockNum.AsInt().Uint64())
+	if err != nil || info == nil {
+		return nil, nil, err
+	}
+	return res, info, nil
+}
+
+func (s *Server) GetTransactionByHash(txHash hexutil.Bytes) (*TransactionResult, error) {
+	res, info, err := s.getTransactionInfoByHash(txHash)
+	if err != nil || res == nil {
 		return nil, err
 	}
 	tx, err := evm.GetTransaction(res.IncomingRequest)
@@ -200,22 +206,21 @@ func (s *Server) GetTransactionByHash(txHash hexutil.Bytes) (*TransactionResult,
 		return nil, err
 	}
 
-	blockInfo, err := s.srv.BlockInfo(res.IncomingRequest.ChainTime.BlockNum.AsInt().Uint64())
-	if err != nil {
-		return nil, err
+	var blockHash *common.Hash
+	if info != nil {
+		h := info.Header.Hash()
+		blockHash = &h
 	}
 
-	return makeTransactionResult(tx, res, blockInfo.Hash.ToEthHash()), nil
+	return makeTransactionResult(tx, res, blockHash), nil
 }
 
-func (s *Server) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint64) (*TransactionResult, error) {
-	header, err := s.srv.Client.HeaderByHash(ctx, blockHash)
-	if err != nil {
-		// If we can't get the header, return nil
-		return nil, nil
+func (s *Server) GetTransactionByBlockHashAndIndex(blockHash common.Hash, index hexutil.Uint64) (*TransactionResult, error) {
+	info, err := s.srv.BlockInfoByHash(arbcommon.NewHashFromEth(blockHash))
+	if err != nil || info == nil {
+		return nil, err
 	}
-
-	return s.getTransactionByBlockAndIndex(header.Number.Uint64(), index)
+	return s.getTransactionByBlockAndIndex(info.Header.Number.Uint64(), index)
 }
 
 func (s *Server) GetTransactionByBlockNumberAndIndex(blockNum *rpc.BlockNumber, index hexutil.Uint64) (*TransactionResult, error) {
@@ -228,31 +233,14 @@ func (s *Server) GetTransactionByBlockNumberAndIndex(blockNum *rpc.BlockNumber, 
 }
 
 func (s *Server) GetTransactionReceipt(txHash hexutil.Bytes) (*GetTransactionReceiptResult, error) {
-	var requestId arbcommon.Hash
-	copy(requestId[:], txHash)
-	val, err := s.srv.GetRequestResult(requestId)
-	if err != nil {
-		return nil, err
-	}
-	if val == nil {
-		return nil, nil
-	}
-	result, err := evm.NewTxResultFromValue(val)
-	if err != nil {
+	res, info, err := s.getTransactionInfoByHash(txHash)
+	if err != nil || res == nil {
 		return nil, err
 	}
 
-	blockInfo, err := s.srv.BlockInfo(result.IncomingRequest.ChainTime.BlockNum.AsInt().Uint64())
-	if err != nil {
-		return nil, err
-	}
-	if blockInfo == nil {
-		return nil, nil
-	}
+	receipt := res.ToEthReceipt(arbcommon.NewHashFromEth(info.Header.Hash()))
 
-	receipt := result.ToEthReceipt(blockInfo.Hash)
-
-	tx, err := evm.GetTransaction(result.IncomingRequest)
+	tx, err := evm.GetTransaction(res.IncomingRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +256,7 @@ func (s *Server) GetTransactionReceipt(txHash hexutil.Bytes) (*GetTransactionRec
 		TransactionIndex:  hexutil.Uint64(receipt.TransactionIndex),
 		BlockHash:         receipt.BlockHash,
 		BlockNumber:       (*hexutil.Big)(receipt.BlockNumber),
-		From:              result.IncomingRequest.Sender.ToEthAddress(),
+		From:              res.IncomingRequest.Sender.ToEthAddress(),
 		To:                tx.Tx.To(),
 		CumulativeGasUsed: hexutil.Uint64(receipt.CumulativeGasUsed),
 		GasUsed:           hexutil.Uint64(receipt.GasUsed),
@@ -277,8 +265,8 @@ func (s *Server) GetTransactionReceipt(txHash hexutil.Bytes) (*GetTransactionRec
 		LogsBloom:         receipt.Bloom.Bytes(),
 		Status:            hexutil.Uint64(receipt.Status),
 
-		ReturnCode: hexutil.Uint64(result.ResultCode),
-		ReturnData: result.ReturnData,
+		ReturnCode: hexutil.Uint64(res.ResultCode),
+		ReturnData: res.ReturnData,
 	}, nil
 }
 
@@ -315,27 +303,31 @@ func (s *Server) GetLogs(ctx context.Context, args filters.FilterCriteria) ([]*t
 	return res, nil
 }
 
-func (s *Server) getBlockTransactionCount(height uint64) (*hexutil.Big, error) {
-	block, err := s.srv.BlockInfo(height)
-	if err != nil {
-		return nil, err
+func (s *Server) getBlockTransactionCount(block *machine.BlockInfo) (*hexutil.Big, error) {
+	if block.BlockLog == nil {
+		// No arbitrum block at this height
+		return (*hexutil.Big)(big.NewInt(0)), nil
 	}
 
-	blockInfo, err := s.srv.GetBlockInfo(block)
+	arbBlock, err := evm.NewBlockResultFromValue(block.BlockLog)
 	if err != nil {
 		return nil, err
 	}
-	return (*hexutil.Big)(blockInfo.BlockStats.TxCount), nil
+	return (*hexutil.Big)(arbBlock.BlockStats.TxCount), nil
 }
 
 func (s *Server) getTransactionByBlockAndIndex(height uint64, index hexutil.Uint64) (*TransactionResult, error) {
-	block, err := s.srv.BlockInfo(height)
-	if err != nil {
-		// If we can't get the header, return nil
+	block, err := s.srv.BlockInfoByNumber(height)
+	if err != nil || block == nil {
+		return nil, err
+	}
+
+	if block.BlockLog == nil {
+		// No arbitrum block at this height
 		return nil, nil
 	}
 
-	blockInfo, err := s.srv.GetBlockInfo(block)
+	blockInfo, err := evm.NewBlockResultFromValue(block.BlockLog)
 	if err != nil {
 		return nil, err
 	}
@@ -348,17 +340,15 @@ func (s *Server) getTransactionByBlockAndIndex(height uint64, index hexutil.Uint
 	if err != nil {
 		return nil, err
 	}
-	return makeTransactionResult(tx, txRes, block.Hash.ToEthHash()), nil
+	blockHash := block.Header.Hash()
+	return makeTransactionResult(tx, txRes, &blockHash), nil
 }
 
-func (s *Server) getBlock(header *types.Header, blockHash common.Hash, includeTxData bool) (*GetBlockResult, error) {
-	// If the db hasn't yet processed the requested block, don't return a header
-	if header.Number.Cmp(new(big.Int).SetUint64(s.srv.GetBlockCount())) > 0 {
-		return nil, nil
-	}
-	block, err := s.srv.BlockInfo(header.Number.Uint64())
-	if err != nil {
-		return nil, err
+func (s *Server) getBlock(block *machine.BlockInfo, includeTxData bool) (*GetBlockResult, error) {
+	blockHash := block.Header.Hash()
+	if block.BlockLog == nil {
+		// No arb block at this height
+		return makeBlockResult(block.Header, nil), nil
 	}
 
 	blockInfo, err := s.srv.GetBlockInfo(block)
@@ -370,8 +360,6 @@ func (s *Server) getBlock(header *types.Header, blockHash common.Hash, includeTx
 	if err != nil {
 		return nil, err
 	}
-
-	bloom, gasLimit, gasUsed := aggregator.GetBlockFields(block, blockInfo)
 
 	processedTxes := make([]*evm.ProcessedTx, 0, len(results))
 	safeResults := make([]*evm.TxResult, 0, len(results))
@@ -394,7 +382,7 @@ func (s *Server) getBlock(header *types.Header, blockHash common.Hash, includeTx
 	if includeTxData {
 		txResults := make([]*TransactionResult, 0, len(safeResults))
 		for i, res := range safeResults {
-			txResults = append(txResults, makeTransactionResult(processedTxes[i], res, blockHash))
+			txResults = append(txResults, makeTransactionResult(processedTxes[i], res, &blockHash))
 		}
 		transactions = txResults
 	} else {
@@ -405,28 +393,21 @@ func (s *Server) getBlock(header *types.Header, blockHash common.Hash, includeTx
 		transactions = txHashes
 	}
 
-	var txRoot common.Hash
-	if len(processedTxes) != 0 {
+	return makeBlockResult(block.Header, transactions), nil
+}
 
-		txes := make([]*types.Transaction, 0, len(processedTxes))
-		for _, tx := range processedTxes {
-			txes = append(txes, tx.Tx)
-		}
-		txRoot = types.DeriveSha(types.Transactions(txes), new(trie.Trie))
-	} else {
-		txRoot = types.EmptyRootHash
-	}
+func makeBlockResult(header *types.Header, transactions interface{}) *GetBlockResult {
 	size := uint64(0)
 	uncles := make([]hexutil.Bytes, 0)
 	return &GetBlockResult{
 		Number:           (*hexutil.Big)(header.Number),
-		Hash:             blockHash.Bytes(),
+		Hash:             header.Hash().Bytes(),
 		ParentHash:       header.ParentHash.Bytes(),
 		MixDigest:        header.MixDigest.Bytes(),
 		Nonce:            &header.Nonce,
 		Sha3Uncles:       header.UncleHash.Bytes(),
-		LogsBloom:        bloom.Bytes(),
-		TransactionsRoot: txRoot.Bytes(),
+		LogsBloom:        header.Bloom.Bytes(),
+		TransactionsRoot: header.TxHash.Bytes(),
 		StateRoot:        header.Root.Bytes(),
 		ReceiptsRoot:     header.ReceiptHash.Bytes(),
 		Miner:            header.Coinbase.Bytes(),
@@ -434,15 +415,15 @@ func (s *Server) getBlock(header *types.Header, blockHash common.Hash, includeTx
 		TotalDifficulty:  (*hexutil.Big)(header.Difficulty),
 		ExtraData:        (*hexutil.Bytes)(&header.Extra),
 		Size:             (*hexutil.Uint64)(&size),
-		GasLimit:         (*hexutil.Uint64)(&gasLimit),
-		GasUsed:          (*hexutil.Uint64)(&gasUsed),
+		GasLimit:         (*hexutil.Uint64)(&header.GasLimit),
+		GasUsed:          (*hexutil.Uint64)(&header.GasUsed),
 		Timestamp:        (*hexutil.Uint64)(&header.Time),
 		Transactions:     transactions,
 		Uncles:           &uncles,
-	}, nil
+	}
 }
 
-func makeTransactionResult(processedTx *evm.ProcessedTx, res *evm.TxResult, blockHash common.Hash) *TransactionResult {
+func makeTransactionResult(processedTx *evm.ProcessedTx, res *evm.TxResult, blockHash *common.Hash) *TransactionResult {
 	tx := processedTx.Tx
 	vVal, rVal, sVal := tx.RawSignatureValues()
 	txIndex := res.TxIndex.Uint64()
@@ -463,7 +444,7 @@ func makeTransactionResult(processedTx *evm.ProcessedTx, res *evm.TxResult, bloc
 	}
 
 	return &TransactionResult{
-		BlockHash:        &blockHash,
+		BlockHash:        blockHash,
 		BlockNumber:      (*hexutil.Big)(blockNum),
 		From:             res.IncomingRequest.Sender.ToEthAddress(),
 		Gas:              hexutil.Uint64(tx.Gas()),
@@ -522,8 +503,8 @@ func buildCallMsg(args CallTxArgs) (arbcommon.Address, message.Call) {
 	}
 }
 
-func (s *Server) executeCall(ctx context.Context, args CallTxArgs, blockNum *rpc.BlockNumber) (*evm.TxResult, error) {
-	snap, err := s.getSnapshot(ctx, blockNum)
+func (s *Server) executeCall(args CallTxArgs, blockNum *rpc.BlockNumber) (*evm.TxResult, error) {
+	snap, err := s.getSnapshot(blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -532,7 +513,7 @@ func (s *Server) executeCall(ctx context.Context, args CallTxArgs, blockNum *rpc
 	return snap.Call(msg, from)
 }
 
-func (s *Server) getSnapshot(ctx context.Context, blockNum *rpc.BlockNumber) (*snapshot.Snapshot, error) {
+func (s *Server) getSnapshot(blockNum *rpc.BlockNumber) (*snapshot.Snapshot, error) {
 	if blockNum == nil || *blockNum == rpc.PendingBlockNumber {
 		return s.srv.PendingSnapshot(), nil
 	}
@@ -541,7 +522,7 @@ func (s *Server) getSnapshot(ctx context.Context, blockNum *rpc.BlockNumber) (*s
 		return s.srv.LatestSnapshot(), nil
 	}
 
-	snap, err := s.srv.GetSnapshot(ctx, uint64(*blockNum))
+	snap, err := s.srv.GetSnapshot(uint64(*blockNum))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/arb-tx-aggregator/web3/eth.go
+++ b/packages/arb-tx-aggregator/web3/eth.go
@@ -185,8 +185,10 @@ func (s *Server) GetTransactionByHash(txHash hexutil.Bytes) (*TransactionResult,
 	var requestId arbcommon.Hash
 	copy(requestId[:], txHash)
 	val, err := s.srv.GetRequestResult(requestId)
-	// If the transaction wasn't found, return nil
-	if val == nil || err != nil {
+	if err != nil {
+		return nil, err
+	}
+	if val == nil {
 		return nil, nil
 	}
 	res, err := evm.NewTxResultFromValue(val)
@@ -229,7 +231,10 @@ func (s *Server) GetTransactionReceipt(txHash hexutil.Bytes) (*GetTransactionRec
 	var requestId arbcommon.Hash
 	copy(requestId[:], txHash)
 	val, err := s.srv.GetRequestResult(requestId)
-	if val == nil || err != nil {
+	if err != nil {
+		return nil, err
+	}
+	if val == nil {
 		return nil, nil
 	}
 	result, err := evm.NewTxResultFromValue(val)

--- a/packages/arb-util/machine/aggregator.go
+++ b/packages/arb-util/machine/aggregator.go
@@ -19,12 +19,9 @@ package machine
 import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/value"
-
-	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 )
 
 type BlockInfo struct {
-	Hash     common.Hash
 	BlockLog value.Value
-	Bloom    types.Bloom
+	Header   *types.Header
 }

--- a/packages/arb-validator/go.sum
+++ b/packages/arb-validator/go.sum
@@ -147,6 +147,7 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huin/goupnp v1.0.0 h1:wg75sLpL6DZqwHQN6E1Cfk6mtfzS45z8OV+ic+DtHRo=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
+github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883 h1:FSeK4fZCo8u40n2JMnyAsd6x7+SbvoOMHvQOU/n10P4=
 github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458 h1:6OvNmYgJyexcZ3pYbTI9jWx5tHo1Dee/tWbLMfPe2TA=
 github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=

--- a/tests/fibgo/go.sum
+++ b/tests/fibgo/go.sum
@@ -49,6 +49,7 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -226,6 +227,9 @@ github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00 h1:8DPul/X0IT/1TNMIxoKLwde
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 h1:3hxavr+IHMsQBrYUPQM5v0CgENFktkkbg1sfpgM3h20=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubrpZHtQLnOf6EwhN2hEMusxZOhcW9H3UQ=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.20.0 h1:38k9hgtUBdxFwE34yS8rTHmHBa4eN16E4DJlv177LNs=
+github.com/rs/zerolog v1.20.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil v2.20.5+incompatible h1:tYH07UPoQt0OCQdgWWMgYHy3/a9bcxNpBIysykNIP7I=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
@@ -322,6 +326,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
This PR updates the aggregator to serve blocks with their own arbitrum specific block header/hash instead of of former method of using the Ethereum block hash associated with the arbitrum block as our L2 block hash as well