### PR TITLE
update launch-geth args to fix cmd run failure

### DIFF
--- a/packages/arb-bridge-eth/scripts/launch-geth
+++ b/packages/arb-bridge-eth/scripts/launch-geth
@@ -10,8 +10,8 @@ docker run -d -it --rm -p 7545:7545 -p 7546:7546 \
        --networkid=44010 \
        --rpc --rpcaddr 0.0.0.0 --rpcport 7545 --rpccorsdomain="*" --rpcvhosts=* \
        --rpcapi 'personal,db,eth,net,web3,txpool,miner' \
-       --ws --wsaddr 0.0.0.0 --wsport 7546 --wsorigins '*' \
-       --wsapi personal,admin,db,eth,net,web3,miner,shh,txpool,debug \
+       --ws --ws.addr 0.0.0.0 --ws.port 7546 --ws.origins '*' \
+       --ws.api personal,admin,db,eth,net,web3,miner,shh,txpool,debug \
        --gcmode=archive
 while ! nc -z localhost 7545; do sleep 2; done;
 echo "Finished waiting for geth on localhost:7545..."


### PR DESCRIPTION
Before this fix, when I ran `yarn docker:geth` as specified in https://developer.offchainlabs.com/docs/local_blockchain, the command failed with the following stacktrace:

`yarn run v1.13.0
$ yarn workspace arb-bridge-eth docker:geth
$ rm -rf deployments/parity && ./scripts/launch-geth
c54c860a7bf65464ea33cf03a5ef01b49722ad52fa0a152d2b9ce57dce97102f
Connection to localhost port 7545 [tcp/nta-us] succeeded!
Finished waiting for geth on localhost:7545...
$ /Users/dhanush/Documents/GitHub/arbitrum/packages/arb-bridge-eth/node_modules/.bin/buidler deploy --network parity --export bridge_eth_addresses.json
Prepending SPDX License Identifier to 0 sources: Apache-2.0
All contracts have already been compiled, skipping compilation.
failed to get chainId, falling back on net_version...
Error BDLR109: Cannot connect to the network parity.
Please make sure your node is running, and check your internet connection and networks config

For more info go to https://buidler.dev/BDLR109 or run Buidler with --show-stack-traces
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: No such container: arb-bridge-eth-geth
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 1
Command: /Users/dhanush/.nvm/versions/node/v10.15.1/bin/node
Arguments: /Users/dhanush/.nvm/versions/node/v10.15.1/lib/node_modules/yarn/lib/cli.js docker:geth
Directory: /Users/dhanush/Documents/GitHub/arbitrum/packages/arb-bridge-eth
Output:

info Visit https://yarnpkg.com/en/docs/cli/workspace for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.`