### PR TITLE
fix doc and demo code of "L2 message batch"

### DIFF
--- a/docs/ArbOS_Formats.md
+++ b/docs/ArbOS_Formats.md
@@ -143,7 +143,7 @@ An L2 message consists of:
 
 **Subtype 3: L2 message batch** has subtype-specific data consisting of a sequence of one or more items, where each item consists of:
 
-- L2 message length (64-bit uint)
+- L2 message length (RLP-encoded uint)
 - L2 message (byte array)
 
 The L2 messages in a batch will be separated, and treated as if each had arrived separately, in the order in which they appear in the batch.

--- a/packages/arb-provider-ethers/package.json
+++ b/packages/arb-provider-ethers/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "@types/promise-poller": "^1.7.0",
     "jayson": "^3.2.0",
-    "promise-poller": "^1.9.1"
+    "promise-poller": "^1.9.1",
+    "rlp": "^2.2.6"
   },
   "peerDependencies": {
     "ethers": "~4.0.47"

--- a/packages/arb-provider-ethers/src/lib/message.ts
+++ b/packages/arb-provider-ethers/src/lib/message.ts
@@ -18,7 +18,12 @@
 
 import * as ArbValue from './value'
 import * as ethers from 'ethers'
-import { decode as RLPDecode, Input as RLPInput, Decoded as RLPDecoded, encode as RLPEncode } from 'rlp'
+import {
+  decode as RLPDecode,
+  Input as RLPInput,
+  Decoded as RLPDecoded,
+  encode as RLPEncode,
+} from 'rlp'
 
 function hex32(val: ethers.utils.BigNumber): Uint8Array {
   return ethers.utils.padZeros(ethers.utils.arrayify(val), 32)
@@ -172,7 +177,9 @@ export class L2Batch {
     const messages: L2Message[] = []
     while (bytes.length > 0) {
       const decoded = RLPDecode(bytes as RLPInput, true) as RLPDecoded
-      const lengthData = ethers.utils.bigNumberify(decoded.data as Buffer).toNumber()
+      const lengthData = ethers.utils
+        .bigNumberify(decoded.data as Buffer)
+        .toNumber()
       bytes = decoded.remainder
       messages.push(L2Message.fromData(bytes.slice(0, lengthData)))
       bytes = bytes.slice(lengthData)


### PR DESCRIPTION
The first field of "L2 message batch" should be RLP-encoded according to 
https://github.com/OffchainLabs/arbitrum/blob/master/packages/arb-evm/message/l2Message.go#L570

but the doc and demo code said it is a plain uint. I fixed them in this PR.
