### PR TITLE
Include extra data in deposit

### DIFF
--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/ArbTokenBridge.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/ArbTokenBridge.sol
@@ -89,6 +89,7 @@ contract ArbTokenBridge is CloneFactory {
         address l1ERC20,
         address account,
         uint256 amount,
+        bytes calldata extraData,
         uint8 decimals
     ) external onlyEthPair {
         IArbToken token = ensureERC777TokenExists(l1ERC20, decimals);
@@ -102,7 +103,7 @@ contract ArbTokenBridge is CloneFactory {
         uint8 decimals
     ) external onlyEthPair {
         IArbToken token = ensureERC20TokenExists(l1ERC20, decimals);
-        token.bridgeMint(account, amount);
+        token.bridgeMint(account, amount, '');
     }
 
     function mintCustomtokenFromL1(

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/IArbToken.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/IArbToken.sol
@@ -25,7 +25,7 @@ interface IArbToken {
         uint8 _decimals
     ) external;
 
-    function bridgeMint(address account, uint256 amount) external;
+    function bridgeMint(address account, uint256 amount, bytes calldata extraData) external;
 
     function withdraw(address destination, uint256 amount) external;
 

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/StandardArbERC20.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/StandardArbERC20.sol
@@ -52,7 +52,7 @@ contract StandardArbERC20 is OZERC20, Cloneable, IArbToken {
         }
     }
 
-    function bridgeMint(address account, uint256 amount) external override onlyBridge {
+    function bridgeMint(address account, uint256 amount, bytes calldata) external override onlyBridge {
         _mint(account, amount);
     }
 
@@ -61,8 +61,8 @@ contract StandardArbERC20 is OZERC20, Cloneable, IArbToken {
         bridge.withdraw(l1Address, destination, amount);
     }
 
-    function migrate(uint256 amount, address target) external {
+    function migrate(uint256 amount, address target, bytes calldata extraData) external {
         _burn(msg.sender, amount);
-        bridge.migrate(l1Address, target, msg.sender, amount);
+        bridge.migrate(l1Address, target, msg.sender, amount, extraData);
     }
 }

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/EthERC20Bridge.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/EthERC20Bridge.sol
@@ -147,6 +147,7 @@ contract EthERC20Bridge is L1Buddy {
         address erc20,
         address destination,
         uint256 amount,
+        bytes calldata extraData,
         uint256 maxGas,
         uint256 gasPriceBid,
         StandardTokenType tokenType


### PR DESCRIPTION
This PR takes advantage of the data field in the ERC777 standard, allowing extra data to be included in the deposit transaction and passed to the recipient on L2.

For example, imagine a user would like to deposit a token in the L1 bridge, and stake it in a contract on L2. They can call deposit on L1, with the recipient being the L2 staking contract field. In the data field, they can include data about which account should be associated with the "staking"