### PR TITLE
Allow L2 token addresses to be calculated on L1

### DIFF
--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/ArbTokenBridge.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/ArbTokenBridge.sol
@@ -44,9 +44,9 @@ contract ArbTokenBridge is CloneFactory {
         _;
     }
 
-    constructor() public {
-        templateERC20 = new StandardArbERC20();
-        templateERC777 = new StandardArbERC777();
+    constructor(address _templateERC20, address _templateERC777) public {
+        templateERC20 = ICloneable(_templateERC20);
+        templateERC777 = ICloneable(_templateERC777);
     }
 
     function mintERC777FromL1(


### PR DESCRIPTION
Some L1 contracts may need to know the address of a corresponding token on L2.

Since we use Create2 to deploy the tokens on L2, we can easily calculate the address in L1.

This PR also means that the L2 template contracts must be manually deployed on L2 before the bridge is set up. Aside from allowing this calculation, it also means that the L1 bridge contract isn't larger than the contract size limit.