### PR TITLE
Delay the validator after making a transaction

### DIFF
--- a/packages/arb-node-core/staker/staker.go
+++ b/packages/arb-node-core/staker/staker.go
@@ -75,13 +75,7 @@ func (s *Staker) RunInBackground(ctx context.Context) chan bool {
 			} else {
 				backoff = time.Second
 			}
-			if tx != nil {
-				// We did something, there's probably something else to do
-				<-time.After(time.Second)
-			} else {
-				// Nothing to do for now
-				<-time.After(time.Minute)
-			}
+			<-time.After(time.Minute)
 		}
 	}()
 	return done


### PR DESCRIPTION
With only a second of delay, the node often wouldn't see the results of its own transaction before its next action.