### PR TITLE
Ensure ArbStorage stays alive while ArbCore is on the Go side

### DIFF
--- a/packages/arb-avm-cpp/cmachine/arbcore.go
+++ b/packages/arb-avm-cpp/cmachine/arbcore.go
@@ -27,24 +27,28 @@ package cmachine
 import "C"
 import (
 	"bytes"
+	"math/big"
+	"unsafe"
+
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/core"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/inbox"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/value"
-	"math/big"
-	"unsafe"
 
 	"github.com/pkg/errors"
 )
 
 type ArbCore struct {
-	c unsafe.Pointer
+	c       unsafe.Pointer
+	storage *ArbStorage
 }
 
-func NewArbCore(c unsafe.Pointer) *ArbCore {
+func NewArbCore(c unsafe.Pointer, storage *ArbStorage) *ArbCore {
 	// ArbCore has same lifetime as ArbStorage, no need to have finalizer
-	return &ArbCore{c: c}
+	// Keeping a reference to ArbStorage makes sure that ArbCore isn't
+	// destroyed too early, as ArbStorage owns ArbCore, not this struct
+	return &ArbCore{c: c, storage: storage}
 }
 
 func (ac *ArbCore) StartThread() bool {

--- a/packages/arb-avm-cpp/cmachine/storage.go
+++ b/packages/arb-avm-cpp/cmachine/storage.go
@@ -26,10 +26,11 @@ package cmachine
 */
 import "C"
 import (
-	"github.com/offchainlabs/arbitrum/packages/arb-util/core"
-	"github.com/pkg/errors"
 	"runtime"
 	"unsafe"
+
+	"github.com/offchainlabs/arbitrum/packages/arb-util/core"
+	"github.com/pkg/errors"
 
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/machine"
@@ -109,7 +110,7 @@ func (s *ArbStorage) DeleteCheckpoint(machineHash common.Hash) bool {
 
 func (s *ArbStorage) GetArbCore() core.ArbCore {
 	ac := C.createArbCore(s.c)
-	return NewArbCore(ac)
+	return NewArbCore(ac, s)
 }
 
 func (s *ArbStorage) GetAggregatorStore() *AggregatorStore {


### PR DESCRIPTION
This is important as the C++ ArbStorage owns ArbCore, the Go struct just has a weak pointer.