### PR TITLE
Parsing fix

### DIFF
--- a/packages/arb-avm-cpp/avm_values/src/buffer.cpp
+++ b/packages/arb-avm-cpp/avm_values/src/buffer.cpp
@@ -142,7 +142,7 @@ std::vector<RawBuffer> RawBuffer::serialize(std::vector<unsigned char>& value_ve
     if (level == 0) {
         value_vector.push_back(1);
         for (uint64_t i = 0; i < LEAF_SIZE; i++) {
-            if (leaf->size() < i) value_vector.push_back(0);
+            if (leaf->size() <= i) value_vector.push_back(0);
             else value_vector.push_back((*leaf)[i]);
         }
     }

--- a/packages/arb-avm-cpp/avm_values/src/vmValueParser.cpp
+++ b/packages/arb-avm-cpp/avm_values/src/vmValueParser.cpp
@@ -56,6 +56,14 @@ RawBuffer buffer_value_from_json(const nlohmann::json& buffer_json) {
         for (auto& item : leaf_data) {
             data->push_back(item.get<uint8_t>());
         }
+        if (data->size() > LEAF_SIZE) {
+            auto res = RawBuffer();
+            for (uint64_t i = 0; i < data->size(); i++) {
+                res = res.set(i, (*data)[i]);
+            }
+            return res;
+        }
+        data->resize(LEAF_SIZE, 0);
         return {std::move(data)};
     } else if (elem_json.contains(BUF_NODE_LABEL)) {
         auto& node_data = elem_json[BUF_NODE_LABEL];


### PR DESCRIPTION
Currently all the leafs should be the same size (1024 bytes). This can be changed if there is some way to get better performance otherwise.