### PR TITLE
Manage Nonce client-side

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,11 @@ aliases:
 
   - &restore_go_cache
     keys:
-      - go-mod-v8-{{ .Branch }}-{{ checksum "packages/arb-validator/go.sum" }}
-      - go-mod-v8-{{ .Branch }}-
-      - go-mod-v8-
+      - go-mod-v9-{{ .Branch }}-{{ checksum "packages/arb-validator/go.sum" }}
+      - go-mod-v9-{{ .Branch }}-
+      - go-mod-v9-
   - &save_go_cache
-    key: go-mod-v8-{{ .Branch }}-{{ checksum "packages/arb-validator/go.sum" }}
+    key: go-mod-v9-{{ .Branch }}-{{ checksum "packages/arb-validator/go.sum" }}
     paths:
       - ~/go/pkg/mod
   - &test-path /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,11 @@ aliases:
 
   - &restore_go_cache
     keys:
-      - go-mod-v7-{{ .Branch }}-{{ checksum "packages/arb-validator/go.sum" }}
-      - go-mod-v7-{{ .Branch }}-
-      - go-mod-v7-
+      - go-mod-v8-{{ .Branch }}-{{ checksum "packages/arb-validator/go.sum" }}
+      - go-mod-v8-{{ .Branch }}-
+      - go-mod-v8-
   - &save_go_cache
-    key: go-mod-v7-{{ .Branch }}-{{ checksum "packages/arb-validator/go.sum" }}
+    key: go-mod-v8-{{ .Branch }}-{{ checksum "packages/arb-validator/go.sum" }}
     paths:
       - ~/go/pkg/mod
   - &test-path /tmp/test-results

--- a/packages/arb-checkpointer/checkpointing/indexedCheckpointer_test.go
+++ b/packages/arb-checkpointer/checkpointing/indexedCheckpointer_test.go
@@ -179,6 +179,8 @@ func TestRestoreSingleCheckpoint(t *testing.T) {
 	}
 	defer cp.db.CloseCheckpointStorage()
 
+	ctx := context.Background()
+
 	checkpointContext := ckptcontext.NewCheckpointContext()
 	if err = writeCheckpoint(cp.bs, cp.db, &writableCheckpoint{
 		blockId:  initialEntryBlockId,
@@ -197,7 +199,7 @@ func TestRestoreSingleCheckpoint(t *testing.T) {
 		},
 	}
 	// Should fail restore if checkpoint has changed
-	if err = cp.RestoreLatestState(context.Background(), tgm, func(bytes []byte, restoreContext ckptcontext.RestoreContext, _ *common.BlockId) error {
+	if err = cp.RestoreLatestState(ctx, tgm, func(bytes []byte, restoreContext ckptcontext.RestoreContext, _ *common.BlockId) error {
 		t.Error("unmarshal func called")
 		return nil
 	}); err != errNoMatchingCheckpoint {
@@ -213,7 +215,7 @@ func TestRestoreSingleCheckpoint(t *testing.T) {
 		},
 	}
 	// Should succeed restore if checkpoint hasn't changed
-	if err = cp.RestoreLatestState(context.Background(), tgm, func(data []byte, restoreContext ckptcontext.RestoreContext, _ *common.BlockId) error {
+	if err = cp.RestoreLatestState(ctx, tgm, func(data []byte, restoreContext ckptcontext.RestoreContext, _ *common.BlockId) error {
 		if !bytes.Equal(data, checkpointData) {
 			t.Error("incorrect checkpoint data restored")
 		}
@@ -272,9 +274,10 @@ func TestRestoreReorg(t *testing.T) {
 		}
 	}
 
+	ctx := context.Background()
 	tgm := &TimeGetterMock{generateReorgTimeGetterMock(laterEntryBlockId, initialEntryBlockId)}
 	// Should restore to latest without reorg
-	if err = cp.RestoreLatestState(context.Background(), tgm, func(data []byte, restoreContext ckptcontext.RestoreContext, _ *common.BlockId) error {
+	if err = cp.RestoreLatestState(ctx, tgm, func(data []byte, restoreContext ckptcontext.RestoreContext, _ *common.BlockId) error {
 		if !bytes.Equal(data, checkpointData2) {
 			t.Error("incorrect checkpoint data restored")
 		}
@@ -285,7 +288,7 @@ func TestRestoreReorg(t *testing.T) {
 
 	tgm = &TimeGetterMock{generateReorgTimeGetterMock(laterEntryBlockId2, initialEntryBlockId)}
 	// Should restore older after reorg
-	if err = cp.RestoreLatestState(context.Background(), tgm, func(data []byte, restoreContext ckptcontext.RestoreContext, _ *common.BlockId) error {
+	if err = cp.RestoreLatestState(ctx, tgm, func(data []byte, restoreContext ckptcontext.RestoreContext, _ *common.BlockId) error {
 		if !bytes.Equal(data, checkpointData) {
 			t.Error("incorrect checkpoint data restored")
 		}
@@ -296,7 +299,7 @@ func TestRestoreReorg(t *testing.T) {
 
 	tgm = &TimeGetterMock{generateReorgTimeGetterMock(laterEntryBlockId2, initialEntryBlockId2)}
 	// Should fail to restore if everything is reorged out
-	if err = cp.RestoreLatestState(context.Background(), tgm, func(data []byte, restoreContext ckptcontext.RestoreContext, _ *common.BlockId) error {
+	if err = cp.RestoreLatestState(ctx, tgm, func(data []byte, restoreContext ckptcontext.RestoreContext, _ *common.BlockId) error {
 		t.Error("shouldn't be able to restore")
 		return nil
 	}); err != errNoMatchingCheckpoint {

--- a/packages/arb-checkpointer/go.sum
+++ b/packages/arb-checkpointer/go.sum
@@ -47,6 +47,7 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -192,6 +193,8 @@ github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00 h1:8DPul/X0IT/1TNMIxoKLwde
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 h1:3hxavr+IHMsQBrYUPQM5v0CgENFktkkbg1sfpgM3h20=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubrpZHtQLnOf6EwhN2hEMusxZOhcW9H3UQ=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.20.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil v2.20.5+incompatible h1:tYH07UPoQt0OCQdgWWMgYHy3/a9bcxNpBIysykNIP7I=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
@@ -276,6 +279,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/packages/arb-evm/go.sum
+++ b/packages/arb-evm/go.sum
@@ -47,6 +47,7 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -198,6 +199,9 @@ github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00 h1:8DPul/X0IT/1TNMIxoKLwde
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 h1:3hxavr+IHMsQBrYUPQM5v0CgENFktkkbg1sfpgM3h20=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubrpZHtQLnOf6EwhN2hEMusxZOhcW9H3UQ=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.20.0 h1:38k9hgtUBdxFwE34yS8rTHmHBa4eN16E4DJlv177LNs=
+github.com/rs/zerolog v1.20.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil v2.20.5+incompatible h1:tYH07UPoQt0OCQdgWWMgYHy3/a9bcxNpBIysykNIP7I=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
@@ -285,6 +289,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/packages/arb-evm/message/main_test.go
+++ b/packages/arb-evm/message/main_test.go
@@ -17,31 +17,44 @@
 package message
 
 import (
+	"context"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridge"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridgetestcontracts"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/test"
 	"log"
 	"os"
 	"testing"
-
-	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/test"
 )
 
 var tester *ethbridgetestcontracts.MessageTester
 
 func TestMain(m *testing.M) {
-	client, pks := test.SimulatedBackend()
+	ctx := context.Background()
+	backend, pks := test.SimulatedBackend()
+	client := &ethutils.SimulatedEthClient{SimulatedBackend: backend}
 	auth := bind.NewKeyedTransactor(pks[0])
-	_, _, deployedMessageTester, err := ethbridgetestcontracts.DeployMessageTester(
-		auth,
-		client,
-	)
+	authClient, err := ethbridge.NewEthAuthClient(ctx, client, auth)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	messageTesterAddr, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error) {
+		return ethbridgetestcontracts.DeployMessageTester(auth, client)
+	})
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	client.Commit()
 
-	tester = deployedMessageTester
+	tester, err = ethbridgetestcontracts.NewMessageTester(messageTesterAddr, client)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	code := m.Run()
 	os.Exit(code)

--- a/packages/arb-tx-aggregator/arbostest/constructor_test.go
+++ b/packages/arb-tx-aggregator/arbostest/constructor_test.go
@@ -45,11 +45,12 @@ func TestContructor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := client.SendTransaction(context.Background(), signedTx); err != nil {
+	ctx := context.Background()
+	if err := client.SendTransaction(ctx, signedTx); err != nil {
 		t.Fatal(err)
 	}
 	client.Commit()
-	ethReceipt, err := client.TransactionReceipt(context.Background(), signedTx.Hash())
+	ethReceipt, err := client.TransactionReceipt(ctx, signedTx.Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +118,7 @@ func TestContructor(t *testing.T) {
 		t.Error("contracts deployed at different addresses")
 	}
 
-	ethCode, err := client.CodeAt(context.Background(), ethReceipt.ContractAddress, nil)
+	ethCode, err := client.CodeAt(ctx, ethReceipt.ContractAddress, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/packages/arb-tx-aggregator/batcher/batcher.go
+++ b/packages/arb-tx-aggregator/batcher/batcher.go
@@ -281,7 +281,7 @@ func (m *Batcher) SendTransaction(_ context.Context, tx *types.Transaction) erro
 	if err != nil {
 		log.Err(err).Msg("failed to marshal tx into json")
 	} else {
-		log.Info().RawJSON("tx", txJSON).Str("sender", sender.Hex()).Msg("user tx")
+		log.Info().RawJSON("tx", txJSON).Hex("sender", sender.Bytes()).Msg("user tx")
 	}
 
 	m.Lock()

--- a/packages/arb-tx-aggregator/batcher/batcher_test.go
+++ b/packages/arb-tx-aggregator/batcher/batcher_test.go
@@ -144,8 +144,9 @@ func TestStatelessBatcher(t *testing.T) {
 	txes, txCounts := generateTxes(t, chain)
 	seenTxesChan := make(chan message.CompressedECDSATransaction, 1000)
 	mock := newMock(t, seenTxesChan, txes)
+	ctx := context.Background()
 	batcher := NewStatelessBatcher(
-		context.Background(),
+		ctx,
 		chain,
 		mock,
 		mock,
@@ -153,7 +154,7 @@ func TestStatelessBatcher(t *testing.T) {
 	)
 
 	for _, tx := range txes {
-		if err := batcher.SendTransaction(context.Background(), tx); err != nil {
+		if err := batcher.SendTransaction(ctx, tx); err != nil {
 			t.Fatal(err)
 		}
 		<-time.After(time.Millisecond * 20)

--- a/packages/arb-tx-aggregator/batcher/forwardingBatcher.go
+++ b/packages/arb-tx-aggregator/batcher/forwardingBatcher.go
@@ -40,7 +40,7 @@ func NewForwarder(client *ethclient.Client) *Forwarder {
 func (b *Forwarder) PendingTransactionCount(ctx context.Context, account common.Address) *uint64 {
 	nonce, err := b.client.PendingNonceAt(ctx, account.ToEthAddress())
 	if err != nil {
-		log.Println("Error fetching pending nice")
+		log.Println("Error fetching pending nonce")
 		return nil
 	}
 	return &nonce

--- a/packages/arb-tx-aggregator/cmd/arb-replay-test/arb-replay-test.go
+++ b/packages/arb-tx-aggregator/cmd/arb-replay-test/arb-replay-test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	zerolog "github.com/rs/zerolog/log"
 	"io/ioutil"
 	"log"
 	"math/big"
@@ -194,6 +195,7 @@ func (a *App) Execute(line string) {
 
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	zerolog.Logger = zerolog.With().Caller().Logger()
 	file := os.Args[1]
 	log.Println("Running test:", file)
 	data, err := ioutil.ReadFile(file)

--- a/packages/arb-tx-aggregator/cmd/arb-test-case/arb-test-case.go
+++ b/packages/arb-tx-aggregator/cmd/arb-test-case/arb-test-case.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	zerolog "github.com/rs/zerolog/log"
 	"io/ioutil"
 	"log"
 
@@ -32,6 +33,7 @@ import (
 func main() {
 	// Enable line numbers in logging
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	zerolog.Logger = zerolog.With().Caller().Logger()
 
 	if err := generateTestCase(
 		"http://localhost:7545",

--- a/packages/arb-tx-aggregator/cmd/arb-tx-aggregator/arb-tx-aggregator.go
+++ b/packages/arb-tx-aggregator/cmd/arb-tx-aggregator/arb-tx-aggregator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/offchainlabs/arbitrum/packages/arb-evm/message"
 	"github.com/offchainlabs/arbitrum/packages/arb-tx-aggregator/rpc"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
+	zerolog "github.com/rs/zerolog/log"
 	"log"
 	"os"
 	"path/filepath"
@@ -38,6 +39,7 @@ import (
 func main() {
 	// Enable line numbers in logging
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	zerolog.Logger = zerolog.With().Caller().Logger()
 
 	ctx := context.Background()
 	fs := flag.NewFlagSet("", flag.ContinueOnError)

--- a/packages/arb-tx-aggregator/machineobserver/reorg_test.go
+++ b/packages/arb-tx-aggregator/machineobserver/reorg_test.go
@@ -69,6 +69,7 @@ func setupRollup(ctx context.Context, client ethutils.EthClient, auth *bind.Tran
 // to test it's ability to handle reorgs
 func TestReorg(t *testing.T) {
 	clnt, pks := test.SimulatedBackend()
+	ctx := context.Background()
 	l1Client := &ethutils.SimulatedEthClient{SimulatedBackend: clnt}
 	go func() {
 		t := time.NewTicker(time.Millisecond * 10)
@@ -98,7 +99,7 @@ func TestReorg(t *testing.T) {
 	auth := bind.NewKeyedTransactor(pks[0])
 
 	authClient := ethbridge.NewEthAuthClient(l1Client, auth)
-	inboxConn, err := authClient.NewGlobalInbox(inboxAddress, rollupAddress)
+	inboxConn, err := authClient.NewGlobalInbox(ctx, inboxAddress, rollupAddress)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/packages/arb-tx-aggregator/machineobserver/reorg_test.go
+++ b/packages/arb-tx-aggregator/machineobserver/reorg_test.go
@@ -35,7 +35,10 @@ func setupRollup(ctx context.Context, client ethutils.EthClient, auth *bind.Tran
 		return common.Address{}, common.Address{}, err
 	}
 
-	arbClient := ethbridge.NewEthAuthClient(client, auth)
+	arbClient, err := ethbridge.NewEthAuthClient(ctx, client, auth)
+	if err != nil {
+		return common.Address{}, common.Address{}, err
+	}
 
 	factory, err := arbClient.NewArbFactory(common.NewAddressFromEth(factoryAddr))
 	if err != nil {
@@ -98,7 +101,11 @@ func TestReorg(t *testing.T) {
 
 	auth := bind.NewKeyedTransactor(pks[0])
 
-	authClient := ethbridge.NewEthAuthClient(l1Client, auth)
+	authClient, err := ethbridge.NewEthAuthClient(ctx, l1Client, auth)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	inboxConn, err := authClient.NewGlobalInbox(ctx, inboxAddress, rollupAddress)
 	if err != nil {
 		t.Fatal(err)

--- a/packages/arb-tx-aggregator/rpc/launch.go
+++ b/packages/arb-tx-aggregator/rpc/launch.go
@@ -91,14 +91,14 @@ func LaunchAggregator(
 		batch = batcher.NewForwarder(forwardClient)
 	case StatelessBatcherMode:
 		authClient := ethbridge.NewEthAuthClient(client, batcherMode.Auth)
-		globalInbox, err := authClient.NewGlobalInbox(inboxAddress, rollupAddress)
+		globalInbox, err := authClient.NewGlobalInbox(ctx, inboxAddress, rollupAddress)
 		if err != nil {
 			return err
 		}
 		batch = batcher.NewStatelessBatcher(ctx, rollupAddress, client, globalInbox, maxBatchTime)
 	case StatefulBatcherMode:
 		authClient := ethbridge.NewEthAuthClient(client, batcherMode.Auth)
-		globalInbox, err := authClient.NewGlobalInbox(inboxAddress, rollupAddress)
+		globalInbox, err := authClient.NewGlobalInbox(ctx, inboxAddress, rollupAddress)
 		if err != nil {
 			return err
 		}

--- a/packages/arb-tx-aggregator/rpc/launch.go
+++ b/packages/arb-tx-aggregator/rpc/launch.go
@@ -90,14 +90,20 @@ func LaunchAggregator(
 		}
 		batch = batcher.NewForwarder(forwardClient)
 	case StatelessBatcherMode:
-		authClient := ethbridge.NewEthAuthClient(client, batcherMode.Auth)
+		authClient, err := ethbridge.NewEthAuthClient(ctx, client, batcherMode.Auth)
+		if err != nil {
+			return err
+		}
 		globalInbox, err := authClient.NewGlobalInbox(ctx, inboxAddress, rollupAddress)
 		if err != nil {
 			return err
 		}
 		batch = batcher.NewStatelessBatcher(ctx, rollupAddress, client, globalInbox, maxBatchTime)
 	case StatefulBatcherMode:
-		authClient := ethbridge.NewEthAuthClient(client, batcherMode.Auth)
+		authClient, err := ethbridge.NewEthAuthClient(ctx, client, batcherMode.Auth)
+		if err != nil {
+			return err
+		}
 		globalInbox, err := authClient.NewGlobalInbox(ctx, inboxAddress, rollupAddress)
 		if err != nil {
 			return err

--- a/packages/arb-tx-aggregator/rpc/launch.go
+++ b/packages/arb-tx-aggregator/rpc/launch.go
@@ -94,7 +94,7 @@ func LaunchAggregator(
 		if err != nil {
 			return err
 		}
-		globalInbox, err := authClient.NewGlobalInbox(ctx, inboxAddress, rollupAddress)
+		globalInbox, err := authClient.NewGlobalInbox(inboxAddress, rollupAddress)
 		if err != nil {
 			return err
 		}
@@ -104,7 +104,7 @@ func LaunchAggregator(
 		if err != nil {
 			return err
 		}
-		globalInbox, err := authClient.NewGlobalInbox(ctx, inboxAddress, rollupAddress)
+		globalInbox, err := authClient.NewGlobalInbox(inboxAddress, rollupAddress)
 		if err != nil {
 			return err
 		}

--- a/packages/arb-validator-core/arbbridge/arbClient.go
+++ b/packages/arb-validator-core/arbbridge/arbClient.go
@@ -53,7 +53,7 @@ type ArbAuthClient interface {
 	Address() common.Address
 	NewArbFactory(address common.Address) (ArbFactory, error)
 	NewRollup(address common.Address) (ArbRollup, error)
-	NewGlobalInbox(ctx context.Context, address common.Address, rollupAddress common.Address) (GlobalInbox, error)
+	NewGlobalInbox(address common.Address, rollupAddress common.Address) (GlobalInbox, error)
 	NewChallengeFactory(address common.Address) (ChallengeFactory, error)
 	NewExecutionChallenge(address common.Address) (ExecutionChallenge, error)
 	NewInboxTopChallenge(address common.Address) (InboxTopChallenge, error)

--- a/packages/arb-validator-core/arbbridge/arbClient.go
+++ b/packages/arb-validator-core/arbbridge/arbClient.go
@@ -53,7 +53,7 @@ type ArbAuthClient interface {
 	Address() common.Address
 	NewArbFactory(address common.Address) (ArbFactory, error)
 	NewRollup(address common.Address) (ArbRollup, error)
-	NewGlobalInbox(address common.Address, rollupAddress common.Address) (GlobalInbox, error)
+	NewGlobalInbox(ctx context.Context, address common.Address, rollupAddress common.Address) (GlobalInbox, error)
 	NewChallengeFactory(address common.Address) (ChallengeFactory, error)
 	NewExecutionChallenge(address common.Address) (ExecutionChallenge, error)
 	NewInboxTopChallenge(address common.Address) (InboxTopChallenge, error)

--- a/packages/arb-validator-core/ethbridge/arbClient.go
+++ b/packages/arb-validator-core/ethbridge/arbClient.go
@@ -277,10 +277,14 @@ func NewEthAuthClient(ctx context.Context, client ethutils.EthClient, auth *bind
 }
 
 func (c *EthArbAuthClient) MakeContract(ctx context.Context, contractFunc func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error)) (ethcommon.Address, *types.Transaction, error) {
+	c.auth.Lock()
+	defer c.auth.Unlock()
 	return c.auth.makeContract(ctx, contractFunc)
 }
 
 func (c *EthArbAuthClient) MakeTx(ctx context.Context, txFunc func(auth *bind.TransactOpts) (*types.Transaction, error)) (*types.Transaction, error) {
+	c.auth.Lock()
+	defer c.auth.Unlock()
 	return c.auth.makeTx(ctx, txFunc)
 }
 

--- a/packages/arb-validator-core/ethbridge/arbClient.go
+++ b/packages/arb-validator-core/ethbridge/arbClient.go
@@ -206,7 +206,7 @@ func (t *TransactAuth) makeContract(ctx context.Context, contractFunc func(auth 
 
 	for i := 0; i < smallNonceRepeatCount && err != nil && strings.Contains(err.Error(), smallNonceError); i++ {
 		// Increment nonce and try again
-		t.auth.Nonce.Add(t.auth.Nonce, big.NewInt(1))
+		auth.Nonce = t.auth.Nonce.Add(t.auth.Nonce, big.NewInt(1))
 		addr, tx, _, err = contractFunc(auth)
 	}
 
@@ -233,7 +233,7 @@ func (t *TransactAuth) makeTx(ctx context.Context, txFunc func(auth *bind.Transa
 
 	for i := 0; i < smallNonceRepeatCount && err != nil && strings.Contains(err.Error(), smallNonceError); i++ {
 		// Increment nonce and try again
-		t.auth.Nonce.Add(t.auth.Nonce, big.NewInt(1))
+		auth.Nonce = t.auth.Nonce.Add(t.auth.Nonce, big.NewInt(1))
 		tx, err = txFunc(auth)
 	}
 

--- a/packages/arb-validator-core/ethbridge/arbClient.go
+++ b/packages/arb-validator-core/ethbridge/arbClient.go
@@ -191,13 +191,13 @@ type TransactAuth struct {
 	auth *bind.TransactOpts
 }
 
-func (t *TransactAuth) makeContract(ctx context.Context, contractFunc func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, error)) (ethcommon.Address, *types.Transaction, error) {
+func (t *TransactAuth) makeContract(ctx context.Context, contractFunc func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error)) (ethcommon.Address, *types.Transaction, error) {
 	const smallNonceRepeatCount = 5
 	const smallNonceError = "Try increasing the gas price or incrementing the nonce."
 
 	auth := t.getAuth(ctx)
 
-	addr, tx, err := contractFunc(auth)
+	addr, tx, _, err := contractFunc(auth)
 
 	if t.auth.Nonce == nil {
 		// Not incrementing nonce, so nothing else to do
@@ -207,7 +207,7 @@ func (t *TransactAuth) makeContract(ctx context.Context, contractFunc func(auth 
 	for i := 0; i < smallNonceRepeatCount && err != nil && strings.Contains(err.Error(), smallNonceError); i++ {
 		// Increment nonce and try again
 		t.auth.Nonce.Add(t.auth.Nonce, big.NewInt(1))
-		addr, tx, err = contractFunc(auth)
+		addr, tx, _, err = contractFunc(auth)
 	}
 
 	if err == nil {
@@ -276,7 +276,7 @@ func NewEthAuthClient(ctx context.Context, client ethutils.EthClient, auth *bind
 	}, nil
 }
 
-func (c *EthArbAuthClient) MakeContract(ctx context.Context, contractFunc func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, error)) (ethcommon.Address, *types.Transaction, error) {
+func (c *EthArbAuthClient) MakeContract(ctx context.Context, contractFunc func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error)) (ethcommon.Address, *types.Transaction, error) {
 	return c.auth.makeContract(ctx, contractFunc)
 }
 

--- a/packages/arb-validator-core/ethbridge/arbFactory.go
+++ b/packages/arb-validator-core/ethbridge/arbFactory.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridgecontracts"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"math/big"
@@ -69,17 +70,19 @@ func (con *arbFactory) CreateRollup(
 ) (common.Address, *common.BlockId, error) {
 	con.auth.Lock()
 	defer con.auth.Unlock()
-	tx, err := con.contract.CreateRollup(
-		con.auth.getAuth(ctx),
-		vmState,
-		params.GracePeriod.Val,
-		new(big.Int).SetUint64(params.ArbGasSpeedLimitPerTick),
-		params.MaxExecutionSteps,
-		params.StakeRequirement,
-		params.StakeToken.ToEthAddress(),
-		owner.ToEthAddress(),
-		[]byte{},
-	)
+	tx, err := con.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return con.contract.CreateRollup(
+			auth,
+			vmState,
+			params.GracePeriod.Val,
+			new(big.Int).SetUint64(params.ArbGasSpeedLimitPerTick),
+			params.MaxExecutionSteps,
+			params.StakeRequirement,
+			params.StakeToken.ToEthAddress(),
+			owner.ToEthAddress(),
+			[]byte{},
+		)
+	})
 	if err != nil {
 		return common.Address{}, nil, errors2.Wrap(err, "Failed to call to ChainFactory.CreateChain")
 	}

--- a/packages/arb-validator-core/ethbridge/arbFactory.go
+++ b/packages/arb-validator-core/ethbridge/arbFactory.go
@@ -46,17 +46,15 @@ func newArbFactory(address ethcommon.Address, client ethutils.EthClient, auth *T
 }
 
 func DeployRollupFactory(ctx context.Context, authClient *EthArbAuthClient, client ethutils.EthClient) (ethcommon.Address, error) {
-	rollupAddr, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, error) {
-		addr, tx, _, err := ethbridgecontracts.DeployArbRollup(auth, client)
-		return addr, tx, err
+	rollupAddr, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error) {
+		return ethbridgecontracts.DeployArbRollup(auth, client)
 	})
 	if err != nil {
 		return ethcommon.Address{}, err
 	}
 
-	inbox, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, error) {
-		addr, tx, _, err := ethbridgecontracts.DeployGlobalInbox(auth, client)
-		return addr, tx, err
+	inbox, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error) {
+		return ethbridgecontracts.DeployGlobalInbox(auth, client)
 	})
 	if err != nil {
 		return ethcommon.Address{}, err
@@ -67,9 +65,8 @@ func DeployRollupFactory(ctx context.Context, authClient *EthArbAuthClient, clie
 		return ethcommon.Address{}, err
 	}
 
-	arbFactory, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, error) {
-		addr, tx, _, err := ethbridgecontracts.DeployArbFactory(auth, client, rollupAddr, inbox, chalFactory)
-		return addr, tx, err
+	arbFactory, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error) {
+		return ethbridgecontracts.DeployArbFactory(auth, client, rollupAddr, inbox, chalFactory)
 	})
 
 	return arbFactory, err

--- a/packages/arb-validator-core/ethbridge/arbRollup.go
+++ b/packages/arb-validator-core/ethbridge/arbRollup.go
@@ -47,24 +47,26 @@ func newRollup(address ethcommon.Address, client ethutils.EthClient, auth *Trans
 func (vm *arbRollup) PlaceStake(ctx context.Context, stakeAmount *big.Int, proof1 []common.Hash, proof2 []common.Hash) ([]arbbridge.Event, error) {
 	vm.auth.Lock()
 	defer vm.auth.Unlock()
-	call := &bind.TransactOpts{
-		From:    vm.auth.auth.From,
-		Signer:  vm.auth.auth.Signer,
-		Context: ctx,
-	}
-	blankAddress := ethcommon.Address{}
-	st, err := vm.ArbRollup.GetStakeToken(&bind.CallOpts{Context: ctx})
-	if err != nil {
-		return nil, err
-	}
-	if st == blankAddress {
-		call.Value = stakeAmount
-	}
-	tx, err := vm.ArbRollup.PlaceStake(
-		call,
-		common.HashSliceToRaw(proof1),
-		common.HashSliceToRaw(proof2),
-	)
+	tx, err := vm.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		call := &bind.TransactOpts{
+			From:    auth.From,
+			Signer:  auth.Signer,
+			Context: ctx,
+		}
+		blankAddress := ethcommon.Address{}
+		st, err := vm.ArbRollup.GetStakeToken(&bind.CallOpts{Context: ctx})
+		if err != nil {
+			return nil, err
+		}
+		if st == blankAddress {
+			call.Value = stakeAmount
+		}
+		return vm.ArbRollup.PlaceStake(
+			call,
+			common.HashSliceToRaw(proof1),
+			common.HashSliceToRaw(proof2),
+		)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -74,10 +76,12 @@ func (vm *arbRollup) PlaceStake(ctx context.Context, stakeAmount *big.Int, proof
 func (vm *arbRollup) RecoverStakeConfirmed(ctx context.Context, proof []common.Hash) ([]arbbridge.Event, error) {
 	vm.auth.Lock()
 	defer vm.auth.Unlock()
-	tx, err := vm.ArbRollup.RecoverStakeConfirmed(
-		vm.auth.getAuth(ctx),
-		common.HashSliceToRaw(proof),
-	)
+	tx, err := vm.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return vm.ArbRollup.RecoverStakeConfirmed(
+			auth,
+			common.HashSliceToRaw(proof),
+		)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -87,11 +91,13 @@ func (vm *arbRollup) RecoverStakeConfirmed(ctx context.Context, proof []common.H
 func (vm *arbRollup) RecoverStakeOld(ctx context.Context, staker common.Address, proof []common.Hash) ([]arbbridge.Event, error) {
 	vm.auth.Lock()
 	defer vm.auth.Unlock()
-	tx, err := vm.ArbRollup.RecoverStakeOld(
-		vm.auth.getAuth(ctx),
-		staker.ToEthAddress(),
-		common.HashSliceToRaw(proof),
-	)
+	tx, err := vm.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return vm.ArbRollup.RecoverStakeOld(
+			auth,
+			staker.ToEthAddress(),
+			common.HashSliceToRaw(proof),
+		)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -101,13 +107,15 @@ func (vm *arbRollup) RecoverStakeOld(ctx context.Context, staker common.Address,
 func (vm *arbRollup) RecoverStakeMooted(ctx context.Context, nodeHash common.Hash, staker common.Address, latestConfirmedProof []common.Hash, stakerProof []common.Hash) ([]arbbridge.Event, error) {
 	vm.auth.Lock()
 	defer vm.auth.Unlock()
-	tx, err := vm.ArbRollup.RecoverStakeMooted(
-		vm.auth.getAuth(ctx),
-		staker.ToEthAddress(),
-		nodeHash,
-		common.HashSliceToRaw(latestConfirmedProof),
-		common.HashSliceToRaw(stakerProof),
-	)
+	tx, err := vm.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return vm.ArbRollup.RecoverStakeMooted(
+			auth,
+			staker.ToEthAddress(),
+			nodeHash,
+			common.HashSliceToRaw(latestConfirmedProof),
+			common.HashSliceToRaw(stakerProof),
+		)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -117,15 +125,17 @@ func (vm *arbRollup) RecoverStakeMooted(ctx context.Context, nodeHash common.Has
 func (vm *arbRollup) RecoverStakePassedDeadline(ctx context.Context, stakerAddress common.Address, deadlineTicks *big.Int, disputableNodeHashVal common.Hash, childType uint64, vmProtoStateHash common.Hash, proof []common.Hash) ([]arbbridge.Event, error) {
 	vm.auth.Lock()
 	defer vm.auth.Unlock()
-	tx, err := vm.ArbRollup.RecoverStakePassedDeadline(
-		vm.auth.getAuth(ctx),
-		stakerAddress.ToEthAddress(),
-		deadlineTicks,
-		disputableNodeHashVal,
-		new(big.Int).SetUint64(childType),
-		vmProtoStateHash,
-		common.HashSliceToRaw(proof),
-	)
+	tx, err := vm.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return vm.ArbRollup.RecoverStakePassedDeadline(
+			auth,
+			stakerAddress.ToEthAddress(),
+			deadlineTicks,
+			disputableNodeHashVal,
+			new(big.Int).SetUint64(childType),
+			vmProtoStateHash,
+			common.HashSliceToRaw(proof),
+		)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -135,11 +145,13 @@ func (vm *arbRollup) RecoverStakePassedDeadline(ctx context.Context, stakerAddre
 func (vm *arbRollup) MoveStake(ctx context.Context, proof1 []common.Hash, proof2 []common.Hash) ([]arbbridge.Event, error) {
 	vm.auth.Lock()
 	defer vm.auth.Unlock()
-	tx, err := vm.ArbRollup.MoveStake(
-		vm.auth.getAuth(ctx),
-		common.HashSliceToRaw(proof1),
-		common.HashSliceToRaw(proof2),
-	)
+	tx, err := vm.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return vm.ArbRollup.MoveStake(
+			auth,
+			common.HashSliceToRaw(proof1),
+			common.HashSliceToRaw(proof2),
+		)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -163,14 +175,16 @@ func (vm *arbRollup) PruneLeaves(ctx context.Context, opps []valprotocol.PrunePa
 		confProofLengths = append(confProofLengths, big.NewInt(int64(len(opp.AncProof))))
 	}
 
-	tx, err := vm.ArbRollup.PruneLeaves(
-		vm.auth.getAuth(ctx),
-		common.HashSliceToRaw(fromNodes),
-		common.HashSliceToRaw(leafProofs),
-		leafProofLengths,
-		common.HashSliceToRaw(confProofs),
-		confProofLengths,
-	)
+	tx, err := vm.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return vm.ArbRollup.PruneLeaves(
+			auth,
+			common.HashSliceToRaw(fromNodes),
+			common.HashSliceToRaw(leafProofs),
+			leafProofLengths,
+			common.HashSliceToRaw(confProofs),
+			confProofLengths,
+		)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -208,19 +222,21 @@ func (vm *arbRollup) MakeAssertion(
 		beforeState.MessageCount,
 		beforeState.LogCount,
 	}
-	tx, err := vm.ArbRollup.MakeAssertion(
-		vm.auth.getAuth(ctx),
-		fields,
-		fields2,
-		validBlock.HeaderHash,
-		validBlock.Height.AsInt(),
-		assertion.MessageCount,
-		assertion.LogCount,
-		uint32(prevChildType),
-		assertionParams.NumSteps,
-		assertion.NumGas,
-		common.HashSliceToRaw(stakerProof),
-	)
+	tx, err := vm.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return vm.ArbRollup.MakeAssertion(
+			auth,
+			fields,
+			fields2,
+			validBlock.HeaderHash,
+			validBlock.Height.AsInt(),
+			assertion.MessageCount,
+			assertion.LogCount,
+			uint32(prevChildType),
+			assertionParams.NumSteps,
+			assertion.NumGas,
+			common.HashSliceToRaw(stakerProof),
+		)
+	})
 	if err != nil {
 		callErr := vm.ArbRollup.MakeAssertionCall(
 			ctx,
@@ -248,21 +264,23 @@ func (vm *arbRollup) Confirm(ctx context.Context, opp *valprotocol.ConfirmOpport
 	vm.auth.Lock()
 	defer vm.auth.Unlock()
 
-	tx, err := vm.ArbRollup.Confirm(
-		vm.auth.getAuth(ctx),
-		proof.InitalProtoStateHash,
-		proof.BeforeSendCount,
-		proof.BranchesNums,
-		proof.DeadlineTicks,
-		proof.ChallengeNodeData,
-		proof.LogsAcc,
-		proof.VMProtoStateHashes,
-		proof.MessageCounts,
-		proof.Messages,
-		addressSliceToRaw(opp.StakerAddresses),
-		proof.CombinedProofs,
-		proof.StakerProofOffsets,
-	)
+	tx, err := vm.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return vm.ArbRollup.Confirm(
+			auth,
+			proof.InitalProtoStateHash,
+			proof.BeforeSendCount,
+			proof.BranchesNums,
+			proof.DeadlineTicks,
+			proof.ChallengeNodeData,
+			proof.LogsAcc,
+			proof.VMProtoStateHashes,
+			proof.MessageCounts,
+			proof.Messages,
+			addressSliceToRaw(opp.StakerAddresses),
+			proof.CombinedProofs,
+			proof.StakerProofOffsets,
+		)
+	})
 	if err != nil {
 		return nil, vm.ArbRollup.ConfirmCall(
 			ctx,
@@ -304,26 +322,28 @@ func (vm *arbRollup) StartChallenge(
 ) ([]arbbridge.Event, error) {
 	vm.auth.Lock()
 	defer vm.auth.Unlock()
-	tx, err := vm.ArbRollup.StartChallenge(
-		vm.auth.getAuth(ctx),
-		asserterAddress.ToEthAddress(),
-		challengerAddress.ToEthAddress(),
-		prevNode,
-		disputableDeadline,
-		[2]*big.Int{
-			new(big.Int).SetUint64(uint64(asserterPosition)),
-			new(big.Int).SetUint64(uint64(challengerPosition)),
-		},
-		[2][32]byte{
-			asserterVMProtoHash,
-			challengerVMProtoHash,
-		},
-		common.HashSliceToRaw(asserterProof),
-		common.HashSliceToRaw(challengerProof),
-		asserterNodeHash,
-		challengerDataHash,
-		challengerPeriodTicks.Val,
-	)
+	tx, err := vm.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return vm.ArbRollup.StartChallenge(
+			auth,
+			asserterAddress.ToEthAddress(),
+			challengerAddress.ToEthAddress(),
+			prevNode,
+			disputableDeadline,
+			[2]*big.Int{
+				new(big.Int).SetUint64(uint64(asserterPosition)),
+				new(big.Int).SetUint64(uint64(challengerPosition)),
+			},
+			[2][32]byte{
+				asserterVMProtoHash,
+				challengerVMProtoHash,
+			},
+			common.HashSliceToRaw(asserterProof),
+			common.HashSliceToRaw(challengerProof),
+			asserterNodeHash,
+			challengerDataHash,
+			challengerPeriodTicks.Val,
+		)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/packages/arb-validator-core/ethbridge/arbRollup.go
+++ b/packages/arb-validator-core/ethbridge/arbRollup.go
@@ -47,22 +47,19 @@ func newRollup(address ethcommon.Address, client ethutils.EthClient, auth *Trans
 func (vm *arbRollup) PlaceStake(ctx context.Context, stakeAmount *big.Int, proof1 []common.Hash, proof2 []common.Hash) ([]arbbridge.Event, error) {
 	vm.auth.Lock()
 	defer vm.auth.Unlock()
+
+	blankAddress := ethcommon.Address{}
+	st, err := vm.ArbRollup.GetStakeToken(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return nil, err
+	}
+
 	tx, err := vm.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
-		call := &bind.TransactOpts{
-			From:    auth.From,
-			Signer:  auth.Signer,
-			Context: ctx,
-		}
-		blankAddress := ethcommon.Address{}
-		st, err := vm.ArbRollup.GetStakeToken(&bind.CallOpts{Context: ctx})
-		if err != nil {
-			return nil, err
-		}
 		if st == blankAddress {
-			call.Value = stakeAmount
+			auth.Value = stakeAmount
 		}
 		return vm.ArbRollup.PlaceStake(
-			call,
+			auth,
 			common.HashSliceToRaw(proof1),
 			common.HashSliceToRaw(proof2),
 		)

--- a/packages/arb-validator-core/ethbridge/bisectionChallenge.go
+++ b/packages/arb-validator-core/ethbridge/bisectionChallenge.go
@@ -19,6 +19,7 @@ package ethbridge
 import (
 	"context"
 	"errors"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridgecontracts"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"math/big"
@@ -76,13 +77,15 @@ func (c *bisectionChallenge) chooseSegment(
 	}
 
 	tree := NewMerkleTree(segments)
-	tx, err := c.BisectionChallenge.ChooseSegment(
-		c.auth.getAuth(ctx),
-		big.NewInt(int64(segmentToChallenge)),
-		tree.GetProofFlat(int(segmentToChallenge)),
-		tree.GetRoot(),
-		tree.GetNode(int(segmentToChallenge)),
-	)
+	tx, err := c.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return c.BisectionChallenge.ChooseSegment(
+			auth,
+			big.NewInt(int64(segmentToChallenge)),
+			tree.GetProofFlat(int(segmentToChallenge)),
+			tree.GetRoot(),
+			tree.GetNode(int(segmentToChallenge)),
+		)
+	})
 	if err != nil {
 		return c.BisectionChallenge.ChooseSegmentCall(
 			ctx,

--- a/packages/arb-validator-core/ethbridge/challenge.go
+++ b/packages/arb-validator-core/ethbridge/challenge.go
@@ -19,6 +19,7 @@ package ethbridge
 import (
 	"context"
 	"errors"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridgecontracts"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"strings"
@@ -66,7 +67,9 @@ func newChallenge(address ethcommon.Address, client ethutils.EthClient, auth *Tr
 func (c *challenge) TimeoutChallenge(ctx context.Context) error {
 	c.auth.Lock()
 	defer c.auth.Unlock()
-	tx, err := c.Challenge.TimeoutChallenge(c.auth.getAuth(ctx))
+	tx, err := c.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return c.Challenge.TimeoutChallenge(auth)
+	})
 	if err != nil {
 		return c.Challenge.TimeoutChallengeCall(
 			ctx,

--- a/packages/arb-validator-core/ethbridge/challengeFactory.go
+++ b/packages/arb-validator-core/ethbridge/challengeFactory.go
@@ -45,33 +45,29 @@ func newChallengeFactory(address ethcommon.Address, client ethutils.EthClient, a
 }
 
 func DeployChallengeFactory(ctx context.Context, authClient *EthArbAuthClient, client ethutils.EthClient) (ethcommon.Address, *types.Transaction, error) {
-	inboxTopAddr, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, error) {
-		inboxTopAddr, tx, _, err := ethbridgecontracts.DeployInboxTopChallenge(auth, client)
-		return inboxTopAddr, tx, err
+	inboxTopAddr, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error) {
+		return ethbridgecontracts.DeployInboxTopChallenge(auth, client)
 	})
 	if err != nil {
 		return ethcommon.Address{}, nil, err
 	}
 
-	executionAddr, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, error) {
-		executionAddr, tx, _, err := ethbridgecontracts.DeployExecutionChallenge(auth, client)
-		return executionAddr, tx, err
+	executionAddr, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error) {
+		return ethbridgecontracts.DeployExecutionChallenge(auth, client)
 	})
 	if err != nil {
 		return ethcommon.Address{}, nil, err
 	}
 
-	ospAddr, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, error) {
-		ospAddr, tx, _, err := ethbridgecontracts.DeployOneStepProof(auth, client)
-		return ospAddr, tx, err
+	ospAddr, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error) {
+		return ethbridgecontracts.DeployOneStepProof(auth, client)
 	})
 	if err != nil {
 		return ethcommon.Address{}, nil, err
 	}
 
-	factoryAddr, tx, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, error) {
-		factoryAddr, tx, _, err := ethbridgecontracts.DeployChallengeFactory(auth, client, inboxTopAddr, executionAddr, ospAddr)
-		return factoryAddr, tx, err
+	factoryAddr, tx, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error) {
+		return ethbridgecontracts.DeployChallengeFactory(auth, client, inboxTopAddr, executionAddr, ospAddr)
 	})
 	return factoryAddr, tx, err
 }

--- a/packages/arb-validator-core/ethbridge/challengeFactory.go
+++ b/packages/arb-validator-core/ethbridge/challengeFactory.go
@@ -19,6 +19,7 @@ package ethbridge
 import (
 	"context"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridgecontracts"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"math/big"
@@ -70,14 +71,16 @@ func (con *challengeFactory) CreateChallenge(
 ) (common.Address, error) {
 	con.auth.Lock()
 	defer con.auth.Unlock()
-	tx, err := con.contract.CreateChallenge(
-		con.auth.getAuth(ctx),
-		asserter.ToEthAddress(),
-		challenger.ToEthAddress(),
-		challengePeriod.Val,
-		challengeHash,
-		challengeType,
-	)
+	tx, err := con.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return con.contract.CreateChallenge(
+			auth,
+			asserter.ToEthAddress(),
+			challenger.ToEthAddress(),
+			challengePeriod.Val,
+			challengeHash,
+			challengeType,
+		)
+	})
 	if err != nil {
 		return common.Address{}, errors2.Wrap(err, "Failed to call to challengeFactory.CreateChallenge")
 	}

--- a/packages/arb-validator-core/ethbridge/executionChallenge.go
+++ b/packages/arb-validator-core/ethbridge/executionChallenge.go
@@ -18,7 +18,9 @@ package ethbridge
 
 import (
 	"context"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/inbox"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridgecontracts"
@@ -70,16 +72,18 @@ func (c *executionChallenge) BisectAssertion(
 	}
 	c.auth.Lock()
 	defer c.auth.Unlock()
-	tx, err := c.challenge.BisectAssertion(
-		c.auth.getAuth(ctx),
-		machineHashes,
-		inboxHashes,
-		messageAccs,
-		logAccs,
-		outCounts,
-		gasses,
-		totalSteps,
-	)
+	tx, err := c.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return c.challenge.BisectAssertion(
+			auth,
+			machineHashes,
+			inboxHashes,
+			messageAccs,
+			logAccs,
+			outCounts,
+			gasses,
+			totalSteps,
+		)
+	})
 	if err != nil {
 		return c.challenge.BisectAssertionCall(
 			ctx,
@@ -105,13 +109,15 @@ func (c *executionChallenge) OneStepProof(
 ) error {
 	c.auth.Lock()
 	defer c.auth.Unlock()
-	tx, err := c.challenge.OneStepProof(
-		c.auth.getAuth(ctx),
-		assertion.AfterInboxHash,
-		assertion.FirstMessageHash,
-		assertion.FirstLogHash,
-		proof,
-	)
+	tx, err := c.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return c.challenge.OneStepProof(
+			auth,
+			assertion.AfterInboxHash,
+			assertion.FirstMessageHash,
+			assertion.FirstLogHash,
+			proof,
+		)
+	})
 	if err != nil {
 		return c.challenge.OneStepProofCall(
 			ctx,
@@ -135,19 +141,21 @@ func (c *executionChallenge) OneStepProofWithMessage(
 ) error {
 	c.auth.Lock()
 	defer c.auth.Unlock()
-	tx, err := c.challenge.OneStepProofWithMessage(
-		c.auth.getAuth(ctx),
-		assertion.AfterInboxHash,
-		assertion.FirstMessageHash,
-		assertion.FirstLogHash,
-		proof,
-		uint8(msg.Kind),
-		msg.ChainTime.BlockNum.AsInt(),
-		msg.ChainTime.Timestamp,
-		msg.Sender.ToEthAddress(),
-		msg.InboxSeqNum,
-		msg.Data,
-	)
+	tx, err := c.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return c.challenge.OneStepProofWithMessage(
+			auth,
+			assertion.AfterInboxHash,
+			assertion.FirstMessageHash,
+			assertion.FirstLogHash,
+			proof,
+			uint8(msg.Kind),
+			msg.ChainTime.BlockNum.AsInt(),
+			msg.ChainTime.Timestamp,
+			msg.Sender.ToEthAddress(),
+			msg.InboxSeqNum,
+			msg.Data,
+		)
+	})
 	if err != nil {
 		return c.challenge.OneStepProofInboxCall(
 			ctx,

--- a/packages/arb-validator-core/ethbridge/globalInbox.go
+++ b/packages/arb-validator-core/ethbridge/globalInbox.go
@@ -36,19 +36,10 @@ type globalInbox struct {
 	auth *TransactAuth
 }
 
-func newGlobalInbox(ctx context.Context, address ethcommon.Address, chain ethcommon.Address, client ethutils.EthClient, auth *TransactAuth) (*globalInbox, error) {
+func newGlobalInbox(address ethcommon.Address, chain ethcommon.Address, client ethutils.EthClient, auth *TransactAuth) (*globalInbox, error) {
 	watcher, err := newGlobalInboxWatcher(address, chain, client)
 	if err != nil {
 		return nil, errors2.Wrap(err, "Failed to connect to GlobalInbox")
-	}
-	auth.Lock()
-	defer auth.Unlock()
-	if auth.auth.Nonce == nil {
-		nonce, err := client.PendingNonceAt(ctx, auth.auth.From)
-		if err != nil {
-			return nil, errors2.Wrap(err, "Failed to get nonce for GlobalInbox")
-		}
-		auth.auth.Nonce = new(big.Int).SetUint64(nonce)
 	}
 	return &globalInbox{watcher, auth}, nil
 }

--- a/packages/arb-validator-core/ethbridge/ierc20.go
+++ b/packages/arb-validator-core/ethbridge/ierc20.go
@@ -46,11 +46,13 @@ func newIERC20(address ethcommon.Address, client ethutils.EthClient, auth *Trans
 func (con *IERC20) Approve(ctx context.Context, spender common.Address, amount *big.Int) error {
 	con.auth.Lock()
 	defer con.auth.Unlock()
-	tx, err := con.IERC20.Approve(
-		con.auth.getAuth(ctx),
-		spender.ToEthAddress(),
-		amount,
-	)
+	tx, err := con.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return con.IERC20.Approve(
+			auth,
+			spender.ToEthAddress(),
+			amount,
+		)
+	})
 	if err != nil {
 		return err
 	}

--- a/packages/arb-validator-core/ethbridge/inboxTopChallenge.go
+++ b/packages/arb-validator-core/ethbridge/inboxTopChallenge.go
@@ -18,6 +18,8 @@ package ethbridge
 
 import (
 	"context"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridgecontracts"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"math/big"
@@ -54,11 +56,13 @@ func (c *inboxTopChallenge) Bisect(
 ) error {
 	c.auth.Lock()
 	defer c.auth.Unlock()
-	tx, err := c.contract.Bisect(
-		c.auth.getAuth(ctx),
-		common.HashSliceToRaw(chainHashes),
-		chainLength,
-	)
+	tx, err := c.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return c.contract.Bisect(
+			auth,
+			common.HashSliceToRaw(chainHashes),
+			chainLength,
+		)
+	})
 	if err != nil {
 		return c.contract.BisectCall(
 			ctx,
@@ -79,11 +83,13 @@ func (c *inboxTopChallenge) OneStepProof(
 ) error {
 	c.auth.Lock()
 	defer c.auth.Unlock()
-	tx, err := c.contract.OneStepProof(
-		c.auth.getAuth(ctx),
-		lowerHashA,
-		value,
-	)
+	tx, err := c.auth.makeTx(ctx, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		return c.contract.OneStepProof(
+			auth,
+			lowerHashA,
+			value,
+		)
+	})
 	if err != nil {
 		return err
 	}

--- a/packages/arb-validator-core/ethbridgetest/keccak_test.go
+++ b/packages/arb-validator-core/ethbridgetest/keccak_test.go
@@ -17,27 +17,44 @@
 package ethbridgetest
 
 import (
+	"context"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridge"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridgetestcontracts"
+	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/test"
+	"log"
 	"math/big"
 	"math/rand"
 	"testing"
 )
 
 func TestKeccak(t *testing.T) {
-	client, pks := test.SimulatedBackend()
+	ctx := context.Background()
+	backend, pks := test.SimulatedBackend()
+	client := &ethutils.SimulatedEthClient{SimulatedBackend: backend}
 	auth := bind.NewKeyedTransactor(pks[0])
+	authClient, err := ethbridge.NewEthAuthClient(ctx, client, auth)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	_, _, precompilesTester, err := ethbridgetestcontracts.DeployPrecompilesTester(
-		auth,
-		client,
-	)
+	precompilesTesterAddr, _, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error) {
+		return ethbridgetestcontracts.DeployPrecompilesTester(auth, client)
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	client.Commit()
+
+	precompilesTester, err := ethbridgetestcontracts.NewPrecompilesTester(precompilesTesterAddr, client)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var data [25]uint64
 	var bigData [25]*big.Int

--- a/packages/arb-validator-core/go.mod
+++ b/packages/arb-validator-core/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/offchainlabs/arbitrum/packages/arb-util v0.7.3
 	github.com/pkg/errors v0.9.1
+	github.com/rs/zerolog v1.20.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	google.golang.org/protobuf v1.25.0
 )

--- a/packages/arb-validator-core/go.sum
+++ b/packages/arb-validator-core/go.sum
@@ -48,6 +48,7 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -207,6 +208,9 @@ github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00 h1:8DPul/X0IT/1TNMIxoKLwde
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 h1:3hxavr+IHMsQBrYUPQM5v0CgENFktkkbg1sfpgM3h20=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubrpZHtQLnOf6EwhN2hEMusxZOhcW9H3UQ=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.20.0 h1:38k9hgtUBdxFwE34yS8rTHmHBa4eN16E4DJlv177LNs=
+github.com/rs/zerolog v1.20.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil v2.20.5+incompatible h1:tYH07UPoQt0OCQdgWWMgYHy3/a9bcxNpBIysykNIP7I=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
@@ -298,6 +302,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/packages/arb-validator/chainobserver/arbRollup_test.go
+++ b/packages/arb-validator/chainobserver/arbRollup_test.go
@@ -126,10 +126,6 @@ func TestRecoverStake(t *testing.T) {
 
 func getRollup(t *testing.T) arbbridge.ArbRollup {
 	ctx := context.Background()
-	authClient, err := ethbridge.NewEthAuthClient(ctx, client, auth)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chainParams := valprotocol.ChainParams{
 		StakeRequirement:        big.NewInt(0),

--- a/packages/arb-validator/chainobserver/arbRollup_test.go
+++ b/packages/arb-validator/chainobserver/arbRollup_test.go
@@ -123,7 +123,7 @@ func TestRecoverStake(t *testing.T) {
 
 func getRollup(t *testing.T) arbbridge.ArbRollup {
 	ctx := context.Background()
-	authClient, err := ethbridge.NewEthAuthClient(ctx, ethclnt, auth)
+	authClient, err := ethbridge.NewEthAuthClient(ctx, client, auth)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func getRollup(t *testing.T) arbbridge.ArbRollup {
 		ArbGasSpeedLimitPerTick: 100000,
 	}
 
-	arbFactoryAddress, err := ethbridge.DeployRollupFactory(ctx, authClient, ethclnt)
+	arbFactoryAddress, err := ethbridge.DeployRollupFactory(ctx, authClient, client)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/packages/arb-validator/chainobserver/arbRollup_test.go
+++ b/packages/arb-validator/chainobserver/arbRollup_test.go
@@ -123,7 +123,7 @@ func TestRecoverStake(t *testing.T) {
 
 func getRollup(t *testing.T) arbbridge.ArbRollup {
 	ctx := context.Background()
-	clnt, err := ethbridge.NewEthAuthClient(ctx, ethclnt, auth)
+	authClient, err := ethbridge.NewEthAuthClient(ctx, ethclnt, auth)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,12 +135,12 @@ func getRollup(t *testing.T) arbbridge.ArbRollup {
 		ArbGasSpeedLimitPerTick: 100000,
 	}
 
-	arbFactoryAddress, err := ethbridge.DeployRollupFactory(auth, ethclnt)
+	arbFactoryAddress, err := ethbridge.DeployRollupFactory(ctx, authClient, ethclnt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	factory, err := clnt.NewArbFactory(common.NewAddressFromEth(arbFactoryAddress))
+	factory, err := authClient.NewArbFactory(common.NewAddressFromEth(arbFactoryAddress))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func getRollup(t *testing.T) arbbridge.ArbRollup {
 		t.Fatal(err)
 	}
 
-	rollupContract, err := clnt.NewRollup(rollupAddress)
+	rollupContract, err := authClient.NewRollup(rollupAddress)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/packages/arb-validator/chainobserver/arbRollup_test.go
+++ b/packages/arb-validator/chainobserver/arbRollup_test.go
@@ -122,7 +122,11 @@ func TestRecoverStake(t *testing.T) {
 }
 
 func getRollup(t *testing.T) arbbridge.ArbRollup {
-	clnt := ethbridge.NewEthAuthClient(ethclnt, auth)
+	ctx := context.Background()
+	clnt, err := ethbridge.NewEthAuthClient(ctx, ethclnt, auth)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	chainParams := valprotocol.ChainParams{
 		StakeRequirement:        big.NewInt(0),

--- a/packages/arb-validator/chainobserver/arbRollup_test.go
+++ b/packages/arb-validator/chainobserver/arbRollup_test.go
@@ -30,8 +30,9 @@ import (
 
 func TestMoveStake(t *testing.T) {
 	rollup := getRollup(t)
+	ctx := context.Background()
 	_, err := rollup.MoveStake(
-		context.Background(),
+		ctx,
 		[]common.Hash{},
 		[]common.Hash{},
 	)
@@ -40,7 +41,7 @@ func TestMoveStake(t *testing.T) {
 	}
 
 	_, err = rollup.PlaceStake(
-		context.Background(),
+		ctx,
 		big.NewInt(0),
 		[]common.Hash{},
 		[]common.Hash{},
@@ -50,7 +51,7 @@ func TestMoveStake(t *testing.T) {
 	}
 
 	_, err = rollup.MoveStake(
-		context.Background(),
+		ctx,
 		[]common.Hash{},
 		[]common.Hash{},
 	)
@@ -62,8 +63,9 @@ func TestMoveStake(t *testing.T) {
 func TestRecoverStakeOld(t *testing.T) {
 	rollup := getRollup(t)
 
+	ctx := context.Background()
 	_, err := rollup.RecoverStakeOld(
-		context.Background(),
+		ctx,
 		common.Address{},
 		[]common.Hash{},
 	)
@@ -72,7 +74,7 @@ func TestRecoverStakeOld(t *testing.T) {
 	}
 
 	_, err = rollup.PlaceStake(
-		context.Background(),
+		ctx,
 		big.NewInt(0),
 		[]common.Hash{},
 		[]common.Hash{},
@@ -82,7 +84,7 @@ func TestRecoverStakeOld(t *testing.T) {
 	}
 
 	_, err = rollup.RecoverStakeOld(
-		context.Background(),
+		ctx,
 		common.Address{},
 		[]common.Hash{},
 	)
@@ -94,8 +96,9 @@ func TestRecoverStakeOld(t *testing.T) {
 func TestRecoverStake(t *testing.T) {
 	rollup := getRollup(t)
 
+	ctx := context.Background()
 	_, err := rollup.RecoverStakeConfirmed(
-		context.Background(),
+		ctx,
 		[]common.Hash{},
 	)
 	if err == nil {
@@ -103,7 +106,7 @@ func TestRecoverStake(t *testing.T) {
 	}
 
 	_, err = rollup.PlaceStake(
-		context.Background(),
+		ctx,
 		big.NewInt(0),
 		[]common.Hash{},
 		[]common.Hash{},
@@ -113,7 +116,7 @@ func TestRecoverStake(t *testing.T) {
 	}
 
 	_, err = rollup.RecoverStakeConfirmed(
-		context.Background(),
+		ctx,
 		[]common.Hash{},
 	)
 	if err != nil {
@@ -151,7 +154,7 @@ func getRollup(t *testing.T) arbbridge.ArbRollup {
 	}
 
 	rollupAddress, _, err := factory.CreateRollup(
-		context.Background(),
+		ctx,
 		mach.Hash(),
 		chainParams,
 		common.Address{},

--- a/packages/arb-validator/chainobserver/ethbridge_test.go
+++ b/packages/arb-validator/chainobserver/ethbridge_test.go
@@ -52,6 +52,7 @@ var dbPath = "./testdb"
 var rollupTester *ethbridgetestcontracts.RollupTester
 var client *ethutils.SimulatedEthClient
 var auth *bind.TransactOpts
+var ctx context.Context
 
 func ethTransfer(t *testing.T, dest common.Address, amount *big.Int) value.Value {
 	ethData := make([]byte, 0)
@@ -81,7 +82,7 @@ func checkBalance(t *testing.T, ctx context.Context, globalInbox arbbridge.Globa
 
 func TestMain(m *testing.M) {
 	backend, pks := test.SimulatedBackend()
-	ctx := context.Background()
+	ctx = context.Background()
 	client = &ethutils.SimulatedEthClient{SimulatedBackend: backend}
 	auth = bind.NewKeyedTransactor(pks[0])
 	authClient, err := ethbridge.NewEthAuthClient(ctx, client, auth)
@@ -127,7 +128,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestConfirmAssertion(t *testing.T) {
-	ctx := context.Background()
 	authClient, err := ethbridge.NewEthAuthClient(ctx, client, auth)
 	if err != nil {
 		t.Fatal(err)

--- a/packages/arb-validator/chainobserver/ethbridge_test.go
+++ b/packages/arb-validator/chainobserver/ethbridge_test.go
@@ -66,8 +66,8 @@ func ethTransfer(t *testing.T, dest common.Address, amount *big.Int) value.Value
 	return tup
 }
 
-func checkBalance(t *testing.T, globalInbox arbbridge.GlobalInbox, address common.Address, amount *big.Int) {
-	balance, err := globalInbox.GetEthBalance(context.Background(), address)
+func checkBalance(t *testing.T, ctx context.Context, globalInbox arbbridge.GlobalInbox, address common.Address, amount *big.Int) {
+	balance, err := globalInbox.GetEthBalance(ctx, address)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,6 +79,7 @@ func checkBalance(t *testing.T, globalInbox arbbridge.GlobalInbox, address commo
 
 func TestMain(m *testing.M) {
 	clnt, pks := test.SimulatedBackend()
+	ctx := context.Background()
 	ethclnt = &ethutils.SimulatedEthClient{SimulatedBackend: clnt}
 	auth = bind.NewKeyedTransactor(pks[0])
 
@@ -98,7 +99,7 @@ func TestMain(m *testing.M) {
 	}
 
 	_, err = ethbridge.WaitForReceiptWithResults(
-		context.Background(),
+		ctx,
 		ethclnt,
 		auth.From,
 		tx,
@@ -118,6 +119,7 @@ func TestMain(m *testing.M) {
 
 func TestConfirmAssertion(t *testing.T) {
 	clnt := ethbridge.NewEthAuthClient(ethclnt, auth)
+	ctx := context.Background()
 
 	chainParams := valprotocol.ChainParams{
 		StakeRequirement:        big.NewInt(0),
@@ -142,7 +144,7 @@ func TestConfirmAssertion(t *testing.T) {
 	}
 
 	rollupAddress, _, err := factory.CreateRollup(
-		context.Background(),
+		ctx,
 		mach.Hash(),
 		chainParams,
 		common.Address{},
@@ -156,25 +158,25 @@ func TestConfirmAssertion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	inboxAddress, err := rollupContract.InboxAddress(context.Background())
+	inboxAddress, err := rollupContract.InboxAddress(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	globalInbox, err := clnt.NewGlobalInbox(inboxAddress, rollupAddress)
+	globalInbox, err := clnt.NewGlobalInbox(ctx, inboxAddress, rollupAddress)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if err := globalInbox.DepositEthMessage(
-		context.Background(),
+		ctx,
 		common.NewAddressFromEth(auth.From),
 		big.NewInt(100),
 	); err != nil {
 		t.Fatal(err)
 	}
 
-	checkBalance(t, globalInbox, rollupAddress, big.NewInt(100))
+	checkBalance(t, ctx, globalInbox, rollupAddress, big.NewInt(100))
 
 	checkpointer, err := checkpointing.NewIndexedCheckpointer(
 		rollupAddress,
@@ -201,7 +203,7 @@ func TestConfirmAssertion(t *testing.T) {
 	chain.Inbox = &structures.Inbox{MessageStack: structures.NewRandomMessageStack(100)}
 
 	events, err := rollupContract.PlaceStake(
-		context.Background(),
+		ctx,
 		big.NewInt(0),
 		[]common.Hash{},
 		[]common.Hash{},
@@ -210,7 +212,7 @@ func TestConfirmAssertion(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, ev := range events {
-		if err := chain.HandleNotification(context.Background(), ev); err != nil {
+		if err := chain.HandleNotification(ctx, ev); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -229,7 +231,7 @@ func TestConfirmAssertion(t *testing.T) {
 		[]value.Value{},
 	)
 
-	currentBlock, err := clnt.BlockIdForHeight(context.Background(), nil)
+	currentBlock, err := clnt.BlockIdForHeight(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,12 +243,12 @@ func TestConfirmAssertion(t *testing.T) {
 	prepared.Assertion = assertion
 	prepared.AssertionStub = structures.NewExecutionAssertionStubFromWholeAssertion(assertion, chain.calculatedValidNode.VMProtoData().InboxTop, chain.Inbox.MessageStack)
 	var stakerProof []common.Hash
-	events, err = chainlistener.MakeAssertion(context.Background(), rollupContract, prepared, stakerProof)
+	events, err = chainlistener.MakeAssertion(ctx, rollupContract, prepared, stakerProof)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, ev := range events {
-		if err := chain.HandleNotification(context.Background(), ev); err != nil {
+		if err := chain.HandleNotification(ctx, ev); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -262,7 +264,7 @@ func TestConfirmAssertion(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	currentTime, err := clnt.BlockIdForHeight(context.Background(), nil)
+	currentTime, err := clnt.BlockIdForHeight(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -423,16 +425,16 @@ func TestConfirmAssertion(t *testing.T) {
 	if ret.ValidNodeHashes[0] != validNode.Hash() {
 		t.Fatal("wrong node hash")
 	}
-	events, err = rollupContract.Confirm(context.Background(), opp)
+	events, err = rollupContract.Confirm(ctx, opp)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, ev := range events {
-		if err := chain.HandleNotification(context.Background(), ev); err != nil {
+		if err := chain.HandleNotification(ctx, ev); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	checkBalance(t, globalInbox, rollupAddress, big.NewInt(25))
-	checkBalance(t, globalInbox, dest, big.NewInt(75))
+	checkBalance(t, ctx, globalInbox, rollupAddress, big.NewInt(25))
+	checkBalance(t, ctx, globalInbox, dest, big.NewInt(75))
 }

--- a/packages/arb-validator/chainobserver/ethbridge_test.go
+++ b/packages/arb-validator/chainobserver/ethbridge_test.go
@@ -118,8 +118,11 @@ func TestMain(m *testing.M) {
 }
 
 func TestConfirmAssertion(t *testing.T) {
-	clnt := ethbridge.NewEthAuthClient(ethclnt, auth)
 	ctx := context.Background()
+	clnt, err := ethbridge.NewEthAuthClient(ctx, ethclnt, auth)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	chainParams := valprotocol.ChainParams{
 		StakeRequirement:        big.NewInt(0),

--- a/packages/arb-validator/chainobserver/rollupEthBridge_test.go
+++ b/packages/arb-validator/chainobserver/rollupEthBridge_test.go
@@ -64,7 +64,7 @@ func TestMainSetup(m *testing.T) {
 	client.Commit()
 
 	_, err = ethbridge.WaitForReceiptWithResults(
-		context.Background(),
+		ctx,
 		client,
 		auth.From,
 		machineTx,

--- a/packages/arb-validator/chainobserver/rollupEthBridge_test.go
+++ b/packages/arb-validator/chainobserver/rollupEthBridge_test.go
@@ -17,11 +17,9 @@
 package chainobserver
 
 import (
-	"context"
 	"errors"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"log"
 	"math/big"
 	"math/rand"
@@ -37,7 +35,6 @@ import (
 	"github.com/offchainlabs/arbitrum/packages/arb-util/value"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridge"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethbridgetestcontracts"
-	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/test"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/valprotocol"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator/structures"
 )
@@ -45,15 +42,6 @@ import (
 var tester *ethbridgetestcontracts.RollupTester
 
 func TestMainSetup(m *testing.T) {
-	backend, pks := test.SimulatedBackend()
-	ctx := context.Background()
-	client = &ethutils.SimulatedEthClient{SimulatedBackend: backend}
-	auth = bind.NewKeyedTransactor(pks[0])
-	authClient, err := ethbridge.NewEthAuthClient(ctx, client, auth)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	rollupAddr, machineTx, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error) {
 		return ethbridgetestcontracts.DeployRollupTester(auth, client)
 	})
@@ -66,7 +54,7 @@ func TestMainSetup(m *testing.T) {
 	_, err = ethbridge.WaitForReceiptWithResults(
 		ctx,
 		client,
-		auth.From,
+		authClient.Address().ToEthAddress(),
 		machineTx,
 		"deployedMachineTester",
 	)

--- a/packages/arb-validator/challenges/challenges_test.go
+++ b/packages/arb-validator/challenges/challenges_test.go
@@ -55,9 +55,8 @@ func TestChallenges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testerAddress, _, err = authClients[0].MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, error) {
-		addr, tx, _, err := ethbridgetestcontracts.DeployChallengeTester(auth, client, factorAddr)
-		return addr, tx, err
+	testerAddress, _, err = authClients[0].MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error) {
+		return ethbridgetestcontracts.DeployChallengeTester(auth, client, factorAddr)
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/packages/arb-validator/challenges/executionChallenge_test.go
+++ b/packages/arb-validator/challenges/executionChallenge_test.go
@@ -35,7 +35,7 @@ func testExecutionChallenge(t *testing.T, ctx context.Context, client ethutils.E
 
 	testChallengerCatchUp(t, ctx, client, asserterClient, challengerClient, valprotocol.InvalidExecutionChildType, challengeHash, func(challengeAddress common.Address, client *ethbridge.EthArbAuthClient, blockId *common.BlockId) (ChallengeState, error) {
 		return DefendExecutionClaim(
-			context.Background(),
+			ctx,
 			client,
 			challengeAddress,
 			blockId,
@@ -49,7 +49,7 @@ func testExecutionChallenge(t *testing.T, ctx context.Context, client ethutils.E
 		)
 	}, func(challengeAddress common.Address, client *ethbridge.EthArbAuthClient, blockId *common.BlockId) (ChallengeState, error) {
 		return DefendExecutionClaim(
-			context.Background(),
+			ctx,
 			client,
 			challengeAddress,
 			blockId,
@@ -67,7 +67,7 @@ func testExecutionChallenge(t *testing.T, ctx context.Context, client ethutils.E
 		)
 	}, func(challengeAddress common.Address, client *ethbridge.EthArbAuthClient, blockId *common.BlockId) (ChallengeState, error) {
 		return ChallengeExecutionClaim(
-			context.Background(),
+			ctx,
 			client,
 			challengeAddress,
 			blockId,
@@ -81,7 +81,7 @@ func testExecutionChallenge(t *testing.T, ctx context.Context, client ethutils.E
 		)
 	}, func(challengeAddress common.Address, client *ethbridge.EthArbAuthClient, blockId *common.BlockId) (ChallengeState, error) {
 		return ChallengeExecutionClaim(
-			context.Background(),
+			ctx,
 			client,
 			challengeAddress,
 			blockId,

--- a/packages/arb-validator/challenges/inboxTopChallenge_test.go
+++ b/packages/arb-validator/challenges/inboxTopChallenge_test.go
@@ -37,7 +37,7 @@ func testInboxTopChallenge(t *testing.T, ctx context.Context, client ethutils.Et
 
 	testChallenge(t, ctx, client, asserterClient, challengerClient, valprotocol.InvalidInboxTopChildType, challengeHash, func(challengeAddress common.Address, client *ethbridge.EthArbAuthClient, blockId *common.BlockId) (ChallengeState, error) {
 		return DefendInboxTopClaim(
-			context.Background(),
+			ctx,
 			client,
 			challengeAddress,
 			blockId,
@@ -49,7 +49,7 @@ func testInboxTopChallenge(t *testing.T, ctx context.Context, client ethutils.Et
 		)
 	}, func(challengeAddress common.Address, client *ethbridge.EthArbAuthClient, blockId *common.BlockId) (ChallengeState, error) {
 		return ChallengeInboxTopClaim(
-			context.Background(),
+			ctx,
 			client,
 			challengeAddress,
 			blockId,

--- a/packages/arb-validator/challenges/testHelper_test.go
+++ b/packages/arb-validator/challenges/testHelper_test.go
@@ -243,8 +243,15 @@ func getChallengeInfo(
 	challengeHash [32]byte,
 	testerAddress ethcommon.Address,
 ) (*ethbridge.EthArbAuthClient, *ethbridge.EthArbAuthClient, common.Address, *common.BlockId, error) {
-	asserterClient := ethbridge.NewEthAuthClient(client, asserter)
-	challengerClient := ethbridge.NewEthAuthClient(client, challenger)
+	ctx := context.Background()
+	asserterClient, err := ethbridge.NewEthAuthClient(ctx, client, asserter)
+	if err != nil {
+		return nil, nil, common.Address{}, nil, err
+	}
+	challengerClient, err := ethbridge.NewEthAuthClient(ctx, client, challenger)
+	if err != nil {
+		return nil, nil, common.Address{}, nil, err
+	}
 
 	tester, err := ethbridgetestcontracts.NewChallengeTester(testerAddress, client)
 	if err != nil {

--- a/packages/arb-validator/cmd/arb-stressed-validator/arb-stressed-validator.go
+++ b/packages/arb-validator/cmd/arb-stressed-validator/arb-stressed-validator.go
@@ -52,7 +52,7 @@ func main() {
 	}
 }
 
-func createStressedManager(rollupAddress common.Address, client arbbridge.ArbClient, contractFile string, dbPath string) (*rollupmanager.Manager, error) {
+func createStressedManager(ctx context.Context, rollupAddress common.Address, client arbbridge.ArbClient, contractFile string, dbPath string) (*rollupmanager.Manager, error) {
 	return rollupmanager.CreateManager(
 		context.Background(),
 		rollupAddress,

--- a/packages/arb-validator/cmd/arb-stressed-validator/arb-stressed-validator.go
+++ b/packages/arb-validator/cmd/arb-stressed-validator/arb-stressed-validator.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	zerolog "github.com/rs/zerolog/log"
 	"log"
 	"os"
 	"time"
@@ -40,6 +41,7 @@ import (
 func main() {
 	// Enable line numbers in logging
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	zerolog.Logger = zerolog.With().Caller().Logger()
 
 	// Check number of args
 	flag.Parse()

--- a/packages/arb-validator/cmd/arb-stressed-validator/arb-stressed-validator.go
+++ b/packages/arb-validator/cmd/arb-stressed-validator/arb-stressed-validator.go
@@ -56,7 +56,7 @@ func main() {
 
 func createStressedManager(ctx context.Context, rollupAddress common.Address, client arbbridge.ArbClient, contractFile string, dbPath string) (*rollupmanager.Manager, error) {
 	return rollupmanager.CreateManager(
-		context.Background(),
+		ctx,
 		rollupAddress,
 		arbbridge.NewStressTestClient(client, time.Second*10),
 		contractFile,

--- a/packages/arb-validator/cmd/arb-validator/arb-validator.go
+++ b/packages/arb-validator/cmd/arb-validator/arb-validator.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
+	zerolog "github.com/rs/zerolog/log"
 	"log"
 	"math/big"
 	"os"
@@ -43,6 +44,7 @@ import (
 func main() {
 	// Enable line numbers in logging
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	zerolog.Logger = zerolog.With().Caller().Logger()
 
 	// Check number of args
 	flag.Parse()

--- a/packages/arb-validator/cmd/arb-validator/arb-validator.go
+++ b/packages/arb-validator/cmd/arb-validator/arb-validator.go
@@ -101,7 +101,10 @@ func createRollupChain() error {
 	}
 
 	// Rollup creation
-	client := ethbridge.NewEthAuthClient(ethclint, auth)
+	client, err := ethbridge.NewEthAuthClient(ctx, ethclint, auth)
+	if err != nil {
+		return err
+	}
 
 	if err := arbbridge.WaitForBalance(ctx, client, common.Address{}, common.NewAddressFromEth(auth.From)); err != nil {
 		return err

--- a/packages/arb-validator/cmd/arb-validator/arb-validator.go
+++ b/packages/arb-validator/cmd/arb-validator/arb-validator.go
@@ -142,6 +142,6 @@ func createRollupChain() error {
 	return nil
 }
 
-func createManager(rollupAddress common.Address, client arbbridge.ArbClient, contractFile string, dbPath string) (*rollupmanager.Manager, error) {
-	return rollupmanager.CreateManager(context.Background(), rollupAddress, client, contractFile, dbPath)
+func createManager(ctx context.Context, rollupAddress common.Address, client arbbridge.ArbClient, contractFile string, dbPath string) (*rollupmanager.Manager, error) {
+	return rollupmanager.CreateManager(ctx, rollupAddress, client, contractFile, dbPath)
 }

--- a/packages/arb-validator/cmd/evil-arb-validator/evil-arb-validator.go
+++ b/packages/arb-validator/cmd/evil-arb-validator/evil-arb-validator.go
@@ -32,6 +32,8 @@ import (
 	"github.com/offchainlabs/arbitrum/packages/arb-validator/rollupmanager"
 
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
+
+	zerolog "github.com/rs/zerolog/log"
 )
 
 // Launches the rollup validator with the following command line arguments:
@@ -42,6 +44,7 @@ import (
 func main() {
 	// Enable line numbers in logging
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	zerolog.Logger = zerolog.With().Caller().Logger()
 
 	// Check number of args
 	flag.Parse()

--- a/packages/arb-validator/cmd/evil-arb-validator/evil-arb-validator.go
+++ b/packages/arb-validator/cmd/evil-arb-validator/evil-arb-validator.go
@@ -54,7 +54,7 @@ func main() {
 	}
 }
 
-func createEvilManager(rollupAddress common.Address, client arbbridge.ArbClient, contractFile string, dbPath string) (*rollupmanager.Manager, error) {
+func createEvilManager(ctx context.Context, rollupAddress common.Address, client arbbridge.ArbClient, contractFile string, dbPath string) (*rollupmanager.Manager, error) {
 	cp, err := rolluptest.NewEvilRollupCheckpointer(
 		rollupAddress,
 		dbPath,
@@ -65,7 +65,7 @@ func createEvilManager(rollupAddress common.Address, client arbbridge.ArbClient,
 		return nil, err
 	}
 	return rollupmanager.CreateManagerAdvanced(
-		context.Background(),
+		ctx,
 		rollupAddress,
 		true,
 		client,

--- a/packages/arb-validator/cmdhelper/cmdhelper.go
+++ b/packages/arb-validator/cmdhelper/cmdhelper.go
@@ -41,6 +41,7 @@ var ContractName = "contract.mexe"
 func ValidateRollupChain(
 	execName string,
 	managerCreationFunc func(
+		ctx context.Context,
 		rollupAddress common.Address,
 		client arbbridge.ArbClient,
 		contractFile string, dbPath string,
@@ -121,6 +122,7 @@ func ValidateRollupChain(
 	dbPath := filepath.Join(rollupArgs.ValidatorFolder, "checkpoint_db")
 
 	manager, err := managerCreationFunc(
+		ctx,
 		rollupArgs.Address,
 		client,
 		contractFile,
@@ -144,6 +146,7 @@ func ValidateRollupChain(
 func ObserveRollupChain(
 	execName string,
 	managerCreationFunc func(
+		ctx context.Context,
 		rollupAddress common.Address,
 		client arbbridge.ArbClient,
 		contractFile string, dbPath string,
@@ -183,6 +186,7 @@ func ObserveRollupChain(
 	dbPath := filepath.Join(rollupArgs.ValidatorFolder, "checkpoint_db")
 
 	manager, err := managerCreationFunc(
+		ctx,
 		rollupArgs.Address,
 		client,
 		contractFile,

--- a/packages/arb-validator/cmdhelper/cmdhelper.go
+++ b/packages/arb-validator/cmdhelper/cmdhelper.go
@@ -88,7 +88,10 @@ func ValidateRollupChain(
 	if err != nil {
 		return err
 	}
-	client := ethbridge.NewEthAuthClient(ethclint, auth)
+	client, err := ethbridge.NewEthAuthClient(ctx, ethclint, auth)
+	if err != nil {
+		return err
+	}
 
 	rollup, err := client.NewRollup(rollupArgs.Address)
 	if err != nil {

--- a/packages/arb-validator/ethbridgemachine/machine_test.go
+++ b/packages/arb-validator/ethbridgemachine/machine_test.go
@@ -57,7 +57,7 @@ func getTester(t *testing.T) *ethbridgetestcontracts.MachineTester {
 	client.Commit()
 
 	_, err = ethbridge.WaitForReceiptWithResults(
-		context.Background(),
+		ctx,
 		client,
 		auth.From,
 		machineTx,

--- a/packages/arb-validator/ethbridgemachine/proofmachine_test.go
+++ b/packages/arb-validator/ethbridgemachine/proofmachine_test.go
@@ -39,6 +39,8 @@ import (
 func runTestValidateProof(t *testing.T, contract string, osp *ethbridgecontracts.OneStepProof) {
 	t.Log("proof test contact: ", contract)
 
+	ctx := context.Background()
+
 	proofs, err := generateProofCases(contract)
 	if err != nil {
 		t.Fatal(err)
@@ -72,7 +74,7 @@ func runTestValidateProof(t *testing.T, contract string, osp *ethbridgecontracts
 
 			if proof.Message != nil {
 				machineData, err = osp.ExecuteStepWithMessage(
-					&bind.CallOpts{Context: context.Background()},
+					&bind.CallOpts{Context: ctx},
 					proof.Assertion.AfterInboxHash,
 					proof.Assertion.FirstMessageHash,
 					proof.Assertion.FirstLogHash,
@@ -86,7 +88,7 @@ func runTestValidateProof(t *testing.T, contract string, osp *ethbridgecontracts
 				)
 			} else {
 				machineData, err = osp.ExecuteStep(
-					&bind.CallOpts{Context: context.Background()},
+					&bind.CallOpts{Context: ctx},
 					proof.Assertion.AfterInboxHash,
 					proof.Assertion.FirstMessageHash,
 					proof.Assertion.FirstLogHash,

--- a/packages/arb-validator/go.mod
+++ b/packages/arb-validator/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/offchainlabs/arbitrum/packages/arb-util v0.7.3
 	github.com/offchainlabs/arbitrum/packages/arb-validator-core v0.7.3
 	github.com/pkg/errors v0.9.1
+	github.com/rs/zerolog v1.20.0
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/packages/arb-validator/go.sum
+++ b/packages/arb-validator/go.sum
@@ -49,6 +49,7 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -215,6 +216,9 @@ github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00 h1:8DPul/X0IT/1TNMIxoKLwde
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 h1:3hxavr+IHMsQBrYUPQM5v0CgENFktkkbg1sfpgM3h20=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubrpZHtQLnOf6EwhN2hEMusxZOhcW9H3UQ=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.20.0 h1:38k9hgtUBdxFwE34yS8rTHmHBa4eN16E4DJlv177LNs=
+github.com/rs/zerolog v1.20.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil v2.20.5+incompatible h1:tYH07UPoQt0OCQdgWWMgYHy3/a9bcxNpBIysykNIP7I=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
@@ -308,6 +312,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/packages/arb-validator/structures/ethbridge_test.go
+++ b/packages/arb-validator/structures/ethbridge_test.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/offchainlabs/arbitrum/packages/arb-validator-core/ethutils"
 	"log"
 	"math/big"
@@ -36,18 +38,21 @@ import (
 var tester *ethbridgetestcontracts.RollupTester
 
 func TestMainSetup(m *testing.T) {
-	clnt, pks := test.SimulatedBackend()
-	client := &ethutils.SimulatedEthClient{SimulatedBackend: clnt}
+	backend, pks := test.SimulatedBackend()
+	ctx := context.Background()
+	client := &ethutils.SimulatedEthClient{SimulatedBackend: backend}
 	auth := bind.NewKeyedTransactor(pks[0])
-
-	_, machineTx, deployedArbRollup, err := ethbridgetestcontracts.DeployRollupTester(
-		auth,
-		client,
-	)
+	authClient, err := ethbridge.NewEthAuthClient(ctx, client, auth)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	rollupAddr, machineTx, err := authClient.MakeContract(ctx, func(auth *bind.TransactOpts) (ethcommon.Address, *types.Transaction, interface{}, error) {
+		return ethbridgetestcontracts.DeployRollupTester(auth, client)
+	})
+
 	client.Commit()
+
 	_, err = ethbridge.WaitForReceiptWithResults(
 		context.Background(),
 		client,
@@ -59,7 +64,7 @@ func TestMainSetup(m *testing.T) {
 		log.Fatal(err)
 	}
 
-	tester = deployedArbRollup
+	tester, err = ethbridgetestcontracts.NewRollupTester(rollupAddr, client)
 }
 
 func TestGenerateLastMessageHash(t *testing.T) {

--- a/packages/arb-validator/structures/ethbridge_test.go
+++ b/packages/arb-validator/structures/ethbridge_test.go
@@ -54,7 +54,7 @@ func TestMainSetup(m *testing.T) {
 	client.Commit()
 
 	_, err = ethbridge.WaitForReceiptWithResults(
-		context.Background(),
+		ctx,
 		client,
 		auth.From,
 		machineTx,

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -120,7 +120,7 @@ func setupValidators(
 		manager.AddListener(ctx, &chainlistener.AnnouncerListener{Prefix: "validator " + client.Address().String() + ": "})
 
 		validatorListener := chainlistener.NewValidatorChainListener(
-			context.Background(),
+			ctx,
 			rollupAddress,
 			rollupActor,
 		)
@@ -245,7 +245,8 @@ func TestFib(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rollupAddress, err := setupRollup(context.Background(), l1Client, bind.NewKeyedTransactor(pks[2]))
+	ctx := context.Background()
+	rollupAddress, err := setupRollup(ctx, l1Client, bind.NewKeyedTransactor(pks[2]))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -351,7 +352,7 @@ Loop:
 		filter := &bind.FilterOpts{
 			Start:   start,
 			End:     nil,
-			Context: context.Background(),
+			Context: ctx,
 		}
 
 		it, err := session.Contract.FilterTestEvent(filter)

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -216,7 +216,7 @@ func TestFib(t *testing.T) {
 	l1Client := &ethutils.SimulatedEthClient{SimulatedBackend: l1Backend}
 
 	// pks[0]:     setupRollup     (L1)
-	// pks[1,2,3]: setupValidators (L1)
+	// pks[1,2]:   setupValidators (L1)
 
 	// pks[4]:     launchAggregator            (not tied to client)
 	// pks[5]:     DeployFibonacci and session (L2, not tied to client)
@@ -224,7 +224,7 @@ func TestFib(t *testing.T) {
 	auths := make([]*bind.TransactOpts, 0)
 	authClients := make([]*ethbridge.EthArbAuthClient, 0)
 	// 0-3 are on L1
-	for _, pk := range pks[0:4] {
+	for _, pk := range pks[0:3] {
 		auth := bind.NewKeyedTransactor(pk)
 		auths = append(auths, auth)
 
@@ -262,7 +262,7 @@ func TestFib(t *testing.T) {
 
 	t.Log("Created rollup chain", rollupAddress)
 
-	if err := setupValidators(ctx, rollupAddress, l1Client, authClients[1:4]); err != nil {
+	if err := setupValidators(ctx, rollupAddress, l1Client, authClients[1:3]); err != nil {
 		t.Fatalf("Validator setup error %v", err)
 	}
 

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -218,8 +218,8 @@ func TestFib(t *testing.T) {
 	// pks[0]:     setupRollup     (L1)
 	// pks[1,2]:   setupValidators (L1)
 
-	// pks[4]:     launchAggregator            (not tied to client)
-	// pks[5]:     DeployFibonacci and session (L2, not tied to client)
+	// pks[3]:     launchAggregator            (not tied to client)
+	// pks[4]:     DeployFibonacci and session (L2, not tied to client)
 
 	auths := make([]*bind.TransactOpts, 0)
 	authClients := make([]*ethbridge.EthArbAuthClient, 0)
@@ -234,11 +234,11 @@ func TestFib(t *testing.T) {
 		}
 		authClients = append(authClients, authClient)
 	}
-	// 4 just uses auth, authClient created inside launchAggregator
-	auths = append(auths, bind.NewKeyedTransactor(pks[4]))
+	// 3 just uses auth, authClient created inside launchAggregator
+	auths = append(auths, bind.NewKeyedTransactor(pks[3]))
 
-	// 5 is on L2, doesn't use ethbridge
-	auths = append(auths, bind.NewKeyedTransactor(pks[5]))
+	// 4 is on L2, doesn't use ethbridge
+	auths = append(auths, bind.NewKeyedTransactor(pks[4]))
 
 	go func() {
 		t := time.NewTicker(time.Second * 2)
@@ -268,7 +268,7 @@ func TestFib(t *testing.T) {
 
 	if err := launchAggregator(
 		l1Client,
-		auths[4],
+		auths[3],
 		rollupAddress,
 	); err != nil {
 		t.Fatal(err)
@@ -281,7 +281,7 @@ func TestFib(t *testing.T) {
 
 	t.Log("Connected to aggregator")
 
-	_, tx, _, err := arbostestcontracts.DeployFibonacci(auths[5], l2Client)
+	_, tx, _, err := arbostestcontracts.DeployFibonacci(auths[4], l2Client)
 	if err != nil {
 		t.Fatal("DeployFibonacci failed", err)
 	}
@@ -309,10 +309,10 @@ func TestFib(t *testing.T) {
 	session := &arbostestcontracts.FibonacciSession{
 		Contract: fib,
 		CallOpts: bind.CallOpts{
-			From:    auths[5].From,
+			From:    auths[4].From,
 			Pending: true,
 		},
-		TransactOpts: *auths[5],
+		TransactOpts: *auths[4],
 	}
 
 	fibsize := 15

--- a/tests/fibgo/connection_test.go
+++ b/tests/fibgo/connection_test.go
@@ -44,17 +44,17 @@ func setupRollup(ctx context.Context, client ethutils.EthClient, auth *bind.Tran
 		ArbGasSpeedLimitPerTick: 200000,
 	}
 
-	factoryAddr, err := ethbridge.DeployRollupFactory(auth, client)
+	authClient, err := ethbridge.NewEthAuthClient(ctx, client, auth)
 	if err != nil {
 		return common.Address{}, err
 	}
 
-	arbClient, err := ethbridge.NewEthAuthClient(ctx, client, auth)
+	factoryAddr, err := ethbridge.DeployRollupFactory(ctx, authClient, client)
 	if err != nil {
 		return common.Address{}, err
 	}
 
-	factory, err := arbClient.NewArbFactory(common.NewAddressFromEth(factoryAddr))
+	factory, err := authClient.NewArbFactory(common.NewAddressFromEth(factoryAddr))
 	if err != nil {
 		return common.Address{}, err
 	}


### PR DESCRIPTION
Parity nodes do not count pending transactions when eth_getTransactionCount is called, so to ensure consistent behavior regardless of which type of ethereum node is used, it is easiest to manage Nonce client side.