### PR TITLE
Fix setbuffer8 bounds checking

### DIFF
--- a/packages/arb-avm-cpp/avm/src/machinestate/machineoperation.cpp
+++ b/packages/arb-avm-cpp/avm/src/machinestate/machineoperation.cpp
@@ -1084,6 +1084,9 @@ void setbuffer8(MachineState& m) {
     m.stack.prepForMod(3);
     auto offset = assumeInt64(assumeInt(m.stack[0]));
     auto val_int = assumeInt(m.stack[1]);
+    if (val_int > std::numeric_limits<uint8_t>::max()) {
+        throw int_out_of_bounds{};
+    }
     auto val = static_cast<uint8_t>(val_int);
     Buffer& md = assumeBuffer(m.stack[2]);
     auto res = md.set(offset, val);


### PR DESCRIPTION
In #757 I missed that the C++ setbuffer8 impl didn't have bounds checking on the value. Bounds checking on the offset is already done with the assumeInt64 (since this is a single byte no extra bytes are needed).