### PR TITLE
remove update:abi from arb-ts post-install

### DIFF
--- a/packages/arb-ts/package.json
+++ b/packages/arb-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arb-ts",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Typescript library client-side interactions with Arbitrum",
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",
@@ -27,8 +27,7 @@
     "lint": "eslint .",
     "format": "prettier './**/*.{js,json,md,ts,yml}' --write && yarn run lint --fix",
     "update:abi": "./scripts/update-abi && yarn format",
-    "test:integration": "yarn run mocha integration_test/arb-bridge.test.ts --timeout 150000",
-    "postinstall": "yarn update:abi"
+    "test:integration": "yarn run mocha integration_test/arb-bridge.test.ts --timeout 150000"
   },
   "dependencies": {
     "@ethersproject/address": "^5.0.8",


### PR DESCRIPTION
triggers a build fail, + we clearly need to figure out a better solution anyway, so removing it from post-install for now