### PR TITLE
Add safer erc20 information handling

### DIFF
--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/ArbTokenBridge.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/ArbTokenBridge.sol
@@ -40,7 +40,6 @@ interface ITransferReceiver {
 
 contract ArbTokenBridge is CloneFactory {
     using Address for address;
-    using BytesParser for bytes;
 
     /// @notice This mapping is from L1 address to L2 address
     mapping(address => address) public customToken;
@@ -208,9 +207,9 @@ contract ArbTokenBridge is CloneFactory {
         bytes calldata _symbol,
         bytes calldata _decimals
     ) external onlyEthPair {
-        string memory name = _name.toString("");
-        string memory symbol = _symbol.toString("");
-        uint8 decimals = _decimals.toDecimals(18);
+        string memory name = BytesParserWithDefault.toString(_name, "");
+        string memory symbol = BytesParserWithDefault.toString(_symbol, "");
+        uint8 decimals = BytesParserWithDefault.toUint8(_decimals, 18);
 
         IArbToken token = ensureERC777TokenExists(l1ERC20, decimals);
         token.updateInfo(name, symbol);
@@ -222,9 +221,9 @@ contract ArbTokenBridge is CloneFactory {
         bytes calldata _symbol,
         bytes calldata _decimals
     ) external onlyEthPair {
-        string memory name = _name.toString("");
-        string memory symbol = _symbol.toString("");
-        uint8 decimals = _decimals.toDecimals(18);
+        string memory name = BytesParserWithDefault.toString(_name, "");
+        string memory symbol = BytesParserWithDefault.toString(_symbol, "");
+        uint8 decimals = BytesParserWithDefault.toUint8(_decimals, 18);
 
         IArbToken token = ensureERC20TokenExists(l1ERC20, decimals);
         token.updateInfo(name, symbol);

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/ArbTokenBridge.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/ArbTokenBridge.sol
@@ -28,6 +28,7 @@ import "arb-bridge-eth/contracts/libraries/ICloneable.sol";
 import "arbos-contracts/arbos/builtin/ArbSys.sol";
 
 import "../ethereum/EthERC20Bridge.sol";
+import "../libraries/BytesParser.sol";
 
 interface ITransferReceiver {
     function onTokenTransfer(
@@ -39,6 +40,7 @@ interface ITransferReceiver {
 
 contract ArbTokenBridge is CloneFactory {
     using Address for address;
+    using BytesParser for bytes;
 
     /// @notice This mapping is from L1 address to L2 address
     mapping(address => address) public customToken;
@@ -202,20 +204,28 @@ contract ArbTokenBridge is CloneFactory {
 
     function updateERC777TokenInfo(
         address l1ERC20,
-        string calldata name,
-        string calldata symbol,
-        uint8 decimals
+        bytes calldata _name,
+        bytes calldata _symbol,
+        bytes calldata _decimals
     ) external onlyEthPair {
+        string memory name = _name.toString("");
+        string memory symbol = _symbol.toString("");
+        uint8 decimals = _decimals.toDecimals(18);
+
         IArbToken token = ensureERC777TokenExists(l1ERC20, decimals);
         token.updateInfo(name, symbol);
     }
 
     function updateERC20TokenInfo(
         address l1ERC20,
-        string calldata name,
-        string calldata symbol,
-        uint8 decimals
+        bytes calldata _name,
+        bytes calldata _symbol,
+        bytes calldata _decimals
     ) external onlyEthPair {
+        string memory name = _name.toString("");
+        string memory symbol = _symbol.toString("");
+        uint8 decimals = _decimals.toDecimals(18);
+
         IArbToken token = ensureERC20TokenExists(l1ERC20, decimals);
         token.updateInfo(name, symbol);
     }

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/EthERC20Bridge.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/EthERC20Bridge.sol
@@ -93,7 +93,7 @@ contract EthERC20Bridge is L1Buddy {
         bytes memory deployCode =
             abi.encodePacked(
                 type(ArbTokenBridge).creationCode,
-                abi.encode(address(this), _l2TemplateERC20, _l2TemplateERC777)
+                abi.encode(address(this), _l2TemplateERC777, _l2TemplateERC20)
             );
 
         // TODO: this stores the creation code in state, but we don't actually need that

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/EthERC20Bridge.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/EthERC20Bridge.sol
@@ -49,9 +49,9 @@ contract EthERC20Bridge is L1Buddy {
     event UpdateTokenInfo(
         uint256 indexed seqNum,
         address indexed l1Address,
-        string name,
-        string symbol,
-        uint8 decimals
+        bytes name,
+        bytes symbol,
+        bytes decimals
     );
 
     event DepositERC20(
@@ -185,6 +185,14 @@ contract EthERC20Bridge is L1Buddy {
         }
     }
 
+    function callStatic(
+        address targetContract,
+        bytes4 targetFunction
+    ) internal returns (bytes memory) {
+        (bool success, bytes memory res) = targetContract.staticcall(abi.encodeWithSelector(targetFunction));
+        return res;
+    }
+
     function updateTokenInfo(
         address erc20,
         bool isERC20,
@@ -192,15 +200,9 @@ contract EthERC20Bridge is L1Buddy {
         uint256 maxGas,
         uint256 gasPriceBid
     ) external payable onlyIfConnected returns (uint256) {
-        string memory name = "";
-        string memory symbol = "";
-        try ERC20(erc20).name() returns (string memory _name) {
-            name = _name;
-        } catch {}
-        try ERC20(erc20).symbol() returns (string memory _symbol) {
-            symbol = _symbol;
-        } catch {}
-        uint8 decimals = ERC20(erc20).decimals();
+        bytes memory name = callStatic(erc20, ERC20.name.selector);
+        bytes memory symbol = callStatic(erc20, ERC20.symbol.selector);
+        bytes memory decimals = callStatic(erc20, ERC20.decimals.selector);
 
         bytes memory data =
             abi.encodeWithSelector(

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/BytesParser.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/BytesParser.sol
@@ -18,9 +18,9 @@
 
 pragma solidity ^0.6.11;
 
-library BytesParser {
+library BytesParserWithDefault {
 
-    function toDecimals(bytes memory input, uint8 defaultValue) internal pure returns (uint8) {
+    function toUint8(bytes memory input, uint8 defaultValue) internal pure returns (uint8) {
         if(input.length == 0) {
             return defaultValue;
         } else {

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/BytesParser.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/BytesParser.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pragma solidity ^0.6.11;
+
+library BytesParser {
+
+    function toDecimals(bytes memory input, uint8 defaultValue) internal pure returns (uint8) {
+        if(input.length == 0) {
+            return defaultValue;
+        } else {
+            // TODO: try catch to handle error
+            return abi.decode(input, (uint8));
+        }
+    }
+
+    function toString(bytes memory input, string memory defaultValue) internal pure returns (string memory) {
+        if(input.length == 0) {
+            return defaultValue;
+        } else if (input.length == 32) {
+            // TODO: remove padding and parse ascii
+            return string(input);
+        } else {
+            // TODO: try catch to handle error
+            return abi.decode(input, (string));
+        }
+    }
+}


### PR DESCRIPTION
Tokens such as MKR have `name` and `symbol` encoded as `bytes32`. Not all tokens implement `decimals`, with this approach  we handle the parsing logic on the L2