### PR TITLE
Update GlobalInbox interface in docs

### DIFF
--- a/docs/Ethereum_Interoperability.md
+++ b/docs/Ethereum_Interoperability.md
@@ -24,15 +24,15 @@ In order to programmatically trigger transfers, call one of the following method
 function depositEthMessage(address chain, address to) external payable;
 function depositERC20Message(
         address chain,
-        address to,
         address erc20,
+        address to,
         uint256 value
     )
         external;
 function depositERC721Message(
         address chain,
-        address to,
         address erc721,
+        address to,
         uint256 id
     )
         external;


### PR DESCRIPTION
Looks like the [GlobalInbox contracts](https://github.com/OffchainLabs/arbitrum/blob/master/packages/arb-bridge-eth/contracts/inbox/GlobalInbox.sol) got updated but the [docs](https://developer.offchainlabs.com/docs/ethereum_interoperability) were not updated to reflect that change.

This fixes the interface for GlobalInbox in the docs.