### PR TITLE
Track nonce locally

### DIFF
--- a/packages/arb-node-core/challenge/common_test.go
+++ b/packages/arb-node-core/challenge/common_test.go
@@ -173,6 +173,7 @@ func initializeChallengeTest(
 	asserterTime *big.Int,
 	challengerTime *big.Int,
 ) (*ethutils.SimulatedEthClient, *ethbridgetestcontracts.ChallengeTester, *ethbridge.ValidatorWallet, *ethbridge.ValidatorWallet, ethcommon.Address) {
+	ctx := context.Background()
 	clnt, pks := test.SimulatedBackend()
 	deployer := bind.NewKeyedTransactor(pks[0])
 	asserter := bind.NewKeyedTransactor(pks[1])
@@ -195,10 +196,14 @@ func initializeChallengeTest(
 	challengerWalletAddress, _, _, err := ethbridgecontracts.DeployValidator(challenger, client)
 	test.FailIfError(t, err)
 
-	asserterWallet, err := ethbridge.NewValidator(asserterWalletAddress, ethcommon.Address{}, client, ethbridge.NewTransactAuth(asserter))
+	asserterAuth, err := ethbridge.NewTransactAuth(ctx, client, asserter)
+	test.FailIfError(t, err)
+	asserterWallet, err := ethbridge.NewValidator(asserterWalletAddress, ethcommon.Address{}, client, asserterAuth)
 	test.FailIfError(t, err)
 
-	challengerWallet, err := ethbridge.NewValidator(challengerWalletAddress, ethcommon.Address{}, client, ethbridge.NewTransactAuth(challenger))
+	challengerAuth, err := ethbridge.NewTransactAuth(ctx, client, challenger)
+	test.FailIfError(t, err)
+	challengerWallet, err := ethbridge.NewValidator(challengerWalletAddress, ethcommon.Address{}, client, challengerAuth)
 	test.FailIfError(t, err)
 
 	_, err = tester.StartChallenge(

--- a/packages/arb-node-core/cmd/arb-validator/arb-validator.go
+++ b/packages/arb-node-core/cmd/arb-validator/arb-validator.go
@@ -190,7 +190,11 @@ func main() {
 		logger.Fatal().Msg("Error starting ArbCore thread")
 	}
 
-	val, err := ethbridge.NewValidator(validatorAddress, rollupAddr, client, ethbridge.NewTransactAuth(auth))
+	valAuth, err := ethbridge.NewTransactAuth(ctx, client, auth)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("Error creating connecting to chain")
+	}
+	val, err := ethbridge.NewValidator(validatorAddress, rollupAddr, client, valAuth)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Error creating validator wallet")
 	}

--- a/packages/arb-node-core/staker/staker_test.go
+++ b/packages/arb-node-core/staker/staker_test.go
@@ -158,10 +158,14 @@ func runStakersTest(t *testing.T, faultConfig challenge.FaultConfig, maxGasPerNo
 
 	client.Commit()
 
-	val, err := ethbridge.NewValidator(validatorAddress, rollupAddr, client, ethbridge.NewTransactAuth(auth))
+	valAuth, err := ethbridge.NewTransactAuth(ctx, client, auth)
+	test.FailIfError(t, err)
+	val, err := ethbridge.NewValidator(validatorAddress, rollupAddr, client, valAuth)
 	test.FailIfError(t, err)
 
-	val2, err := ethbridge.NewValidator(validatorAddress2, rollupAddr, client, ethbridge.NewTransactAuth(auth2))
+	val2Auth, err := ethbridge.NewTransactAuth(ctx, client, auth2)
+	test.FailIfError(t, err)
+	val2, err := ethbridge.NewValidator(validatorAddress2, rollupAddr, client, val2Auth)
 	test.FailIfError(t, err)
 
 	core, shutdown := test.PrepareArbCore(t, []inbox.InboxMessage{})

--- a/packages/arb-rpc-node/rpc/launch.go
+++ b/packages/arb-rpc-node/rpc/launch.go
@@ -81,14 +81,20 @@ func LaunchNode(
 		}
 		batch = batcher.NewForwarder(forwardClient)
 	case StatelessBatcherMode:
-		auth := ethbridge.NewTransactAuth(batcherMode.Auth)
+		auth, err := ethbridge.NewTransactAuth(ctx, client, batcherMode.Auth)
+		if err != nil {
+			return err
+		}
 		inbox, err := ethbridge.NewStandardInbox(batcherMode.InboxAddress.ToEthAddress(), client, auth)
 		if err != nil {
 			return err
 		}
 		batch = batcher.NewStatelessBatcher(ctx, db, l2ChainID, client, inbox, maxBatchTime)
 	case StatefulBatcherMode:
-		auth := ethbridge.NewTransactAuth(batcherMode.Auth)
+		auth, err := ethbridge.NewTransactAuth(ctx, client, batcherMode.Auth)
+		if err != nil {
+			return err
+		}
 		inbox, err := ethbridge.NewStandardInbox(batcherMode.InboxAddress.ToEthAddress(), client, auth)
 		if err != nil {
 			return err


### PR DESCRIPTION
Track nonce locally instead of relying on remote node to report the correct nonce