### PR TITLE
Enable local Arbitrum on MacOS

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -85,7 +85,7 @@ For most users we recommend that you run Arbitrum through our easy docker setup.
 #### MacOS
 
 ```bash
-brew install autoconf automake boost cmake gmp go libtool rocksdb
+brew install autoconf automake boost cmake gmp go libtool rocksdb openssl
 ```
 
 #### Ubuntu 18.04

--- a/docs/Local_Blockchain.md
+++ b/docs/Local_Blockchain.md
@@ -4,38 +4,47 @@ title: Running on Local Blockchain
 sidebar_label: Local Blockchain
 ---
 
-## Launching a Local Blockchain
+## Basics
 
-To build a docker image hosting a local test blockchain docker image with Arbitrum smart contracts already deployed, run:
+To run Arbitrum locally, you need several things:
+
+* A local Ethereum blockchain (the L1)
+* A set of Arbitrum smart contracts deployed on that L1
+* The Arbitrum blockchain itself (the L2)
+* And, something that interacts with the L1 and the L2, in this case, one or more Arbitrum validators.   
+
+## Launching a Local Ethereum Blockchain (the L1)
+
+To *build* a docker image hosting a local Geth blockchain with Arbitrum smart contracts (the `eth-bridge`) already deployed, run:
 
 ```bash
 yarn docker:build:geth
 ```
 
-To start the local blockchain inside the Arbitrum monorepo, run:
+To *start* this local Geth, run:
 
 ```bash
 yarn docker:geth
 ```
 
-Note that stopping and restarting the client will lose all blockchain state.
+Note that stopping and restarting the client will lose all blockchain state. At this point, you should see typical Geth INFO updates scrolling in your terminal. Geth is now happy running at localhost:7545.  
 
-## Launching the chain
+## Configuring your local Arbitrum chain (the L2)
 
-To set up a local rollup chain using the Arbitrum geth docker image with 1 or more validators, run the following from the root arbitrum repo.
+To set up a local rollup chain using the Arbitrum geth docker image you created above with 1 or more validators, open a second terminal window and run the following from the root arbitrum repo:
 
 ```bash
 yarn demo:initialize [--validatorcount N=1]
 ```
 
-Running the `demo:initialize` command will perform two main tasks 1) Launch an Arbitrum Rollup chain on the local testnet 2) Create a `validator-states` folder. This folder contains pre-seeded wallets for the created validators which are prepared for launch. It serves as a lightweight simulation of an enviroment where the validators are running on multiple machines.
+This command will fail if Geth is not up yet and/or if there were problems with the Hardhat deployment of all the bridge smart contracts. Specifically, you will not have `bridge_eth_addresses.json`, and thus, your L2 will not be able to talk to the bridge on the L1. Running `demo:initialize` will *configure* an Arbitrum L2 rollup on your local machine - see the contents of `/rollups/local/` for more information on what `demo:initialize` sets up. Among other things, this folder contains pre-seeded wallets for the created validators which are prepared for launch. It serves as a lightweight simulation of an enviroment where the validators are running on multiple machines.
 
-## Deploying your validators
+## Firing up the Arbitrum L2 and Deploying your validator(s)
 
-To launch a set of docker images containing your validators, run:
+To *launch* the L2 node and run the validators, run:
 
 ```bash
 yarn demo:deploy
 ```
 
-Unlike the blockchain docker image, the validators can be stopped and restarted without losing any state.
+Unlike the blockchain docker image, the validators can be stopped and restarted without losing any state. At this point, you will have a local Geth running in your first terminal window, and `arbitrum_arb-validator1_1` and `arbitrum_arb-node_1` in terminal two. You can now watch the L1, the L2, and the validator(s) interact and execute a variety of predefined transactions. 

--- a/packages/arb-avm-cpp/CMakeLists.txt
+++ b/packages/arb-avm-cpp/CMakeLists.txt
@@ -61,6 +61,25 @@ option(AVM_BUILD_TESTING "Build tests" ON)
 find_package(Threads REQUIRED)
 find_package(GMP REQUIRED)
 find_package(GMPXX REQUIRED)
+
+# On macOS, search Homebrew for keg-only versions of OpenSSL
+if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+    execute_process(
+        COMMAND brew --prefix OpenSSL 
+        RESULT_VARIABLE BREW_OPENSSL
+        OUTPUT_VARIABLE BREW_OPENSSL_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (BREW_OPENSSL EQUAL 0 AND EXISTS "${BREW_OPENSSL_PREFIX}")
+        message(STATUS "Found OpenSSL keg installed by Homebrew at ${BREW_OPENSSL_PREFIX}")
+        set(OPENSSL_ROOT_DIR "${BREW_OPENSSL_PREFIX}/")
+        set(OPENSSL_INCLUDE_DIR "${BREW_OPENSSL_PREFIX}/include")
+        set(OPENSSL_LIBRARIES "${BREW_OPENSSL_PREFIX}/lib")
+        set(OPENSSL_CRYPTO_LIBRARY "${BREW_OPENSSL_PREFIX}/lib/libcrypto.dylib")
+        set(OPENSSL_SSL_LIBRARY (ADVANCED) "${BREW_OPENSSL_PREFIX}/lib/libssl.dylib")
+    endif()
+endif()
+
 find_package(Boost 1.65 COMPONENTS filesystem system REQUIRED)
 if(NOT TARGET Boost::boost)
     add_library(Boost::boost IMPORTED INTERFACE)

--- a/packages/arb-provider-ethers/src/lib/client.ts
+++ b/packages/arb-provider-ethers/src/lib/client.ts
@@ -111,6 +111,7 @@ export class ArbClient {
           } else if (error) {
             reject(error)
           } else {
+            if (result.transactionHash === undefined) return
             resolve(result.transactionHash)
           }
         }
@@ -130,6 +131,7 @@ export class ArbClient {
           } else if (error) {
             reject(error)
           } else {
+            if (result.height === undefined) return
             resolve(result.height)
           }
         }
@@ -150,6 +152,7 @@ export class ArbClient {
             } else if (error) {
               reject(error)
             } else {
+              if (result === undefined) return
               resolve(result)
             }
           }
@@ -261,6 +264,7 @@ export class ArbClient {
           } else if (error) {
             reject(error)
           } else {
+            if (result.logs === undefined) return
             resolve(result.logs)
           }
         }
@@ -280,6 +284,7 @@ export class ArbClient {
           } else if (error) {
             reject(error)
           } else {
+            if (result.chainAddress === undefined) return
             resolve(result.chainAddress)
           }
         }
@@ -287,3 +292,4 @@ export class ArbClient {
     })
   }
 }
+


### PR DESCRIPTION
Installation of Arbitrum currently fails on a fresh MacOS install. This PR updates slightly outdated documentation (`Local_blockchain.md`) and fixes some tiny little things that new Arbitrum users might encounter when locally deploying. With these changes, v0.8.0 should work right out of the box on MacOS.