### PR TITLE
Nodehealth improvements

### DIFF
--- a/packages/arb-node-core/cmd/arb-validator/arb-validator.go
+++ b/packages/arb-node-core/cmd/arb-validator/arb-validator.go
@@ -98,6 +98,18 @@ func main() {
 	walletFlags := cmdhelp.AddWalletFlags(flagSet)
 	enablePProf := flagSet.Bool("pprof", false, "enable profiling server")
 	gethLogLevel, arbLogLevel := cmdhelp.AddLogFlags(flagSet)
+
+	//Healthcheck Config
+	disablePrimaryCheck := flagSet.Bool("disable-primary-check", true, "disable checking the health of the primary")
+	disableOpenEthereumCheck := flagSet.Bool("disable-openethereum-check", false, "disable checking the health of the OpenEthereum node")
+	healthcheckMetrics := flagSet.Bool("metrics", false, "enable prometheus endpoint")
+	healthcheckRPC := flagSet.String("healthcheck-rpc", "", "address to bind the healthcheck RPC to")
+
+	healthChan <- nodehealth.Log{Config: true, Var: "healthcheckMetrics", ValBool: *healthcheckMetrics}
+	healthChan <- nodehealth.Log{Config: true, Var: "disablePrimaryCheck", ValBool: *disablePrimaryCheck}
+	healthChan <- nodehealth.Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: *disableOpenEthereumCheck}
+	healthChan <- nodehealth.Log{Config: true, Var: "healthcheckRPC", ValStr: *healthcheckRPC}
+
 	if err := flagSet.Parse(os.Args[6:]); err != nil {
 		logger.Fatal().Err(err).Msg("failed parsing command line arguments")
 	}
@@ -115,6 +127,7 @@ func main() {
 	folder := os.Args[1]
 
 	healthChan <- nodehealth.Log{Config: true, Var: "openethereumHealthcheckRPC", ValStr: os.Args[2]}
+	nodehealth.Init(healthChan)
 
 	client, err := ethutils.NewRPCEthClient(os.Args[2])
 	if err != nil {

--- a/packages/arb-node-core/nodehealth/nodehealth.go
+++ b/packages/arb-node-core/nodehealth/nodehealth.go
@@ -1,10 +1,16 @@
 package nodehealth
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"math/big"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -15,7 +21,11 @@ import (
 
 //Configuration struct
 type configStruct struct {
-	mu                             sync.Mutex
+	//Mutex for config struct
+	mu sync.Mutex
+
+	//Aggregator Healthcheck Config
+	//Rate to poll the remote APIs at
 	pollingRate                    time.Duration
 	loopDelayTimer                 time.Duration
 	healthcheckRPC                 string
@@ -25,6 +35,198 @@ type configStruct struct {
 	primaryHealthcheckRPCPort      string
 	successCode                    int
 	blockDifferenceTolerance       int64
+
+	//OpenEthereum Healthcheck Config
+	//Address to the OpenEthereum API
+	openethereumAPI string
+	//Maximum time to wait for http requests
+	requestTimeout time.Duration
+	//Number of blocks OpenEthereum's current block can be away from the
+	//estimated current block before a healthcheck error is triggered
+	blockSyncDifference int64
+	//Minimum number of peers that can be connected to OpenEthereum
+	//without a healthcheck error being triggered
+	peerMinimum int
+	//Maximum time OpenEthereum can take to change its current block
+	//before a healthcheck error is triggered
+	blockUpdateTimeout time.Duration
+	//Debug variable to print the responses from the OpenEthereum API
+	printRequests bool
+	//Debug variable to print the status of the configuration load
+	printConfigMsg                  bool
+	openEthereumInternalCheckEnable bool
+	openEthereumCheckSet            bool
+}
+
+// Default configuration values for the healthcheck server
+func newConfig() *configStruct {
+	config := configStruct{}
+	//Global configuration
+	const healthcheckRPC = ""
+
+	//Node health configuration
+	const defaultSuccessCode = 200
+	const defaultBlockDifferenceTolerance = 2
+	const defaultPollingRate = 10 * time.Second
+	const loopDelayTimer = 1 * time.Second
+	const defaultHealthCheckPort = "8080"
+
+	//OpenEthereum health configuration
+	const requestTimeout = 10 * time.Second
+	const blockSyncDifference = 10
+	const peerMinimum = 1
+	const blockUpdateTimeout = 45 * time.Second
+	const printRequests = false
+	const printConfigMsg = false
+	const openEthereumInternalCheckEnable = false
+	const openEthereumCheckSet = false
+
+	config.healthcheckRPC = healthcheckRPC
+	config.openethereumHealthcheckRPCPort = defaultHealthCheckPort
+	config.primaryHealthcheckRPCPort = defaultHealthCheckPort
+	config.pollingRate = defaultPollingRate
+	config.loopDelayTimer = loopDelayTimer
+	config.openethereumHealthcheckRPC = ""
+	config.primaryHealthcheckRPC = ""
+	config.successCode = defaultSuccessCode
+	config.blockDifferenceTolerance = defaultBlockDifferenceTolerance
+
+	config.openethereumAPI = ""
+	config.requestTimeout = requestTimeout
+	config.blockDifferenceTolerance = blockSyncDifference
+	config.peerMinimum = peerMinimum
+	config.blockUpdateTimeout = blockUpdateTimeout
+	config.printRequests = printRequests
+	config.printConfigMsg = printConfigMsg
+	config.openEthereumInternalCheckEnable = openEthereumInternalCheckEnable
+	config.openEthereumCheckSet = openEthereumCheckSet
+
+	return &config
+}
+
+type healthState struct {
+	mu          sync.Mutex
+	inboxReader inboxReaderState
+}
+
+type inboxReaderState struct {
+	loadingDatabase    bool
+	getNextBlockToRead *big.Int
+	currentHeight      *big.Int
+	arbCorePosition    *big.Int
+	caughtUpTarget     *big.Int
+}
+
+func newHealthState() *healthState {
+	state := healthState{}
+
+	state.inboxReader.loadingDatabase = true
+	state.inboxReader.currentHeight = new(big.Int)
+	state.inboxReader.caughtUpTarget = new(big.Int)
+	state.inboxReader.arbCorePosition = new(big.Int)
+	state.inboxReader.getNextBlockToRead = new(big.Int)
+
+	return &state
+}
+
+type asyncDataStruct struct {
+	//Healthchecks to allow the status to be shared between handlers
+	checkOpenethereum healthcheck.Check
+	checkPrimary      healthcheck.Check
+	inboxReaderStatus healthcheck.Check
+
+	//Response structs to process the OpenEthereum responses
+	ethSyncResp        OpenEthereumResponse
+	parityNetPeersResp OpenEthereumResponse
+
+	//Healthchecks to allow the status to be shared between handlers
+	ethSyncCheck        healthcheck.Check
+	parityNetPeersCheck healthcheck.Check
+	tcpDialCheck        healthcheck.Check
+	blockRefreshCheck   healthcheck.Check
+	minimumPeersCheck   healthcheck.Check
+	blockSyncCheck      healthcheck.Check
+}
+
+//Perform all upstream checks at a set time interval in an asynchronous manner
+func newAsyncUpstream(state *healthState, config *configStruct) *asyncDataStruct {
+	asyncData := asyncDataStruct{}
+
+	if config.openEthereumInternalCheckEnable {
+		//Request eth_syncing status from OpenEthereum
+		asyncData.ethSyncCheck = ethSyncCheck(config, &asyncData)
+
+		//Request eth_syncing status from OpenEthereum
+		asyncData.parityNetPeersCheck = netPeersCheck(config, &asyncData)
+
+		//Check OpenEthereum has more than peerMinimum peers currently connected to it
+		asyncData.minimumPeersCheck = openEthereumPeerCount(config, &asyncData)
+
+		//Check OpenEthereum is refreshing its currentBlock quicker than the blockUpdateTimeout
+		asyncData.blockRefreshCheck = openEthereumBlockUpdateCheck(config, &asyncData)
+
+		//Check if OpenEthereum is within blockSyncDifference from the estimated block
+		asyncData.blockSyncCheck = openEthereumBlockSyncCheck(config, &asyncData)
+
+		//Check if the OpenEthereum API is accepting pings
+		asyncData.tcpDialCheck = healthcheck.Async(
+			healthcheck.TCPDialCheck(config.openethereumAPI,
+				config.requestTimeout), config.pollingRate)
+
+	} else {
+		//Check the healthcheck endpoint for OpenEthereum
+		asyncData.checkOpenethereum = checkEndpoint(config, &config.openethereumHealthcheckRPC, &config.openethereumHealthcheckRPCPort)
+	}
+
+	//Check the primary endpoint
+	asyncData.checkPrimary = checkEndpoint(config, &config.primaryHealthcheckRPC, &config.primaryHealthcheckRPCPort)
+
+	//Check how many blocks the inboxReader is behind
+	asyncData.inboxReaderStatus = checkInboxReader(config, state)
+
+	return &asyncData
+}
+
+//OpenEthereum response struct for json parsing
+type OpenEthereumResponse struct {
+	//Raw json response from the OpenEthereum API
+	respBody string
+	//Request ID
+	Id int `json:"id"`
+	//JSON RPC version
+	Jsonrpc string `json:"jsonrpc"`
+	//Result struct to process the json
+	Result OpenEthereumResult `json:"result"`
+}
+
+//OpenEthereum result field struct for json parsing
+type OpenEthereumResult struct {
+	//Result field for parityNetPeers
+	Active    int                `json:"active"`
+	Connected int                `json:"connected"`
+	Max       int                `json:"max"`
+	Peers     []OpenEthereumPeer `json:"peers"`
+
+	//Result field for ethSyncing
+	StartingBlock       string `json:"startingBlock"`
+	CurrentBlock        string `json:"currentBlock"`
+	HighestBlock        string `json:"highestBlock"`
+	WarpChunksAmount    string `json:"warpChunksAmount"`
+	WarpChunksProcessed string `json:"warpChunksProcessed"`
+}
+
+//OpenEthereum result peer field struct for json parsing
+type OpenEthereumPeer struct {
+	//Peer client ID
+	Id string `json:"id"`
+}
+
+//OpenEthereum result peer network field struct for json parsing
+type OpenEthereumPeerNetwork struct {
+	//Peer local IP address
+	localAddress string
+	//Peer remote IP address
+	remoteAddress string
 }
 
 //Log structure for passing messages on healthChan to logger
@@ -42,40 +244,20 @@ type Log struct {
 	ValTime   time.Duration
 }
 
-type inboxReaderState struct {
-	loadingDatabase    bool
-	getNextBlockToRead *big.Int
-	currentHeight      *big.Int
-	arbCorePosition    *big.Int
-	caughtUpTarget     *big.Int
-}
-
-type healthState struct {
-	mu          sync.Mutex
-	inboxReader inboxReaderState
-}
-
-type asyncDataStruct struct {
-	//Healthchecks to allow the status to be shared between handlers
-	checkOpenethereum healthcheck.Check
-	checkPrimary      healthcheck.Check
-	inboxReaderStatus healthcheck.Check
-}
-
-//Perform all upstream checks at a set time interval in an asynchronous manner
-func newAsyncUpstream(state *healthState, config *configStruct) *asyncDataStruct {
-	asyncData := asyncDataStruct{}
-
-	//Check the healthcheck endpoint for OpenEthereum
-	asyncData.checkOpenethereum = checkEndpoint(config, &config.openethereumHealthcheckRPC, &config.openethereumHealthcheckRPCPort)
-
-	//Check the primary endpoint
-	asyncData.checkPrimary = checkEndpoint(config, &config.primaryHealthcheckRPC, &config.primaryHealthcheckRPCPort)
-
-	//Check how many blocks the inboxReader is behind
-	asyncData.inboxReaderStatus = checkInboxReader(config, state)
-
-	return &asyncData
+func logger(config *configStruct, state *healthState, logMsgChan <-chan Log) {
+	for {
+		//Read log structure from channel
+		logMessage := <-logMsgChan
+		//Check if a configuration message has been sent
+		if logMessage.Config {
+			updateConfig(config, logMessage)
+		} else {
+			//Check if the InboxReader is sending logs
+			if logMessage.Comp == "InboxReader" {
+				updateInboxReader(state, logMessage)
+			}
+		}
+	}
 }
 
 func updateInboxReader(state *healthState, logMessage Log) {
@@ -126,55 +308,216 @@ func updateConfig(config *configStruct, logMessage Log) {
 	}
 }
 
-func logger(config *configStruct, state *healthState, logMsgChan <-chan Log) {
-	for {
-		//Read log structure from channel
-		logMessage := <-logMsgChan
-		//Check if a configuration message has been sent
-		if logMessage.Config {
-			updateConfig(config, logMessage)
-		} else {
-			//Check if the InboxReader is sending logs
-			if logMessage.Comp == "InboxReader" {
-				updateInboxReader(state, logMessage)
+func ethSyncCheck(config *configStruct, aSyncData *asyncDataStruct) healthcheck.Check {
+	check := healthcheck.Async(func() error {
+		//OpenEthereum API call to send
+		var jsonRequest = []byte(`{"method":"eth_syncing","params":[],"id":1,"jsonrpc":"2.0"}`)
+
+		//Generate POST request to OpenEthereum
+		req, err := http.NewRequest("POST", "http://"+config.openethereumAPI,
+			bytes.NewBuffer(jsonRequest))
+		if err != nil {
+			panic(err)
+		}
+		req.Header.Set("X-Custom-Header", "openethereum-healthcheck-client")
+		req.Header.Set("Content-Type", "application/json")
+		client := &http.Client{}
+
+		//Perform POST request
+		resp, err := client.Do(req)
+		if err != nil {
+			aSyncData.ethSyncResp.respBody = "failed"
+			return (err)
+		}
+		defer resp.Body.Close()
+
+		//Decode reponse into a string for ease of use
+		body, err := ioutil.ReadAll(resp.Body)
+		aSyncData.ethSyncResp.respBody = string(body)
+
+		//Check if OpenEthereum is not currently syncing
+		if strings.Contains(aSyncData.ethSyncResp.respBody, `"result":false`) {
+			return nil
+		}
+		if strings.Contains(aSyncData.ethSyncResp.respBody, `failed`) {
+			err := fmt.Errorf("GET request failed")
+			return err
+		}
+
+		//If OpenEthereum is currently syncing, parse the response
+		err = json.Unmarshal(body, &aSyncData.ethSyncResp)
+		if err != nil {
+			return (err)
+		}
+
+		//Debug statement to print the response status, header, and body
+		if config.printRequests == true {
+			fmt.Println("response Status:", resp.Status)
+			fmt.Println("response Headers:", resp.Header)
+			fmt.Println("response Body:", aSyncData.ethSyncResp.respBody)
+		}
+
+		return err
+	}, config.pollingRate)
+	return check
+}
+
+func netPeersCheck(config *configStruct, aSyncData *asyncDataStruct) healthcheck.Check {
+	check := healthcheck.Async(func() error {
+		//OpenEthereum API call to send
+		var jsonRequest = []byte(`{"method":"parity_netPeers","params":[],"id":1,"jsonrpc":"2.0"}`)
+
+		//Generate POST request to OpenEthereum
+		req, err := http.NewRequest("POST", "http://"+config.openethereumAPI,
+			bytes.NewBuffer(jsonRequest))
+		if err != nil {
+			panic(err)
+		}
+		req.Header.Set("X-Custom-Header",
+			"openethereum-healthcheck-client")
+		req.Header.Set("Content-Type", "application/json")
+		client := &http.Client{}
+
+		//Perform POST request
+		resp, err := client.Do(req)
+		if err != nil {
+			aSyncData.parityNetPeersResp.respBody = "failed"
+			return (err)
+		}
+		defer resp.Body.Close()
+
+		//Decode reponse into a string for ease of use
+		body, err := ioutil.ReadAll(resp.Body)
+		aSyncData.parityNetPeersResp.respBody = string(
+			body)
+
+		//Parse the response into a struct
+		err = json.Unmarshal(body, &aSyncData.parityNetPeersResp)
+		if err != nil {
+			return (err)
+		}
+
+		//Debug statement to print the response status, header, and body
+		if config.printRequests == true {
+			fmt.Println("response Status:", resp.Status)
+			fmt.Println("response Headers:", resp.Header)
+			fmt.Println("response Body:", aSyncData.parityNetPeersResp.respBody)
+		}
+
+		return err
+	}, config.pollingRate)
+	return check
+}
+
+func openEthereumPeerCount(config *configStruct, aSyncData *asyncDataStruct) healthcheck.Check {
+	check := healthcheck.Async(func() error {
+		//Check if GET request to OpenEthereum failed
+		if strings.Contains(aSyncData.ethSyncResp.respBody, `failed`) {
+			err := fmt.Errorf("GET request failed")
+			return err
+		}
+		//Compare currently connected peers to config struct
+		if aSyncData.parityNetPeersResp.Result.Connected < config.peerMinimum {
+			err := fmt.Errorf("minimumPeers :%d",
+				aSyncData.parityNetPeersResp.Result.Connected)
+			return err
+		}
+		return nil
+	}, config.pollingRate)
+	return check
+}
+
+func openEthereumBlockUpdateCheck(config *configStruct, aSyncData *asyncDataStruct) healthcheck.Check {
+	check := healthcheck.Async(func() error {
+		//Pause to allow request to be captured
+		time.Sleep(2 * time.Second)
+		//Check if OpenEthereum is not currently syncing
+		if strings.Contains(aSyncData.ethSyncResp.respBody, `"result":false`) {
+			return nil
+		}
+		if strings.Contains(aSyncData.ethSyncResp.respBody, `failed`) {
+			err := fmt.Errorf("GET request failed")
+			return err
+		}
+
+		//Retrieve current block from response struct
+		currentBlock := aSyncData.ethSyncResp.Result.CurrentBlock
+
+		//Retrieve snapshot status
+		warpBlock := aSyncData.ethSyncResp.Result.WarpChunksProcessed
+
+		//Wait the blockUpdateTimeout
+		time.Sleep(config.blockUpdateTimeout)
+
+		//Check if the new block is equal to the old block
+		if currentBlock == aSyncData.ethSyncResp.Result.CurrentBlock {
+			if warpBlock == aSyncData.ethSyncResp.Result.WarpChunksProcessed {
+				err := fmt.Errorf("currentBlock/warpBlock have not refreshed within timeout")
+				return err
 			}
 		}
+		return nil
+	}, 2*config.blockUpdateTimeout)
+	return check
+}
+
+func openEthereumBlockDifference(aSyncData *asyncDataStruct) (int64, error) {
+	//Check if OpenEthereum is not currently syncing
+	if strings.Contains(aSyncData.ethSyncResp.respBody, `"result":false`) {
+		return 0, nil
 	}
+	if strings.Contains(aSyncData.ethSyncResp.respBody, `failed`) {
+		err := fmt.Errorf("GET request failed")
+		return 0, err
+	}
+
+	//Convert the hex string to an integer
+	currentBlockInt, err := strconv.ParseInt(strings.Replace(
+		aSyncData.ethSyncResp.Result.CurrentBlock, "0x", "", -1), 16, 64)
+	if err != nil {
+		return -1, err
+	}
+
+	//Convert the hex string to an integer
+	highestBlockInt, err := strconv.ParseInt(strings.Replace(
+		aSyncData.ethSyncResp.Result.HighestBlock, "0x", "", -1), 16, 64)
+	if err != nil {
+		return -1, err
+	}
+
+	//Calculate how many blocks behind OpenEthereum is
+	blockDifference := highestBlockInt - currentBlockInt
+
+	return blockDifference, nil
 }
 
-// Default configuration values for the healthcheck server
-func newConfig() *configStruct {
-	config := configStruct{}
+func openEthereumBlockSyncCheck(config *configStruct, aSyncData *asyncDataStruct) healthcheck.Check {
+	check := healthcheck.Async(func() error {
+		//Check if OpenEthereum is not currently syncing
+		if strings.Contains(aSyncData.ethSyncResp.respBody, `"result":false`) {
+			return nil
+		}
+		if strings.Contains(aSyncData.ethSyncResp.respBody, `failed`) {
+			err := fmt.Errorf("GET request failed")
+			return err
+		}
 
-	const defaultSuccessCode = 200
-	const defaultBlockDifferenceTolerance = 2
-	const defaultPollingRate = 10 * time.Second
-	const loopDelayTimer = 1 * time.Second
-	const defaultHealthCheckPort = "8080"
+		//Retrieve the current block difference between the estimated block and the current block
+		currentBlockDifference, err := openEthereumBlockDifference(aSyncData)
+		if err != nil {
+			return err
+		}
 
-	config.healthcheckRPC = "0.0.0.0:8080"
-	config.openethereumHealthcheckRPCPort = defaultHealthCheckPort
-	config.primaryHealthcheckRPCPort = defaultHealthCheckPort
-	config.pollingRate = defaultPollingRate
-	config.loopDelayTimer = loopDelayTimer
-	config.openethereumHealthcheckRPC = ""
-	config.primaryHealthcheckRPC = ""
-	config.successCode = defaultSuccessCode
-	config.blockDifferenceTolerance = defaultBlockDifferenceTolerance
+		//Compare to blockSyncDifference
+		if currentBlockDifference > config.blockSyncDifference {
+			err := fmt.Errorf("blockDifference :%d",
+				currentBlockDifference)
+			return err
+		}
 
-	return &config
-}
-
-func newHealthState() *healthState {
-	state := healthState{}
-
-	state.inboxReader.loadingDatabase = true
-	state.inboxReader.currentHeight = new(big.Int)
-	state.inboxReader.caughtUpTarget = new(big.Int)
-	state.inboxReader.arbCorePosition = new(big.Int)
-	state.inboxReader.getNextBlockToRead = new(big.Int)
-
-	return &state
+		return nil
+	}, config.pollingRate)
+	return check
 }
 
 func checkEndpoint(config *configStruct, endpoint *string, port *string) healthcheck.Check {
@@ -228,7 +571,7 @@ func checkInboxReader(config *configStruct, state *healthState) healthcheck.Chec
 }
 
 //Define which healthchecks to use for the readiness API and expose the readiness API
-func nodeReadinessChecks(health healthcheck.Handler, httpMux *http.ServeMux, aSyncData *asyncDataStruct) {
+func nodeReadinessChecks(health healthcheck.Handler, config *configStruct, httpMux *http.ServeMux, aSyncData *asyncDataStruct) {
 	//Add healthchecks to the readiness check
 	health.AddReadinessCheck(
 		"openethereum-status",
@@ -241,6 +584,34 @@ func nodeReadinessChecks(health healthcheck.Handler, httpMux *http.ServeMux, aSy
 	health.AddReadinessCheck(
 		"inbox-reader-status",
 		aSyncData.inboxReaderStatus)
+
+	//OpenEthereum healthchecks
+	//Add healthchecks to the readiness check
+	if config.openEthereumInternalCheckEnable {
+		health.AddReadinessCheck(
+			"openethereum-api-status",
+			aSyncData.tcpDialCheck)
+
+		health.AddReadinessCheck(
+			"openethereum-sync-response-status",
+			aSyncData.ethSyncCheck)
+
+		health.AddReadinessCheck(
+			"openethereum-netpeers-response-status",
+			aSyncData.parityNetPeersCheck)
+
+		health.AddReadinessCheck(
+			"openethereum-sync-status",
+			aSyncData.blockSyncCheck)
+
+		health.AddReadinessCheck(
+			"openethereum-peer-status",
+			aSyncData.minimumPeersCheck)
+
+		health.AddReadinessCheck(
+			"openethereum-block-refresh-status",
+			aSyncData.blockRefreshCheck)
+	}
 
 	//Create an endpoint to serve the readiness check
 	httpMux.HandleFunc("/ready", health.ReadyEndpoint)
@@ -275,7 +646,7 @@ func startHealthCheck(config *configStruct, state *healthState) error {
 	httpMux.HandleFunc("/live", health.LiveEndpoint)
 
 	//Define which healthchecks to use for the readiness API and expose the readiness API
-	nodeReadinessChecks(health, httpMux, asyncUpstream)
+	nodeReadinessChecks(health, config, httpMux, asyncUpstream)
 
 	//Create an endpoint to serve the prometheus endpoint
 	httpMux.Handle("/metrics", promhttp.HandlerFor(

--- a/packages/arb-node-core/nodehealth/nodehealth_test.go
+++ b/packages/arb-node-core/nodehealth/nodehealth_test.go
@@ -41,7 +41,7 @@ func newTestConfig() *testConfigStruct {
 	const passMessage = "Passed"
 	const startUpSleepTime = 5 * time.Second
 	const timeDelayTests = 11 * time.Second
-	const nodehealthAddress = "http://127.0.0.1:8080"
+	const nodehealthAddress = "http://127.0.0.1:8087"
 	const inboxReaderName = "InboxReader"
 	const failServerPort = "8088"
 	const passServerPort = "8089"
@@ -100,7 +100,7 @@ func setNodeHealthBaseConfig(healthChan chan Log) {
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8087"}
 }
 
 func healthEndpointStatus(testConfig *testConfigStruct, mode string, healthChan chan Log) error {
@@ -319,7 +319,7 @@ func disablePrimaryCheckTest(testConfig *testConfigStruct, healthChan chan Log) 
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8087"}
 	setOpenEthereumEndpoint(healthChan)
 	Init(healthChan)
 
@@ -381,7 +381,7 @@ func disableOpenEthereumCheckTest(testConfig *testConfigStruct, healthChan chan 
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8087"}
 	Init(healthChan)
 
 	err := retrieveVerifyOpenEthereumDisabled(testConfig, healthChan)
@@ -413,7 +413,7 @@ func disableOpenEthereumPrimaryCheckTest(testConfig *testConfigStruct, healthCha
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8087"}
 	Init(healthChan)
 
 	respMap, err := getHealthcheckStatus(testConfig, healthChan)
@@ -447,7 +447,7 @@ func disableMetricsTest(testConfig *testConfigStruct, healthChan chan Log) error
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8087"}
 	Init(healthChan)
 
 	if testConfig.verbose {
@@ -498,7 +498,7 @@ func openethereumFailureTest(testConfig *testConfigStruct, healthChan chan Log) 
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8087"}
 
 	Init(healthChan)
 
@@ -546,7 +546,7 @@ func primaryFailureTest(testConfig *testConfigStruct, healthChan chan Log) error
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8087"}
 
 	Init(healthChan)
 
@@ -555,7 +555,7 @@ func primaryFailureTest(testConfig *testConfigStruct, healthChan chan Log) error
 	healthChan <- Log{Comp: testConfig.inboxReaderName, Var: "arbCorePosition", ValBigInt: new(big.Int).Set(blockTest)}
 	healthChan <- Log{Comp: testConfig.inboxReaderName, Var: "caughtUpTarget", ValBigInt: new(big.Int).Set(blockTest)}
 
-	healthChan <- Log{Config: true, Var: "primaryHealthcheckRPC", ValStr: "http://127.0.0.1:0000"}
+	healthChan <- Log{Config: true, Var: "primaryHealthcheckRPC", ValStr: "http://127.0.0.1:8087"}
 	healthChan <- Log{Config: true, Var: "primaryHealthcheckRPCPort", ValStr: testConfig.passServerPort}
 	time.Sleep(testConfig.timeDelayTests)
 
@@ -594,7 +594,7 @@ func inboxReaderCatchUpTest(testConfig *testConfigStruct, healthChan chan Log) e
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8087"}
 
 	Init(healthChan)
 

--- a/packages/arb-node-core/nodehealth/nodehealth_test.go
+++ b/packages/arb-node-core/nodehealth/nodehealth_test.go
@@ -1,6 +1,7 @@
 package nodehealth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/big"
@@ -227,13 +228,14 @@ func inboxReaderTest(healthChan chan Log, config *configTestStruct) error {
 func TestNodeHealth(t *testing.T) {
 	config := configTestStruct{}
 	config.newTestConfig()
+	ctx := context.Background()
 
 	//Generate sample servers for testing
 	go startTestingServerFail()
 	go startTestingServerPass()
 
 	healthChan := make(chan Log, config.largeBufferSize)
-	go NodeHealthCheck(healthChan)
+	go StartNodeHealthCheck(ctx, healthChan)
 	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
 	//healthChan <- Log{Config: true, Var: "openEthereumAPI", ValStr: "https://eth-kovan.alchemyapi.io/v2/yvzMZUhX0jmdpRfqrUEGwh--U59mJNhf"}
 	//Test startup configuration delay

--- a/packages/arb-node-core/nodehealth/nodehealth_test.go
+++ b/packages/arb-node-core/nodehealth/nodehealth_test.go
@@ -191,6 +191,8 @@ func inboxReaderTest(healthChan chan Log, config *configTestStruct) error {
 
 	//Test server response
 	res, err := http.Get(config.nodehealthAddress + config.readinessEndpoint)
+	fmt.Println(res)
+	fmt.Println("1")
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -206,9 +208,14 @@ func inboxReaderTest(healthChan chan Log, config *configTestStruct) error {
 	healthChan <- Log{Comp: config.inboxReaderName, Var: "arbCorePosition", ValBigInt: new(big.Int).Set(blockTest)}
 	healthChan <- Log{Comp: config.inboxReaderName, Var: "caughtUpTarget", ValBigInt: new(big.Int).Set(testBigInt)}
 	time.Sleep(config.timeDelayTests)
+	time.Sleep(config.timeDelayTests)
 
 	//Test server response
 	res, err = http.Get(config.nodehealthAddress + config.readinessEndpoint)
+
+	fmt.Println(res)
+	fmt.Println("2")
+
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -233,8 +240,9 @@ func TestNodeHealth(t *testing.T) {
 	healthChan := make(chan Log, config.largeBufferSize)
 	go NodeHealthCheck(healthChan)
 	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
-	//healthChan <- Log{Config: true, Var: "openEthereumAPI", ValStr: "https://eth-kovan.alchemyapi.io/v2/yvzMZUhX0jmdpRfqrUEGwh--U59mJNhf"}
+	healthChan <- Log{Config: true, Var: "openEthereumAPI", ValStr: "https://eth-kovan.alchemyapi.io/v2/yvzMZUhX0jmdpRfqrUEGwh--U59mJNhf"}
 	//Test startup configuration delay
+	time.Sleep(200 * time.Second)
 	err := startUpTest(&config)
 	if err != nil {
 		t.Fatal(err)

--- a/packages/arb-node-core/nodehealth/nodehealth_test.go
+++ b/packages/arb-node-core/nodehealth/nodehealth_test.go
@@ -232,8 +232,8 @@ func TestNodeHealth(t *testing.T) {
 
 	healthChan := make(chan Log, config.largeBufferSize)
 	go NodeHealthCheck(healthChan)
-	healthChan <- Log{Config: true, Var: "healcheckRPC", ValStr: "0.0.0.0:8080"}
-	healthChan <- Log{Config: true, Var: "openEthereumInternalCheckEnable", ValStr: "https://eth-kovan.alchemyapi.io/v2/yvzMZUhX0jmdpRfqrUEGwh--U59mJNhf"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	//healthChan <- Log{Config: true, Var: "openEthereumAPI", ValStr: "https://eth-kovan.alchemyapi.io/v2/yvzMZUhX0jmdpRfqrUEGwh--U59mJNhf"}
 	//Test startup configuration delay
 	err := startUpTest(&config)
 	if err != nil {

--- a/packages/arb-node-core/nodehealth/nodehealth_test.go
+++ b/packages/arb-node-core/nodehealth/nodehealth_test.go
@@ -232,7 +232,8 @@ func TestNodeHealth(t *testing.T) {
 
 	healthChan := make(chan Log, config.largeBufferSize)
 	go NodeHealthCheck(healthChan)
-
+	healthChan <- Log{Config: true, Var: "healcheckRPC", ValStr: "0.0.0.0:8080"}
+	healthChan <- Log{Config: true, Var: "openEthereumInternalCheckEnable", ValStr: "https://eth-kovan.alchemyapi.io/v2/yvzMZUhX0jmdpRfqrUEGwh--U59mJNhf"}
 	//Test startup configuration delay
 	err := startUpTest(&config)
 	if err != nil {

--- a/packages/arb-node-core/nodehealth/nodehealth_test.go
+++ b/packages/arb-node-core/nodehealth/nodehealth_test.go
@@ -34,7 +34,7 @@ func newTestConfig() *testConfigStruct {
 
 	//Configuration constants
 	const successfulStatus = 200
-	const verbose = false
+	const verbose = true
 	const bufferSize = 10
 	const readinessEndpoint = "/ready"
 	const failMessage = "Failed"

--- a/packages/arb-node-core/nodehealth/nodehealth_test.go
+++ b/packages/arb-node-core/nodehealth/nodehealth_test.go
@@ -74,7 +74,7 @@ func startTestingServerFail(testConfig *testConfigStruct) {
 	//Create an endpoint to serve the readiness check
 	httpMux.HandleFunc("/ready", health.ReadyEndpoint)
 
-	http.ListenAndServe("0.0.0.0:"+testConfig.failServerPort, httpMux)
+	http.ListenAndServe("127.0.0.1:"+testConfig.failServerPort, httpMux)
 }
 
 func startTestingServerPass(testConfig *testConfigStruct) {
@@ -89,7 +89,7 @@ func startTestingServerPass(testConfig *testConfigStruct) {
 	//Create an endpoint to serve the readiness check
 	httpMux.HandleFunc("/ready", health.ReadyEndpoint)
 
-	http.ListenAndServe("0.0.0.0:"+testConfig.passServerPort, httpMux)
+	http.ListenAndServe("127.0.0.1:"+testConfig.passServerPort, httpMux)
 }
 
 func setOpenEthereumEndpoint(healthChan chan Log) {
@@ -100,7 +100,7 @@ func setNodeHealthBaseConfig(healthChan chan Log) {
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
 }
 
 func healthEndpointStatus(testConfig *testConfigStruct, mode string, healthChan chan Log) error {
@@ -319,7 +319,7 @@ func disablePrimaryCheckTest(testConfig *testConfigStruct, healthChan chan Log) 
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
 	setOpenEthereumEndpoint(healthChan)
 	Init(healthChan)
 
@@ -381,7 +381,7 @@ func disableOpenEthereumCheckTest(testConfig *testConfigStruct, healthChan chan 
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
 	Init(healthChan)
 
 	err := retrieveVerifyOpenEthereumDisabled(testConfig, healthChan)
@@ -413,7 +413,7 @@ func disableOpenEthereumPrimaryCheckTest(testConfig *testConfigStruct, healthCha
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
 	Init(healthChan)
 
 	respMap, err := getHealthcheckStatus(testConfig, healthChan)
@@ -447,7 +447,7 @@ func disableMetricsTest(testConfig *testConfigStruct, healthChan chan Log) error
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
 	Init(healthChan)
 
 	if testConfig.verbose {
@@ -498,7 +498,7 @@ func openethereumFailureTest(testConfig *testConfigStruct, healthChan chan Log) 
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
 
 	Init(healthChan)
 
@@ -546,7 +546,7 @@ func primaryFailureTest(testConfig *testConfigStruct, healthChan chan Log) error
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
 
 	Init(healthChan)
 
@@ -594,7 +594,7 @@ func inboxReaderCatchUpTest(testConfig *testConfigStruct, healthChan chan Log) e
 	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: true}
 	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "127.0.0.1:8080"}
 
 	Init(healthChan)
 

--- a/packages/arb-node-core/nodehealth/nodehealth_test.go
+++ b/packages/arb-node-core/nodehealth/nodehealth_test.go
@@ -191,8 +191,6 @@ func inboxReaderTest(healthChan chan Log, config *configTestStruct) error {
 
 	//Test server response
 	res, err := http.Get(config.nodehealthAddress + config.readinessEndpoint)
-	fmt.Println(res)
-	fmt.Println("1")
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -212,9 +210,6 @@ func inboxReaderTest(healthChan chan Log, config *configTestStruct) error {
 
 	//Test server response
 	res, err = http.Get(config.nodehealthAddress + config.readinessEndpoint)
-
-	fmt.Println(res)
-	fmt.Println("2")
 
 	if err != nil {
 		fmt.Println(err)
@@ -240,9 +235,9 @@ func TestNodeHealth(t *testing.T) {
 	healthChan := make(chan Log, config.largeBufferSize)
 	go NodeHealthCheck(healthChan)
 	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
-	healthChan <- Log{Config: true, Var: "openEthereumAPI", ValStr: "https://eth-kovan.alchemyapi.io/v2/yvzMZUhX0jmdpRfqrUEGwh--U59mJNhf"}
+	//healthChan <- Log{Config: true, Var: "openEthereumAPI", ValStr: "https://eth-kovan.alchemyapi.io/v2/yvzMZUhX0jmdpRfqrUEGwh--U59mJNhf"}
 	//Test startup configuration delay
-	time.Sleep(200 * time.Second)
+	//time.Sleep(200 * time.Second)
 	err := startUpTest(&config)
 	if err != nil {
 		t.Fatal(err)

--- a/packages/arb-node-core/nodehealth/nodehealth_test.go
+++ b/packages/arb-node-core/nodehealth/nodehealth_test.go
@@ -2,8 +2,10 @@ package nodehealth
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"math/big"
 	"net/http"
 	"testing"
@@ -12,9 +14,10 @@ import (
 	"github.com/heptiolabs/healthcheck"
 )
 
-type configTestStruct struct {
+type testConfigStruct struct {
 	successfulStatus  int
-	largeBufferSize   int
+	verbose           bool
+	bufferSize        int
 	readinessEndpoint string
 	failMessage       string
 	passMessage       string
@@ -22,12 +25,17 @@ type configTestStruct struct {
 	timeDelayTests    time.Duration
 	nodehealthAddress string
 	inboxReaderName   string
+	failServerPort    string
+	passServerPort    string
 }
 
-func (config *configTestStruct) newTestConfig() {
+func newTestConfig() *testConfigStruct {
+	testConfig := testConfigStruct{}
+
 	//Configuration constants
 	const successfulStatus = 200
-	const largeBufferSize = 200
+	const verbose = false
+	const bufferSize = 10
 	const readinessEndpoint = "/ready"
 	const failMessage = "Failed"
 	const passMessage = "Passed"
@@ -35,19 +43,26 @@ func (config *configTestStruct) newTestConfig() {
 	const timeDelayTests = 11 * time.Second
 	const nodehealthAddress = "http://127.0.0.1:8080"
 	const inboxReaderName = "InboxReader"
+	const failServerPort = "8088"
+	const passServerPort = "8089"
 
-	config.successfulStatus = successfulStatus
-	config.largeBufferSize = largeBufferSize
-	config.readinessEndpoint = readinessEndpoint
-	config.failMessage = failMessage
-	config.passMessage = passMessage
-	config.startUpSleepTime = startUpSleepTime
-	config.timeDelayTests = timeDelayTests
-	config.nodehealthAddress = nodehealthAddress
-	config.inboxReaderName = inboxReaderName
+	testConfig.successfulStatus = successfulStatus
+	testConfig.verbose = verbose
+	testConfig.bufferSize = bufferSize
+	testConfig.readinessEndpoint = readinessEndpoint
+	testConfig.failMessage = failMessage
+	testConfig.passMessage = passMessage
+	testConfig.startUpSleepTime = startUpSleepTime
+	testConfig.timeDelayTests = timeDelayTests
+	testConfig.nodehealthAddress = nodehealthAddress
+	testConfig.inboxReaderName = inboxReaderName
+	testConfig.failServerPort = failServerPort
+	testConfig.passServerPort = passServerPort
+
+	return &testConfig
 }
 
-func startTestingServerFail() {
+func startTestingServerFail(testConfig *testConfigStruct) {
 	health := healthcheck.NewHandler()
 	httpMux := http.NewServeMux()
 
@@ -59,10 +74,10 @@ func startTestingServerFail() {
 	//Create an endpoint to serve the readiness check
 	httpMux.HandleFunc("/ready", health.ReadyEndpoint)
 
-	http.ListenAndServe("0.0.0.0:8088", httpMux)
+	http.ListenAndServe("0.0.0.0:"+testConfig.failServerPort, httpMux)
 }
 
-func startTestingServerPass() {
+func startTestingServerPass(testConfig *testConfigStruct) {
 	health := healthcheck.NewHandler()
 	httpMux := http.NewServeMux()
 
@@ -74,197 +89,681 @@ func startTestingServerPass() {
 	//Create an endpoint to serve the readiness check
 	httpMux.HandleFunc("/ready", health.ReadyEndpoint)
 
-	http.ListenAndServe("0.0.0.0:8089", httpMux)
+	http.ListenAndServe("0.0.0.0:"+testConfig.passServerPort, httpMux)
 }
 
-func startUpTest(config *configTestStruct) error {
-	fmt.Println("Startup delay")
-	time.Sleep(config.startUpSleepTime)
-	_, err := http.Get(config.nodehealthAddress + config.readinessEndpoint)
+func setOpenEthereumEndpoint(healthChan chan Log) {
+	healthChan <- Log{Config: true, Var: "openEthereumAPI", ValStr: "https://eth-kovan.alchemyapi.io/v2/yvzMZUhX0jmdpRfqrUEGwh--U59mJNhf"}
+}
+
+func setNodeHealthBaseConfig(healthChan chan Log) {
+	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
+	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: false}
+	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+}
+
+func healthEndpointStatus(testConfig *testConfigStruct, mode string, healthChan chan Log) error {
+	function := "healthEndpointStatus: "
+	time.Sleep(testConfig.startUpSleepTime)
+	_, err := http.Get(testConfig.nodehealthAddress + testConfig.readinessEndpoint)
+	if mode == "unavailable" {
+		if err != nil {
+			if testConfig.verbose {
+				fmt.Println(function + testConfig.passMessage)
+			}
+		} else {
+			if testConfig.verbose {
+				fmt.Println(function + testConfig.failMessage)
+			}
+			return errors.New(function + testConfig.failMessage)
+		}
+	} else if mode == "available" {
+		if err == nil {
+			if testConfig.verbose {
+				fmt.Println(function + testConfig.passMessage)
+			}
+		} else {
+			if testConfig.verbose {
+				fmt.Println(function + testConfig.failMessage)
+			}
+			return errors.New(function + testConfig.failMessage)
+		}
+	}
+	fmt.Println("")
+	return nil
+}
+
+//Test that nodehealth properly waits for its configuration
+func startUpDelayTest(testConfig *testConfigStruct, healthChan chan Log) error {
+	fmt.Println("startUpDelayTest")
+
+	if testConfig.verbose {
+		fmt.Println("Configure the basic required nodehealth setting")
+	}
+	setNodeHealthBaseConfig(healthChan)
+
+	if testConfig.verbose {
+		fmt.Println("The healthcheck server should not be running unit the OE endpoint is set and init is called")
+	}
+	err := healthEndpointStatus(testConfig, "unavailable", healthChan)
 	if err != nil {
-		fmt.Println(config.passMessage)
+		return err
+	}
+
+	if testConfig.verbose {
+		fmt.Println("Send init to healthcheck")
+	}
+	Init(healthChan)
+
+	if testConfig.verbose {
+		fmt.Println("The healthcheck server should still be waiting for the OE endpoint")
+	}
+	err = healthEndpointStatus(testConfig, "unavailable", healthChan)
+	if err != nil {
+		return err
+	}
+
+	if testConfig.verbose {
+		fmt.Println("The healthcheck should be running after the OE endpoint is set")
+	}
+	setOpenEthereumEndpoint(healthChan)
+	err = healthEndpointStatus(testConfig, "available", healthChan)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(testConfig.passMessage)
+	return nil
+}
+
+//Initialize the nodehealth server
+func initNodeHealthCheck(ctx context.Context, healthChan chan Log) {
+	go StartNodeHealthCheck(ctx, healthChan)
+	setNodeHealthBaseConfig(healthChan)
+	setOpenEthereumEndpoint(healthChan)
+	Init(healthChan)
+}
+
+//Test the healthcheck server is gracefully shutdown when the CancelFunc is called
+func gracefulShutdownTest(cancel context.CancelFunc, testConfig *testConfigStruct, healthChan chan Log) error {
+	fmt.Println("gracefulShutdownTest")
+
+	if testConfig.verbose {
+		fmt.Println("The healthcheck endpoint should be running")
+	}
+	err := healthEndpointStatus(testConfig, "available", healthChan)
+	if err != nil {
+		return err
+	}
+
+	if testConfig.verbose {
+		fmt.Println("Cancel the context")
+	}
+	cancel()
+
+	if testConfig.verbose {
+		fmt.Println("The healthcheck endpoint should be stopped")
+	}
+	time.Sleep(5 * time.Second) //TCP timeout
+	err = healthEndpointStatus(testConfig, "unavailable", healthChan)
+	if err != nil {
+		return err
+	}
+
+	if testConfig.verbose {
+		fmt.Println("Check the channel logger no longer running")
+	}
+	for i := 0; i <= testConfig.bufferSize; i++ {
+		healthChan <- Log{Config: true, Var: "TESTVARIABLE", ValBool: false}
+	}
+	select {
+	case healthChan <- Log{Config: true, Var: "TESTVARIABLE", ValBool: false}:
+		return errors.New("Channel logger not stopped")
+	default:
+	}
+
+	fmt.Println(testConfig.passMessage)
+	return nil
+}
+
+//Check the healthcheck disables itself when healthcheckRPC is not set
+func disableHealthcheckTest(testConfig *testConfigStruct, healthChan chan Log) error {
+	fmt.Println("disableHealthcheckTest")
+
+	if testConfig.verbose {
+		fmt.Println("Disable the healthcheck by not setting healthcheckRPC")
+	}
+	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
+	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: false}
+	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
+
+	if testConfig.verbose {
+		fmt.Println("The healthcheck endpoint should be stopped")
+	}
+	time.Sleep(5 * time.Second) //TCP timeout
+	err := healthEndpointStatus(testConfig, "unavailable", healthChan)
+	if err != nil {
+		return err
+	}
+
+	if testConfig.verbose {
+		fmt.Println("The healthcheck server should not start")
+	}
+	Init(healthChan)
+
+	if testConfig.verbose {
+		fmt.Println("The healthcheck endpoint should be stopped")
+	}
+	time.Sleep(5 * time.Second) //TCP timeout
+	err = healthEndpointStatus(testConfig, "unavailable", healthChan)
+	if err != nil {
+		return err
+	}
+
+	if testConfig.verbose {
+		fmt.Println("Check the channel logger is still running to prevent blocking")
+	}
+	for i := 0; i <= testConfig.bufferSize; i++ {
+		healthChan <- Log{Config: true, Var: "TESTVARIABLE", ValBool: false}
+	}
+	time.Sleep(testConfig.startUpSleepTime)
+	select {
+	case healthChan <- Log{Config: true, Var: "TESTVARIABLE", ValBool: false}:
+	default:
+		return errors.New("Channel logger improperly stopped causing a blocking condition")
+	}
+
+	fmt.Println(testConfig.passMessage)
+	return nil
+}
+
+func getHealthcheckStatus(testConfig *testConfigStruct, healthChan chan Log) (map[string]string, error) {
+	function := "getHealthcheckStatus"
+	var parsedResp map[string]string
+
+	time.Sleep(testConfig.startUpSleepTime)
+
+	resp, err := http.Get(testConfig.nodehealthAddress + testConfig.readinessEndpoint + "?full=1")
+	if err == nil {
+		if testConfig.verbose {
+			fmt.Println(function + testConfig.passMessage)
+		}
 	} else {
-		fmt.Println(config.failMessage)
-		return errors.New("Failed startup delay test - exiting")
+		if testConfig.verbose {
+			fmt.Println(function + testConfig.failMessage)
+		}
+		return nil, errors.New(function + testConfig.failMessage)
 	}
-	fmt.Println("")
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal([]byte(body), &parsedResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsedResp, err
+}
+
+//Check the healthcheck disables the primary check
+func disablePrimaryCheckTest(testConfig *testConfigStruct, healthChan chan Log) error {
+	fmt.Println("disablePrimaryCheck")
+
+	if testConfig.verbose {
+		fmt.Println("Disable the primary by setting disablePrimaryCheck to true")
+	}
+	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: true}
+	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: false}
+	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	setOpenEthereumEndpoint(healthChan)
+	Init(healthChan)
+
+	if testConfig.verbose {
+		fmt.Println("Retrieve and parse the full healthcheck server response")
+	}
+	respMap, err := getHealthcheckStatus(testConfig, healthChan)
+	if err != nil {
+		return err
+	}
+
+	if testConfig.verbose {
+		fmt.Println("Check if the response contains the primary healthcheck")
+	}
+	_, ok := respMap["primary-status"]
+	if ok {
+		return errors.New("Primary healthcheck still present after being disabled")
+	}
+	_, ok = respMap["openethereum-api-status"]
+	if !ok {
+		return errors.New("OpenEthereum healthcheck improperly disabled")
+	}
+
+	fmt.Println(testConfig.passMessage)
 	return nil
 }
 
-func aSyncTest(healthChan chan Log, config *configTestStruct) error {
-	fmt.Println("Test Removing Primary aSync")
-	healthChan <- Log{Config: true, Var: "openethereumHealthcheckRPC", ValStr: "http://127.0.0.1:8092"}
-	healthChan <- Log{Config: true, Var: "openethereumHealthcheckRPCPort", ValStr: "8089"}
+func retrieveVerifyOpenEthereumDisabled(testConfig *testConfigStruct, healthChan chan Log) error {
+	if testConfig.verbose {
+		fmt.Println("Retrieve and parse the full healthcheck server response")
+	}
+	respMap, err := getHealthcheckStatus(testConfig, healthChan)
+	if err != nil {
+		return err
+	}
+
+	if testConfig.verbose {
+		fmt.Println("Check if the response contains the OpenEthereum healthcheck")
+	}
+	_, ok := respMap["openethereum-api-status"]
+	if ok {
+		return errors.New("OpenEthereum healthcheck still present after being disabled")
+	}
+	_, ok = respMap["primary-status"]
+	if !ok {
+		return errors.New("Primary healthcheck improperly disabled")
+	}
+
+	return nil
+}
+
+//Check the healthcheck disables the OpenEthereumCheck
+func disableOpenEthereumCheckTest(testConfig *testConfigStruct, healthChan chan Log) error {
+	fmt.Println("disableOpenEthereumCheck")
+
+	if testConfig.verbose {
+		fmt.Println("Disable the OpenEthereum check by setting disableOpenEthereumCheck to true")
+	}
+	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
+	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: true}
+	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	Init(healthChan)
+
+	err := retrieveVerifyOpenEthereumDisabled(testConfig, healthChan)
+	if err != nil {
+		return err
+	}
+
+	if testConfig.verbose {
+		fmt.Println("Verify setting the OpenEthereum endpoint does not affect the check being disabled")
+	}
+	setOpenEthereumEndpoint(healthChan)
+
+	err = retrieveVerifyOpenEthereumDisabled(testConfig, healthChan)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(testConfig.passMessage)
+	return nil
+}
+
+//Check the healthcheck can disable both OpenEthereum and primary check
+func disableOpenEthereumPrimaryCheckTest(testConfig *testConfigStruct, healthChan chan Log) error {
+	fmt.Println("disableOpenEthereumPrimaryCheck")
+
+	if testConfig.verbose {
+		fmt.Println("Disable the both OpenEthereum and primary healthcheck")
+	}
+	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: true}
+	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: true}
+	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	Init(healthChan)
+
+	respMap, err := getHealthcheckStatus(testConfig, healthChan)
+	if err != nil {
+		return err
+	}
+
+	if testConfig.verbose {
+		fmt.Println("Check if the response contains the primary healthcheck")
+	}
+	_, ok := respMap["primary-status"]
+	if ok {
+		return errors.New("Primary healthcheck still present after being disabled")
+	}
+	_, ok = respMap["openethereum-api-status"]
+	if ok {
+		return errors.New("OpenEthereum healthcheck improperly disabled")
+	}
+
+	fmt.Println(testConfig.passMessage)
+	return nil
+}
+
+//Check the healthcheck successfully disables the prometheus endpoint
+func disableMetricsTest(testConfig *testConfigStruct, healthChan chan Log) error {
+	fmt.Println("disableOpenEthereumPrimaryCheck")
+
+	if testConfig.verbose {
+		fmt.Println("Disable the both OpenEthereum and primary healthcheck")
+	}
+	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
+	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: false}
+	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	Init(healthChan)
+
+	if testConfig.verbose {
+		fmt.Println("Retrieve metrics endpoint response code")
+	}
+	res, err := http.Get(testConfig.nodehealthAddress + "/metrics")
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	if res.StatusCode != 404 {
+		return errors.New("Prometheus metrics not properly disabled")
+	}
+
+	fmt.Println(testConfig.passMessage)
+	return nil
+}
+
+func testServerResponse(testConfig *testConfigStruct, mode string, healthChan chan Log) error {
+	function := "testServerResponse: "
+	time.Sleep(testConfig.startUpSleepTime)
+	//Test server response
+	res, err := http.Get(testConfig.nodehealthAddress + testConfig.readinessEndpoint)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	if mode == "ready" {
+		if res.StatusCode != testConfig.successfulStatus {
+			return errors.New(function + "Error - node not ready")
+		}
+	} else if mode == "notReady" {
+		if res.StatusCode == testConfig.successfulStatus {
+			return errors.New(function + "Error - node ready")
+		}
+	}
+
+	fmt.Println(testConfig.passMessage)
+	return nil
+}
+
+func openethereumFailureTest(testConfig *testConfigStruct, healthChan chan Log) error {
+	fmt.Println("openethereumFailureTest")
+
+	if testConfig.verbose {
+		fmt.Println("Prepare healthcheck server for failure testing ")
+	}
+	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: true}
+	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: false}
+	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+
+	Init(healthChan)
+
+	healthChan <- Log{Config: true, Var: "openethereumHealthcheckRPC", ValStr: "http://127.0.0.1:0000"}
+	healthChan <- Log{Config: true, Var: "openethereumHealthcheckRPCPort", ValStr: testConfig.passServerPort}
 	healthChan <- Log{Comp: "InboxReader", Var: "loadingDatabase", ValBool: false}
-	const smallBigInt = 10
+
 	blockTest := big.NewInt(10)
-	healthChan <- Log{Comp: config.inboxReaderName, Var: "arbCorePosition", ValBigInt: new(big.Int).Set(blockTest)}
-	healthChan <- Log{Comp: config.inboxReaderName, Var: "caughtUpTarget", ValBigInt: new(big.Int).Set(blockTest)}
-	time.Sleep(config.timeDelayTests)
+	healthChan <- Log{Comp: testConfig.inboxReaderName, Var: "arbCorePosition", ValBigInt: new(big.Int).Set(blockTest)}
+	healthChan <- Log{Comp: testConfig.inboxReaderName, Var: "caughtUpTarget", ValBigInt: new(big.Int).Set(blockTest)}
+	time.Sleep(testConfig.timeDelayTests)
 
-	//Test server response
-	res, err := http.Get(config.nodehealthAddress + config.readinessEndpoint + "?full=1")
-
+	if testConfig.verbose {
+		fmt.Println("Check the server is ready before OpenEthereum fails")
+	}
+	err := testServerResponse(testConfig, "ready", healthChan)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
-	if res.StatusCode != config.successfulStatus {
-		//The server is returning an unexpected status code
-		fmt.Println(config.failMessage)
-		return errors.New("Failed test without primary - exiting")
+
+	if testConfig.verbose {
+		fmt.Println("Simulate OpenEthereum failure")
 	}
-	fmt.Println(config.passMessage)
-	fmt.Println("")
+	healthChan <- Log{Config: true, Var: "openethereumHealthcheckRPCPort", ValStr: testConfig.failServerPort}
+	time.Sleep(testConfig.timeDelayTests)
+
+	if testConfig.verbose {
+		fmt.Println("Check the server is not ready after OpenEthereum fails")
+	}
+	err = testServerResponse(testConfig, "notReady", healthChan)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(testConfig.passMessage)
 	return nil
 }
 
-func openEthereumFailure(healthChan chan Log, config *configTestStruct) error {
-	fmt.Println("Failing OpenEthereum Node Test")
-	healthChan <- Log{Config: true, Var: "openethereumHealthcheckRPCPort", ValStr: "8088"}
+func primaryFailureTest(testConfig *testConfigStruct, healthChan chan Log) error {
+	fmt.Println("primaryFailureTest")
 
-	time.Sleep(config.timeDelayTests)
-	//Test server response
-	res, err := http.Get(config.nodehealthAddress + "/ready")
+	if testConfig.verbose {
+		fmt.Println("Prepare healthcheck server for failure testing ")
+	}
+	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
+	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: true}
+	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+
+	Init(healthChan)
+
+	healthChan <- Log{Comp: "InboxReader", Var: "loadingDatabase", ValBool: false}
+	blockTest := big.NewInt(10)
+	healthChan <- Log{Comp: testConfig.inboxReaderName, Var: "arbCorePosition", ValBigInt: new(big.Int).Set(blockTest)}
+	healthChan <- Log{Comp: testConfig.inboxReaderName, Var: "caughtUpTarget", ValBigInt: new(big.Int).Set(blockTest)}
+
+	healthChan <- Log{Config: true, Var: "primaryHealthcheckRPC", ValStr: "http://127.0.0.1:0000"}
+	healthChan <- Log{Config: true, Var: "primaryHealthcheckRPCPort", ValStr: testConfig.passServerPort}
+	time.Sleep(testConfig.timeDelayTests)
+
+	if testConfig.verbose {
+		fmt.Println("Check the server is ready before the primary fails")
+	}
+	err := testServerResponse(testConfig, "ready", healthChan)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
-	if res.StatusCode == config.successfulStatus {
-		//The server is returning an unexpected status code
-		fmt.Println(config.failMessage)
-		return errors.New("Failed test of OpenEthereum failure - exiting")
+
+	if testConfig.verbose {
+		fmt.Println("Simulate primary failure")
 	}
-	fmt.Println(config.passMessage)
-	fmt.Println("")
+	healthChan <- Log{Config: true, Var: "primaryHealthcheckRPCPort", ValStr: testConfig.failServerPort}
+	time.Sleep(testConfig.timeDelayTests)
+
+	if testConfig.verbose {
+		fmt.Println("Check the server is not ready after primary fails")
+	}
+	err = testServerResponse(testConfig, "notReady", healthChan)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(testConfig.passMessage)
 	return nil
 }
 
-func addPrimaryWhileRunning(healthChan chan Log, config *configTestStruct) error {
-	fmt.Println("Adding Primary Late Test")
-	healthChan <- Log{Config: true, Var: "openethereumHealthcheckRPCPort", ValStr: "8089"}
-	healthChan <- Log{Config: true, Var: "primaryHealthcheckRPC", ValStr: "http://127.0.0.1:9010"}
-	healthChan <- Log{Config: true, Var: "primaryHealthcheckRPCPort", ValStr: "8089"}
+func inboxReaderCatchUpTest(testConfig *testConfigStruct, healthChan chan Log) error {
+	fmt.Println("inboxReaderCatchUpTest")
 
-	time.Sleep(config.timeDelayTests)
+	if testConfig.verbose {
+		fmt.Println("Prepare healthcheck server for InboxReader testing ")
+	}
+	healthChan <- Log{Config: true, Var: "disablePrimaryCheck", ValBool: true}
+	healthChan <- Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: true}
+	healthChan <- Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
+	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
 
-	//Test server response
-	res, err := http.Get(config.nodehealthAddress + config.readinessEndpoint)
+	Init(healthChan)
+
+	healthChan <- Log{Comp: "InboxReader", Var: "loadingDatabase", ValBool: false}
+	blockTest := big.NewInt(10)
+	healthChan <- Log{Comp: testConfig.inboxReaderName, Var: "arbCorePosition", ValBigInt: new(big.Int).Set(blockTest)}
+	healthChan <- Log{Comp: testConfig.inboxReaderName, Var: "caughtUpTarget", ValBigInt: new(big.Int).Set(blockTest)}
+	time.Sleep(testConfig.timeDelayTests)
+
+	if testConfig.verbose {
+		fmt.Println("Check the server is ready when arbCorePosition == caughtUpTarget")
+	}
+	err := testServerResponse(testConfig, "ready", healthChan)
 	if err != nil {
 		return err
 	}
-	if res.StatusCode != config.successfulStatus {
-		//The server is returning an unexpected status code
-		fmt.Println(config.failMessage)
-		return errors.New("Failed adding primary while running test - exiting")
+
+	if testConfig.verbose {
+		fmt.Println("Set caughtUpTarget > tolerance blocks away from arbCorePosition")
 	}
-	healthChan <- Log{Config: true, Var: "primaryHealthcheckRPCPort", ValStr: "8088"}
+	caughtUpTarget := big.NewInt(20)
+	healthChan <- Log{Comp: testConfig.inboxReaderName, Var: "arbCorePosition", ValBigInt: new(big.Int).Set(blockTest)}
+	healthChan <- Log{Comp: testConfig.inboxReaderName, Var: "caughtUpTarget", ValBigInt: new(big.Int).Set(caughtUpTarget)}
+	time.Sleep(testConfig.timeDelayTests)
 
-	time.Sleep(config.timeDelayTests)
-
-	//Test server response
-	res, err = http.Get(config.nodehealthAddress + config.readinessEndpoint)
+	if testConfig.verbose {
+		fmt.Println("Check the server is not ready when arbCorePosition is greater than the tolerance from caughtUpTarget")
+	}
+	err = testServerResponse(testConfig, "notReady", healthChan)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
-	if res.StatusCode == config.successfulStatus {
-		//The server is returning an unexpected status code
-		fmt.Println(config.failMessage)
-		return errors.New("Failed adding primary while running test - exiting")
+
+	if testConfig.verbose {
+		fmt.Println("Set arbCorePosition > caughtUpTarget (specific issue that occurs when primary fails during refresh)")
 	}
-	fmt.Println(config.passMessage)
+	arbCorePosition := big.NewInt(40)
+	healthChan <- Log{Comp: testConfig.inboxReaderName, Var: "arbCorePosition", ValBigInt: new(big.Int).Set(arbCorePosition)}
+	healthChan <- Log{Comp: testConfig.inboxReaderName, Var: "caughtUpTarget", ValBigInt: new(big.Int).Set(caughtUpTarget)}
+	time.Sleep(testConfig.timeDelayTests)
 
-	fmt.Println("")
-	return nil
-}
-
-func inboxReaderTest(healthChan chan Log, config *configTestStruct) error {
-	fmt.Println("Test InboxReader blockStatus")
-	healthChan <- Log{Config: true, Var: "primaryHealthcheckRPCPort", ValStr: "8089"}
-	time.Sleep(config.timeDelayTests)
-	const largeBigInt = 20
-	testBigInt := big.NewInt(largeBigInt)
-	healthChan <- Log{Comp: config.inboxReaderName, Var: "currentHeight", ValBigInt: new(big.Int).Set(testBigInt)}
-	healthChan <- Log{Comp: config.inboxReaderName, Var: "caughtUpTarget", ValBigInt: new(big.Int).Set(testBigInt)}
-	healthChan <- Log{Comp: config.inboxReaderName, Var: "arbCorePosition", ValBigInt: new(big.Int).Set(testBigInt)}
-	healthChan <- Log{Comp: config.inboxReaderName, Var: "getNextBlockToRead", ValBigInt: new(big.Int).Set(testBigInt)}
-
-	//Test server response
-	res, err := http.Get(config.nodehealthAddress + config.readinessEndpoint)
+	if testConfig.verbose {
+		fmt.Println("Check the server is ready when arbCorePosition is greater than caughtUpTarget")
+	}
+	err = testServerResponse(testConfig, "ready", healthChan)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
-	if res.StatusCode != config.successfulStatus {
-		fmt.Println(config.failMessage)
-		//The server is returning an unexpected status code
-		return errors.New("Failed inbox reader test - exiting")
-	}
 
-	const smallBigInt = 10
-	blockTest := big.NewInt(smallBigInt)
-	healthChan <- Log{Comp: config.inboxReaderName, Var: "arbCorePosition", ValBigInt: new(big.Int).Set(blockTest)}
-	healthChan <- Log{Comp: config.inboxReaderName, Var: "caughtUpTarget", ValBigInt: new(big.Int).Set(testBigInt)}
-	time.Sleep(config.timeDelayTests)
-	time.Sleep(config.timeDelayTests)
-
-	//Test server response
-	res, err = http.Get(config.nodehealthAddress + config.readinessEndpoint)
-
-	if err != nil {
-		fmt.Println(err)
-		return err
-	}
-	if res.StatusCode == config.successfulStatus {
-		//The server is returning an unexpected status code
-		fmt.Println(config.failMessage)
-		return errors.New("Failed inbox reader test - exiting")
-	}
-	fmt.Println(config.passMessage)
+	fmt.Println(testConfig.passMessage)
 	return nil
 }
 
 func TestNodeHealth(t *testing.T) {
-	config := configTestStruct{}
-	config.newTestConfig()
-	ctx := context.Background()
+	//Load the unit test configuration variables
+	testConfig := newTestConfig()
+	healthChan := make(chan Log, testConfig.bufferSize)
 
 	//Generate sample servers for testing
-	go startTestingServerFail()
-	go startTestingServerPass()
+	go startTestingServerFail(testConfig)
+	go startTestingServerPass(testConfig)
 
-	healthChan := make(chan Log, config.largeBufferSize)
+	//Start the healthcheck server with a background context for testing
+	ctx, cancel := context.WithCancel(context.Background())
 	go StartNodeHealthCheck(ctx, healthChan)
-	healthChan <- Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
-	//healthChan <- Log{Config: true, Var: "openEthereumAPI", ValStr: "https://eth-kovan.alchemyapi.io/v2/yvzMZUhX0jmdpRfqrUEGwh--U59mJNhf"}
-	//Test startup configuration delay
-	//time.Sleep(200 * time.Second)
-	err := startUpTest(&config)
+
+	//Test the startup delay works properly
+	err := startUpDelayTest(testConfig, healthChan)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	//Primary aSync Test
-	err = aSyncTest(healthChan, &config)
+	//Test the server performs a graceful shutdown when the CloseFunc is called
+	err = gracefulShutdownTest(cancel, testConfig, healthChan)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	//Test failing OpenEthereum Node
-	err = openEthereumFailure(healthChan, &config)
+	//Restart the healthcheck server with a fresh context and healthchan
+	ctx, cancel = context.WithCancel(context.Background())
+	healthChan = make(chan Log, testConfig.bufferSize)
+	go StartNodeHealthCheck(ctx, healthChan)
+
+	//Test the server doesn't bind when the healthcheck is disabled
+	err = disableHealthcheckTest(testConfig, healthChan)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	//Test adding primary after start
-	err = addPrimaryWhileRunning(healthChan, &config)
+	//Restart the healthcheck server with a fresh context and healthchan
+	cancel()
+	time.Sleep(5 * time.Second) //TCP Timeout
+	ctx, cancel = context.WithCancel(context.Background())
+	healthChan = make(chan Log, testConfig.bufferSize)
+	go StartNodeHealthCheck(ctx, healthChan)
+
+	//Test the server removes the primary healthcheck when it is disabled
+	err = disablePrimaryCheckTest(testConfig, healthChan)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	//Test InboxReader block status check
-	err = inboxReaderTest(healthChan, &config)
+	//Restart the healthcheck server with a fresh context and healthchan
+	cancel()
+	time.Sleep(5 * time.Second) //TCP Timeout
+	ctx, cancel = context.WithCancel(context.Background())
+	healthChan = make(chan Log, testConfig.bufferSize)
+	go StartNodeHealthCheck(ctx, healthChan)
+
+	//Test the server removes the OpenEthereum healthcheck when it is disabled
+	err = disableOpenEthereumCheckTest(testConfig, healthChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Restart the healthcheck server with a fresh context and healthchan
+	cancel()
+	time.Sleep(5 * time.Second) //TCP Timeout
+	ctx, cancel = context.WithCancel(context.Background())
+	healthChan = make(chan Log, testConfig.bufferSize)
+	go StartNodeHealthCheck(ctx, healthChan)
+
+	//Test the healthcheck can disable both OpenEthereum and primary check
+	err = disableOpenEthereumPrimaryCheckTest(testConfig, healthChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Test whether metrics are disabled on the healthcheck
+	err = disableMetricsTest(testConfig, healthChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Restart the healthcheck server with a fresh context and healthchan
+	cancel()
+	time.Sleep(5 * time.Second) //TCP Timeout
+	ctx, cancel = context.WithCancel(context.Background())
+	healthChan = make(chan Log, testConfig.bufferSize)
+	go StartNodeHealthCheck(ctx, healthChan)
+
+	//OpenEthereum failure test
+	err = openethereumFailureTest(testConfig, healthChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Restart the healthcheck server with a fresh context and healthchan
+	cancel()
+	time.Sleep(5 * time.Second) //TCP Timeout
+	ctx, cancel = context.WithCancel(context.Background())
+	healthChan = make(chan Log, testConfig.bufferSize)
+	go StartNodeHealthCheck(ctx, healthChan)
+
+	//Primary failure test
+	err = primaryFailureTest(testConfig, healthChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Restart the healthcheck server with a fresh context and healthchan
+	cancel()
+	time.Sleep(5 * time.Second) //TCP Timeout
+	ctx, cancel = context.WithCancel(context.Background())
+	healthChan = make(chan Log, testConfig.bufferSize)
+	go StartNodeHealthCheck(ctx, healthChan)
+
+	//Test InboxReader catch up status
+	err = inboxReaderCatchUpTest(testConfig, healthChan)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/packages/arb-node-core/staker/staker_test.go
+++ b/packages/arb-node-core/staker/staker_test.go
@@ -183,7 +183,7 @@ func runStakersTest(t *testing.T, faultConfig challenge.FaultConfig, maxGasPerNo
 	const largeChannelBuffer = 200
 	healthChan := make(chan nodehealth.Log, largeChannelBuffer)
 	go func() {
-		nodehealth.NodeHealthCheck(healthChan)
+		nodehealth.StartNodeHealthCheck(ctx, healthChan)
 	}()
 
 	reader, err := NewInboxReader(ctx, bridge, core, healthChan)

--- a/packages/arb-node-core/staker/staker_test.go
+++ b/packages/arb-node-core/staker/staker_test.go
@@ -182,6 +182,12 @@ func runStakersTest(t *testing.T, faultConfig challenge.FaultConfig, maxGasPerNo
 
 	const largeChannelBuffer = 200
 	healthChan := make(chan nodehealth.Log, largeChannelBuffer)
+	healthChan <- nodehealth.Log{Config: true, Var: "disablePrimaryCheck", ValBool: false}
+	healthChan <- nodehealth.Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: true}
+	healthChan <- nodehealth.Log{Config: true, Var: "healthcheckMetrics", ValBool: false}
+	healthChan <- nodehealth.Log{Config: true, Var: "healthcheckRPC", ValStr: "0.0.0.0:8080"}
+	nodehealth.Init(healthChan)
+
 	go func() {
 		nodehealth.StartNodeHealthCheck(ctx, healthChan)
 	}()

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -93,7 +93,6 @@ func main() {
 	healthChan <- nodehealth.Log{Config: true, Var: "disablePrimaryCheck", ValBool: *disablePrimaryCheck}
 	healthChan <- nodehealth.Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: *disableOpenEthereumCheck}
 	healthChan <- nodehealth.Log{Config: true, Var: "healthcheckRPC", ValStr: *healthcheckRPC}
-	nodehealth.Init(healthChan)
 
 	maxBatchTime := fs.Int64(
 		"maxBatchTime",
@@ -151,6 +150,7 @@ func main() {
 		healthChan <- nodehealth.Log{Config: true, Var: "primaryHealthcheckRPC", ValStr: *forwardTxURL}
 	}
 	healthChan <- nodehealth.Log{Config: true, Var: "openethereumHealthcheckRPC", ValStr: rollupArgs.EthURL}
+	nodehealth.Init(healthChan)
 
 	var batcherMode rpc.BatcherMode
 	if *forwardTxURL != "" {

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -83,6 +83,17 @@ func main() {
 	keepPendingState := fs.Bool("pending", false, "enable pending state tracking")
 	waitToCatchUp := fs.Bool("wait-to-catch-up", false, "wait to catch up to the chain before opening the RPC")
 
+	//Healthcheck Config
+	disableHealthcheck := fs.Bool("disable-healthcheck", false, "disable the healthcheck server")
+	disablePrimaryCheck := fs.Bool("disable-primary-check", false, "disable checking the health of the primary")
+	disableOpenEthereumCheck := fs.Bool("disable-openethereum-check", false, "disable checking the health of the OpenEthereum node")
+	healthcheckRPC := fs.String("healthcheck-rpc", "", "address to bind the healthcheck RPC to")
+
+	healthChan <- nodehealth.Log{Config: true, Var: "disableHealthcheck", ValBool: *disableHealthcheck}
+	healthChan <- nodehealth.Log{Config: true, Var: "disablePrimaryCheck", ValBool: *disablePrimaryCheck}
+	healthChan <- nodehealth.Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: *disableOpenEthereumCheck}
+	healthChan <- nodehealth.Log{Config: true, Var: "healthcheckRPC", ValStr: *healthcheckRPC}
+
 	maxBatchTime := fs.Int64(
 		"maxBatchTime",
 		10,

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -84,15 +84,16 @@ func main() {
 	waitToCatchUp := fs.Bool("wait-to-catch-up", false, "wait to catch up to the chain before opening the RPC")
 
 	//Healthcheck Config
-	disableHealthcheck := fs.Bool("disable-healthcheck", false, "disable the healthcheck server")
 	disablePrimaryCheck := fs.Bool("disable-primary-check", false, "disable checking the health of the primary")
 	disableOpenEthereumCheck := fs.Bool("disable-openethereum-check", false, "disable checking the health of the OpenEthereum node")
+	healthcheckMetrics := fs.Bool("metrics", false, "enable prometheus endpoint")
 	healthcheckRPC := fs.String("healthcheck-rpc", "", "address to bind the healthcheck RPC to")
 
-	healthChan <- nodehealth.Log{Config: true, Var: "disableHealthcheck", ValBool: *disableHealthcheck}
+	healthChan <- nodehealth.Log{Config: true, Var: "healthcheckMetrics", ValBool: *healthcheckMetrics}
 	healthChan <- nodehealth.Log{Config: true, Var: "disablePrimaryCheck", ValBool: *disablePrimaryCheck}
 	healthChan <- nodehealth.Log{Config: true, Var: "disableOpenEthereumCheck", ValBool: *disableOpenEthereumCheck}
 	healthChan <- nodehealth.Log{Config: true, Var: "healthcheckRPC", ValStr: *healthcheckRPC}
+	nodehealth.Init(healthChan)
 
 	maxBatchTime := fs.Int64(
 		"maxBatchTime",

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -65,17 +65,18 @@ func main() {
 	// Print line number that log was created on
 	logger = log.With().Caller().Stack().Str("component", "arb-node").Logger()
 
+	ctx := context.Background()
+
 	const largeChannelBuffer = 200
 	healthChan := make(chan nodehealth.Log, largeChannelBuffer)
 
 	go func() {
-		err := nodehealth.NodeHealthCheck(healthChan)
+		err := nodehealth.StartNodeHealthCheck(ctx, healthChan)
 		if err != nil {
 			log.Error().Err(err).Msg("healthcheck server failed")
 		}
 	}()
 
-	ctx := context.Background()
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	walletArgs := cmdhelp.AddWalletFlags(fs)
 	rpcVars := utils2.AddRPCFlags(fs)


### PR DESCRIPTION
- Refactor unit tests for more coverage
- Add internal OpenEthereum check for providers not running our OE healthcheck
- Patch error that occurs when primary fails during snapshot refresh
- Add command line configuration of the healthcheck
- Allow individual checks to be disabled
- Integrate graceful shutdowns 
- Add prometheus metrics handler
