### PR TITLE
Fix issue with empty logscursor after reorg

### DIFF
--- a/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
@@ -1993,6 +1993,12 @@ rocksdb::Status ArbCore::handleLogsCursorReorg(size_t cursor_index,
         }
     }
 
+    if (logs_cursors[cursor_index].status == DataCursor::READY &&
+        logs_cursors[cursor_index].data.empty() &&
+        logs_cursors[cursor_index].deleted_data.empty()) {
+        logs_cursors[cursor_index].status = DataCursor::REQUESTED;
+    }
+
     return tx.commit();
 }
 


### PR DESCRIPTION
When a reorg happens and logscursor had waiting logs before reorg, but no new logs or deleted logs after reorg, should be switched back to REQUESTED so that error state is not entered.