### PR TITLE
Change single param Tuple constructors to factories

### DIFF
--- a/packages/arb-avm-cpp/avm_values/src/tuple.cpp
+++ b/packages/arb-avm-cpp/avm_values/src/tuple.cpp
@@ -20,8 +20,33 @@
 
 #include <iostream>
 
-Tuple::Tuple(value val) : tpl(TuplePool::get_impl().getResource(1)) {
-    tpl->data.push_back(std::move(val));
+Tuple Tuple::createSizedTuple(size_t size) {
+    if (size == 0) {
+        return {};
+    }
+
+    auto tpl = TuplePool::get_impl().getResource(size);
+    tpl->data.resize(size);
+
+    return Tuple(std::move(tpl));
+}
+
+Tuple Tuple::createTuple(std::vector<value> values) {
+    if (!values.empty() && values.size() > 8) {
+        return {};
+    }
+
+    auto tpl = TuplePool::get_impl().getResource(values.size());
+    tpl->data.insert(tpl->data.end(), values.begin(), values.end());
+
+    return Tuple(std::move(tpl));
+}
+
+Tuple Tuple::createTuple(value val) {
+    auto tpl = TuplePool::get_impl().getResource(1);
+    tpl->data.emplace_back(std::move(val));
+
+    return Tuple(std::move(tpl));
 }
 
 Tuple::Tuple(value val1, value val2)
@@ -105,15 +130,6 @@ Tuple::Tuple(value val1,
     tpl->data.push_back(std::move(val8));
 }
 
-Tuple::Tuple(std::vector<value> values) {
-    if (!values.empty() && values.size() < 9) {
-        tpl = TuplePool::get_impl().getResource(values.size());
-        for (auto& val : values) {
-            tpl->data.push_back(std::move(val));
-        }
-    }
-}
-
 constexpr uint64_t hash_size = 32;
 
 // BasicValChecker checks to see whether a value can be hashed without
@@ -132,7 +148,7 @@ struct BasicValChecker {
 };
 
 HashPreImage calcHashPreImage(const Tuple& tup) {
-    std::array<unsigned char, 1 + 8 * 32> tupData;
+    std::array<unsigned char, 1 + 8 * 32> tupData{};
     uint256_t size = 1;
 
     tupData[0] = tup.tuple_size();
@@ -148,7 +164,7 @@ HashPreImage calcHashPreImage(const Tuple& tup) {
     auto hash_val = ethash::keccak256(
         tupData.data(),
         static_cast<unsigned int>(1 + hash_size * (tup.tuple_size())));
-    std::array<unsigned char, 32> hashData;
+    std::array<unsigned char, 32> hashData{};
     std::copy(&hash_val.bytes[0], &hash_val.bytes[32], hashData.begin());
 
     return HashPreImage{hashData, size};
@@ -180,12 +196,12 @@ void Tuple::calculateHashPreImage() const {
 }
 
 HashPreImage zeroPreimage() {
-    std::array<unsigned char, 1> tupData;
+    std::array<unsigned char, 1> tupData{};
     tupData[0] = 0;
 
     auto hash_val = ethash::keccak256(tupData.data(), 1);
 
-    std::array<unsigned char, 32> hashData;
+    std::array<unsigned char, 32> hashData{};
     std::copy(&hash_val.bytes[0], &hash_val.bytes[32], hashData.begin());
 
     return HashPreImage(hashData, 1);

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/datacursor.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/datacursor.hpp
@@ -39,8 +39,7 @@ class DataCursor {
    public:
     std::atomic<status_enum> status{EMPTY};
 
-    // Mutex is acquired by core thread when reorg is occurring.
-    // Other threads should acquire mutex whenever accessing below data.
+    // All threads should acquire mutex before modifying any of the below fields
     std::mutex reorg_mutex;
     uint256_t pending_total_count;
     uint256_t current_total_count;

--- a/packages/arb-avm-cpp/data_storage/src/value/value.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/value/value.cpp
@@ -208,8 +208,8 @@ std::vector<value> serializeValue(
             ret.push_back(nested);
         } else {
             auto res = serializeValue(nested, value_vector, segment_counts);
-            for (size_t i = 0; i < res.size(); i++) {
-                ret.push_back(res[i]);
+            for (const auto& re : res) {
+                ret.push_back(re);
             }
         }
     }
@@ -229,8 +229,9 @@ std::vector<value> serializeValue(const Buffer& b,
     int len = 0;
     parseBuffer<ParsedBufVal>((char*)value_vector.data() + l1, len);
     std::vector<value> ret{};
-    for (size_t i = 0; i < res.size(); i++) {
-        ret.emplace_back(Buffer(res[i]));
+    ret.reserve(res.size());
+    for (auto& re : res) {
+        ret.emplace_back(Buffer(re));
     }
     return ret;
 }
@@ -274,8 +275,8 @@ void deleteParsedValue(const std::vector<ParsedTupVal>& tup,
             vals_to_delete.push_back(std::get<ValueHash>(val).hash);
         } else if (std::holds_alternative<ParsedBuffer>(val)) {
             auto parsed = std::get<ParsedBuffer>(val);
-            for (const auto& val : parsed.nodes) {
-                vals_to_delete.push_back(val);
+            for (const auto& val2 : parsed.nodes) {
+                vals_to_delete.push_back(val2);
             }
         }
     }
@@ -457,7 +458,8 @@ GetResults processVal(const Transaction&,
                       uint32_t reference_count,
                       ValueCache&) {
     // Add empty tuple to stack, will be filled in as values are processed
-    val_stack.emplace_back(Tuple(val.size()), reference_count);
+    val_stack.emplace_back(Tuple::createSizedTuple(val.size()),
+                           reference_count);
 
     // Fill new vector with list of elements that will populate tuple
     val_stack.back().raw_vals.insert(val_stack.back().raw_vals.end(),

--- a/packages/arb-avm-cpp/tests/buffer.cpp
+++ b/packages/arb-avm-cpp/tests/buffer.cpp
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-#include "helper.hpp"
-
 #include <data_storage/storageresult.hpp>
-#include <data_storage/value/value.hpp>
 
 #include <avm/machinestate/datastack.hpp>
 
@@ -25,7 +22,11 @@
 
 #include <ethash/keccak.hpp>
 
-uint256_t hash_buffer_aux(uint8_t* buf, int offset, int sz, bool pack, bool &zero) {
+uint256_t hash_buffer_aux(uint8_t* buf,
+                          int offset,
+                          int sz,
+                          bool pack,
+                          bool& zero) {
     if (sz == 32) {
         auto hash_val = ethash::keccak256(buf + offset, 32);
         auto res = intx::be::load<uint256_t>(hash_val);
@@ -88,13 +89,10 @@ TEST_CASE("Buffer") {
     }
 
     SECTION("hashing with single zeroes") {
-        const int SIZE = 1024*32;
+        const int SIZE = 1024 * 32;
         for (int j = 0; j < 1024; j++) {
-            uint8_t arr[SIZE];
-            for (int i = 0; i < SIZE; i++) {
-                arr[i] = 0;
-            }
-            arr[j*32] = 123;
+            uint8_t arr[SIZE] = {};
+            arr[j * 32] = 123;
             REQUIRE(hash_buffer(arr, 0, SIZE) == hash_acc(arr, SIZE));
         }
     }

--- a/packages/arb-avm-cpp/tests/checkpoint.cpp
+++ b/packages/arb-avm-cpp/tests/checkpoint.cpp
@@ -23,8 +23,6 @@
 
 #include <avm/machine.hpp>
 
-#include <avm_values/vmValueParser.hpp>
-
 #define CATCH_CONFIG_ENABLE_BENCHMARKING 1
 #include <catch2/catch.hpp>
 
@@ -90,7 +88,7 @@ TEST_CASE("Save value") {
 
     SECTION("save 1 num tuple") {
         uint256_t num = 1;
-        auto tuple = Tuple(num);
+        auto tuple = Tuple::createTuple(num);
         saveValue(*transaction, tuple, 1, true);
     }
     SECTION("save num") {
@@ -110,19 +108,19 @@ TEST_CASE("Save tuple") {
 
     SECTION("save 1 num tuple") {
         uint256_t num = 1;
-        auto tuple = Tuple(num);
+        auto tuple = Tuple::createTuple(num);
         saveValue(*transaction, tuple, 1, true);
     }
     SECTION("save 2, 1 num tuples") {
         uint256_t num = 1;
-        auto tuple = Tuple(num);
+        auto tuple = Tuple::createTuple(num);
         saveValue(*transaction, tuple, 1, true);
         saveValue(*transaction, tuple, 2, true);
     }
     SECTION("saved tuple in tuple") {
         uint256_t num = 1;
-        value inner_tuple = Tuple(num);
-        auto tuple = Tuple(inner_tuple);
+        value inner_tuple = Tuple::createTuple(num);
+        auto tuple = Tuple::createTuple(inner_tuple);
         saveValue(*transaction, tuple, 1, true);
         saveValue(*transaction, tuple, 2, true);
     }
@@ -164,28 +162,28 @@ TEST_CASE("Save and get tuple values") {
 
     SECTION("save num tuple") {
         uint256_t num = 1;
-        auto tuple = Tuple(num);
+        auto tuple = Tuple::createTuple(num);
         saveValue(*transaction, tuple, 1, true);
         std::vector<uint256_t> hashes{hash(num)};
         getTupleValues(*transaction, hash(tuple), hashes, value_cache);
     }
     SECTION("save codepoint tuple") {
         CodePointStub code_point_stub({0, 1}, 654546);
-        auto tuple = Tuple(code_point_stub);
+        auto tuple = Tuple::createTuple(code_point_stub);
         saveValue(*transaction, tuple, 1, true);
         std::vector<uint256_t> hashes{hash(code_point_stub)};
         getTupleValues(*transaction, hash(tuple), hashes, value_cache);
     }
     SECTION("save codepoint tuple") {
         CodePointStub code_point_stub({0, 1}, 654546);
-        auto tuple = Tuple(code_point_stub);
+        auto tuple = Tuple::createTuple(code_point_stub);
         saveValue(*transaction, tuple, 1, true);
         std::vector<uint256_t> hashes{hash(code_point_stub)};
         getTupleValues(*transaction, hash(tuple), hashes, value_cache);
     }
     SECTION("save nested tuple") {
         value inner_tuple = Tuple();
-        value tuple = Tuple(inner_tuple);
+        value tuple = Tuple::createTuple(inner_tuple);
         saveValue(*transaction, tuple, 1, true);
         std::vector<uint256_t> hashes{hash_value(inner_tuple)};
         getTupleValues(*transaction, hash_value(tuple), hashes, value_cache);
@@ -220,14 +218,14 @@ TEST_CASE("Save And Get Tuple") {
 
     SECTION("save 1 num tuple") {
         uint256_t num = 1;
-        auto tuple = Tuple(num);
+        auto tuple = Tuple::createTuple(num);
         saveValue(*transaction, tuple, 1, true);
         getTuple(*transaction, tuple, 1, true, value_cache);
     }
     SECTION("save codepoint in tuple") {
         value_cache.clear();
         CodePointStub code_point_stub({0, 1}, 654546);
-        auto tuple = Tuple(code_point_stub);
+        auto tuple = Tuple::createTuple(code_point_stub);
         saveValue(*transaction, tuple, 1, true);
         getTuple(*transaction, tuple, 1, true, value_cache);
     }
@@ -235,7 +233,7 @@ TEST_CASE("Save And Get Tuple") {
         value_cache.clear();
         auto transaction2 = storage.makeTransaction();
         uint256_t num = 1;
-        auto tuple = Tuple(num);
+        auto tuple = Tuple::createTuple(num);
         saveValue(*transaction, tuple, 1, true);
         saveValue(*transaction2, tuple, 2, true);
         getTuple(*transaction, tuple, 2, true, value_cache);
@@ -255,8 +253,8 @@ TEST_CASE("Save And Get Tuple") {
     SECTION("save tuple in tuple") {
         value_cache.clear();
         uint256_t num = 1;
-        auto inner_tuple = Tuple(num);
-        auto tuple = Tuple(value(inner_tuple));
+        auto inner_tuple = Tuple::createTuple(num);
+        auto tuple = Tuple::createTuple(inner_tuple);
         REQUIRE(hash(tuple) != hash(inner_tuple));
         saveValue(*transaction, tuple, 1, true);
         getTuple(*transaction, tuple, 1, true, value_cache);
@@ -265,9 +263,9 @@ TEST_CASE("Save And Get Tuple") {
     SECTION("save 2 tuples in tuple") {
         value_cache.clear();
         uint256_t num = 1;
-        value inner_tuple = Tuple(num);
+        value inner_tuple = Tuple::createTuple(num);
         uint256_t num2 = 2;
-        value inner_tuple2 = Tuple(num2);
+        value inner_tuple2 = Tuple::createTuple(num2);
         auto tuple = Tuple(inner_tuple, inner_tuple2);
         saveValue(*transaction, tuple, 1, true);
         getTuple(*transaction, tuple, 1, true, value_cache);
@@ -278,8 +276,8 @@ TEST_CASE("Save And Get Tuple") {
         value_cache.clear();
         auto transaction2 = storage.makeTransaction();
         uint256_t num = 1;
-        value inner_tuple = Tuple(num);
-        value tuple = Tuple(inner_tuple);
+        value inner_tuple = Tuple::createTuple(num);
+        value tuple = Tuple::createTuple(inner_tuple);
         saveValue(*transaction, inner_tuple, 1, true);
         getTuple(*transaction, inner_tuple, 1, true, value_cache);
         saveValue(*transaction, tuple, 1, true);
@@ -299,9 +297,9 @@ TEST_CASE("Checkpoint Benchmark") {
     ArbStorage storage(dbpath);
     auto transaction = storage.makeTransaction();
     uint256_t num = 1;
-    value tuple = Tuple(num);
+    value tuple = Tuple::createTuple(num);
     for (uint64_t i = 1; i < 100000; i++) {
-        tuple = Tuple(tuple);
+        tuple = Tuple::createTuple(tuple);
     }
     saveValue(*transaction, tuple);
     ValueCache value_cache{};

--- a/packages/arb-avm-cpp/tests/datastack.cpp
+++ b/packages/arb-avm-cpp/tests/datastack.cpp
@@ -134,7 +134,7 @@ TEST_CASE("Initialize datastack") {
     SECTION("push num, tuple") {
         CodePointStub code_point_stub{{0, 0}, 3452345};
         uint256_t num = 1;
-        auto tuple = Tuple(code_point_stub);
+        auto tuple = Tuple::createTuple(code_point_stub);
         data_stack.push(num);
         data_stack.push(tuple);
         auto tuple_ret = data_stack.getTupleRepresentation();
@@ -146,7 +146,7 @@ TEST_CASE("Initialize datastack") {
     SECTION("push codepoint, tuple") {
         CodePointStub code_point_stub{{0, 0}, 3452345};
         uint256_t num = 1;
-        auto tuple = Tuple(num);
+        auto tuple = Tuple::createTuple(num);
         data_stack.push(code_point_stub);
         data_stack.push(tuple);
         auto tuple_ret = data_stack.getTupleRepresentation();
@@ -166,7 +166,7 @@ TEST_CASE("Save datastack") {
     SECTION("save with values") {
         uint256_t num = 1;
         uint256_t intVal = 5435;
-        auto tuple = Tuple(intVal);
+        auto tuple = Tuple::createTuple(intVal);
         datastack.push(num);
         datastack.push(tuple);
         Tuple tup0;
@@ -177,7 +177,7 @@ TEST_CASE("Save datastack") {
     SECTION("save with values, twice") {
         uint256_t num = 1;
         uint256_t intVal = 5435;
-        auto tuple = Tuple(intVal);
+        auto tuple = Tuple::createTuple(intVal);
         datastack.push(num);
         datastack.push(tuple);
         Tuple tup0;
@@ -196,7 +196,7 @@ TEST_CASE("Save and get datastack") {
         uint256_t intVal = 5435;
         auto transaction = storage.makeTransaction();
         uint256_t num = 1;
-        auto tuple = Tuple(intVal);
+        auto tuple = Tuple::createTuple(intVal);
         datastack.push(num);
         datastack.push(tuple);
         Tuple tup0;
@@ -208,7 +208,7 @@ TEST_CASE("Save and get datastack") {
         uint256_t intVal = 5435;
         auto transaction = storage.makeTransaction();
         uint256_t num = 1;
-        auto tuple = Tuple(intVal);
+        auto tuple = Tuple::createTuple(intVal);
         datastack.push(num);
         datastack.push(tuple);
         Tuple tup0;


### PR DESCRIPTION
There were multiple single parameter overloaded Tuple constructors that have already caused a few problems. 