### PR TITLE
Update CMakelists to support MacOS compile

### DIFF
--- a/packages/arb-avm-cpp/CMakeLists.txt
+++ b/packages/arb-avm-cpp/CMakeLists.txt
@@ -61,6 +61,25 @@ option(AVM_BUILD_TESTING "Build tests" ON)
 find_package(Threads REQUIRED)
 find_package(GMP REQUIRED)
 find_package(GMPXX REQUIRED)
+
+# On macOS, search Homebrew for keg-only versions of OpenSSL
+ if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+     execute_process(
+         COMMAND brew --prefix OpenSSL 
+         RESULT_VARIABLE BREW_OPENSSL
+         OUTPUT_VARIABLE BREW_OPENSSL_PREFIX
+         OUTPUT_STRIP_TRAILING_WHITESPACE
+     )
+     if (BREW_OPENSSL EQUAL 0 AND EXISTS "${BREW_OPENSSL_PREFIX}")
+         message(STATUS "Found OpenSSL keg installed by Homebrew at ${BREW_OPENSSL_PREFIX}")
+         set(OPENSSL_ROOT_DIR "${BREW_OPENSSL_PREFIX}/")
+         set(OPENSSL_INCLUDE_DIR "${BREW_OPENSSL_PREFIX}/include")
+         set(OPENSSL_LIBRARIES "${BREW_OPENSSL_PREFIX}/lib")
+         set(OPENSSL_CRYPTO_LIBRARY "${BREW_OPENSSL_PREFIX}/lib/libcrypto.dylib")
+         set(OPENSSL_SSL_LIBRARY (ADVANCED) "${BREW_OPENSSL_PREFIX}/lib/libssl.dylib")
+     endif()
+ endif()
+
 find_package(Boost 1.65 COMPONENTS filesystem system REQUIRED)
 if(NOT TARGET Boost::boost)
     add_library(Boost::boost IMPORTED INTERFACE)


### PR DESCRIPTION
Import the change that jliphardt contributed to master, so Arbitrum compiles out-of-the-box on MacOS