### PR TITLE
Code cache

### DIFF
--- a/packages/arb-rpc-node/arbosmachine/arbostestmachine.go
+++ b/packages/arb-rpc-node/arbosmachine/arbostestmachine.go
@@ -43,8 +43,11 @@ func (m *TestMachine) ExecuteAssertion(
 	goOverGas bool,
 	messages []inbox.InboxMessage,
 	finalMessageOfBlock bool,
-) (*protocol.ExecutionAssertion, []value.Value, uint64) {
-	assertion, debugPrints, numSteps := m.Machine.ExecuteAssertion(maxGas, goOverGas, messages, finalMessageOfBlock)
+) (*protocol.ExecutionAssertion, []value.Value, uint64, error) {
+	assertion, debugPrints, numSteps, err := m.Machine.ExecuteAssertion(maxGas, goOverGas, messages, finalMessageOfBlock)
+	if err != nil {
+		return nil, nil, 0, err
+	}
 	for _, d := range debugPrints {
 		parsed, err := handleDebugPrint(d)
 		if err != nil {
@@ -53,5 +56,5 @@ func (m *TestMachine) ExecuteAssertion(
 			m.t.Log("debugprint", parsed)
 		}
 	}
-	return assertion, debugPrints, numSteps
+	return assertion, debugPrints, numSteps, nil
 }

--- a/packages/arb-rpc-node/arbosmachine/debugprint.go
+++ b/packages/arb-rpc-node/arbosmachine/debugprint.go
@@ -1,0 +1,289 @@
+/*
+* Copyright 2020-2021, Offchain Labs, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package arbosmachine
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+
+	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
+	"github.com/offchainlabs/arbitrum/packages/arb-util/inbox"
+	"github.com/offchainlabs/arbitrum/packages/arb-util/value"
+)
+
+type callFrameAddresses struct {
+	executor common.Address
+	code     common.Address
+}
+
+func (cf callFrameAddresses) String() string {
+	return fmt.Sprintf("{executor: %v, code: %v}", cf.executor, cf.code)
+}
+
+func (cf callFrameAddresses) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("executor", cf.executor.Hex()).Str("code", cf.code.Hex())
+}
+
+func (cf callFrameAddresses) same() bool {
+	return cf.executor == cf.code
+}
+
+func getAddresses(val value.Value) (callFrameAddresses, error) {
+	tup, ok := val.(*value.TupleValue)
+	if !ok || tup.Len() != 2 {
+		return callFrameAddresses{}, errors.New("addresses wasn't a 2-tuple")
+	}
+	executorAddressVal, _ := tup.GetByInt64(0)
+	codeAddressVal, _ := tup.GetByInt64(1)
+
+	executorAddressInt, ok := executorAddressVal.(value.IntValue)
+	if !ok {
+		return callFrameAddresses{}, errors.New("expected first address to be int")
+	}
+
+	codeAddressInt, ok := codeAddressVal.(value.IntValue)
+	if !ok {
+		return callFrameAddresses{}, errors.New("expected second address to be int")
+	}
+	cf := callFrameAddresses{
+		executor: inbox.NewAddressFromInt(executorAddressInt),
+		code:     inbox.NewAddressFromInt(codeAddressInt),
+	}
+	return cf, nil
+}
+
+type DebugPrintLog struct {
+	txId    common.Hash
+	current callFrameAddresses
+	parent  callFrameAddresses
+	kind    string
+	pc      *uint64
+}
+
+func (d *DebugPrintLog) String() string {
+	ret := ""
+	ret += fmt.Sprintf("DebugPrintLog{txId: %v, kind: %v", d.txId, d.kind)
+	if d.current.same() {
+		ret += fmt.Sprintf(", current: %v", d.current.code)
+	} else {
+		ret += fmt.Sprintf(", current: %v", d.current)
+	}
+	if d.parent.same() {
+		emptyAddress := common.Address{}
+		if d.parent.code != emptyAddress {
+			ret += fmt.Sprintf(", parent: %v", d.parent.code)
+		}
+	} else {
+		ret += fmt.Sprintf(", parent: %v", d.parent)
+	}
+	if d.pc != nil {
+		ret += fmt.Sprintf(", pc: %v", *d.pc)
+	}
+	ret += "}"
+	return ret
+}
+
+func (d *DebugPrintLog) MarshalZerologObject(e *zerolog.Event) {
+	e.Hex("tx_id", d.txId[:]).Str("kind", d.kind)
+	if d.current.same() {
+		e.Str("current", d.current.code.Hex())
+	} else {
+		e.Object("current", d.current)
+	}
+
+	if d.parent.same() {
+		emptyAddress := common.Address{}
+		if d.parent.code != emptyAddress {
+			e.Str("parent", d.parent.code.Hex())
+		}
+	} else {
+		e.Object("parent", d.parent)
+	}
+	if d.pc != nil {
+		e.Uint64("pc", *d.pc)
+	}
+}
+
+func generateLog(txID, currentFrame, parentFrame value.Value, kind string, pc *uint64) (*DebugPrintLog, error) {
+	txIDInt, ok := txID.(value.IntValue)
+	if !ok {
+		return nil, errors.New("expected txid to be int")
+	}
+	current, err := getAddresses(currentFrame)
+	if err != nil {
+		return nil, err
+	}
+	parent, err := getAddresses(parentFrame)
+	if err != nil {
+		return nil, err
+	}
+	return &DebugPrintLog{
+		txId:    txIDInt.ToBytes(),
+		current: current,
+		parent:  parent,
+		kind:    kind,
+		pc:      pc,
+	}, nil
+}
+
+func decodeEVMCallError(errorCode uint64) string {
+	switch errorCode {
+	case 0:
+		return "application code error"
+	case 1:
+		return "Failed to transfer eth balance to contract: insufficient balance or unknown error"
+	case 2:
+		return "Can't pay for gas to contract"
+	case 3:
+		return "Failed to transfer eth balance to EOA"
+	case 4:
+		return "Can't pay for gas in constructor"
+	case 5:
+		return "Somehow the constructor didn't have storage"
+	case 7:
+		return "Should never reach end of call entry function"
+	case 8:
+		return "Should never reach end of call return function"
+	case 9:
+		return "Should never reach end of call return function"
+	case 10:
+		return "Called evmCallStack_getTopFrameMemoryOrDie while not in global stack frame"
+	case 11:
+		return "EVM code tried to jump to a forbidden EVM jump destination"
+	case 12:
+		return "Shouldn't reach at end of evmOp_getjumpaddr function"
+	case 14:
+		return "Called evmCallStack_queueMessage while not in global stack frame"
+	case 15:
+		return "Can't pay for gas in constructor"
+	case 17:
+		return "Called arbAddressTable_txcall while not in EVM tx"
+	case 18:
+		return "Called arbBLS_txcall or arbFunctionTable_txcall while not in EVM tx"
+	case 19:
+		return "Called arbosTest_txcall while not in EVM tx or error in snapshotAuxStack or restoreAuxStackAndCall"
+	case 20:
+		return "Chain hasn't been initialized"
+	case 21:
+		return "Called arbsys_txcall while not in EVM tx"
+	case 22:
+		return "Called arbowner_txcall while not in EVM tx"
+	case 23:
+		return "generateCodeForEvmSegment pushN without data"
+	default:
+		return "unknown"
+	}
+}
+
+type EVMCallError struct {
+	description string
+	errorCode   uint64
+}
+
+func (e *EVMCallError) String() string {
+	return fmt.Sprintf("EVMCallError{description: %v, errorCode: %v", e.description, e.errorCode)
+}
+
+func (e *EVMCallError) MarshalZerologObject(event *zerolog.Event) {
+	event.
+		Str("description", e.description).
+		Str("kind", "evm_call_error").
+		Uint64("error_code", e.errorCode)
+}
+
+type ErrorHandlerError struct {
+}
+
+func (e *ErrorHandlerError) String() string {
+	return fmt.Sprintf("ErrorHandlerError{error_in_error_handler}")
+}
+
+func (e *ErrorHandlerError) MarshalZerologObject(event *zerolog.Event) {
+	event.Str("kind", "error_in_error_handler")
+}
+
+type EVMLogLine interface {
+	zerolog.LogObjectMarshaler
+}
+
+func handleDebugPrint(d value.Value) (EVMLogLine, error) {
+	tup, ok := d.(*value.TupleValue)
+	if !ok || tup.Len() == 0 {
+		return nil, errors.New("expected debugprint to be tuple")
+	}
+	// Tuple already checked to be at least size 1
+	debugPrintType, _ := tup.GetByInt64(0)
+	debugPrintTypeInt, ok := debugPrintType.(value.IntValue)
+	if !ok {
+		return nil, errors.New("expected debugprint typecode to be int")
+	}
+	typ := debugPrintTypeInt.BigInt().Uint64()
+	if typ == 664 {
+		if tup.Len() != 2 {
+			return nil, errors.New("expected type 664 to be 2-tuple")
+		}
+		subCodeVal, _ := tup.GetByInt64(1)
+		subCodeInt, ok := subCodeVal.(value.IntValue)
+		if !ok {
+			return nil, errors.New("expected type 664 to have subcode")
+		}
+		errorCode := subCodeInt.BigInt().Uint64()
+		errorStr := decodeEVMCallError(errorCode)
+		return &EVMCallError{
+			description: errorStr,
+			errorCode:   errorCode,
+		}, nil
+	} else if typ == 666 && tup.Len() == 1 {
+		return &ErrorHandlerError{}, nil
+	} else if typ == 665 || typ == 666 {
+		var kind string
+		if typ == 665 {
+			kind = "out_of_gas"
+		} else {
+			kind = "hit_error_handler"
+		}
+
+		if tup.Len() != 4 {
+			return nil, errors.New("expected 665 or 666 to be 4-tuple")
+		}
+		txID, _ := tup.GetByInt64(1)
+		currentFrame, _ := tup.GetByInt64(2)
+		parentFrame, _ := tup.GetByInt64(3)
+
+		return generateLog(txID, currentFrame, parentFrame, kind, nil)
+	} else if typ == 10000 {
+		if tup.Len() != 6 {
+			return nil, errors.New("expected type 10000 to be 6-tuple")
+		}
+		evmPC, _ := tup.GetByInt64(2)
+		txID, _ := tup.GetByInt64(3)
+		currentFrame, _ := tup.GetByInt64(4)
+		parentFrame, _ := tup.GetByInt64(5)
+
+		evmPCInt, ok := evmPC.(value.IntValue)
+		if !ok {
+			return nil, errors.New("expected pc to be in")
+		}
+		pc := evmPCInt.BigInt().Uint64()
+
+		return generateLog(txID, currentFrame, parentFrame, "evm_revert", &pc)
+	} else {
+		return nil, errors.New("unknown debug print type")
+	}
+}

--- a/packages/arb-rpc-node/arbostest/arbos_test.go
+++ b/packages/arb-rpc-node/arbostest/arbos_test.go
@@ -75,7 +75,7 @@ func TestFib(t *testing.T) {
 		message.NewSafeL2Message(getFibTx),
 	}
 
-	logs, _, snap, _ := runSimpleAssertion(t, messages)
+	logs, _, snap := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 	allResultsSucceeded(t, results)
 	checkConstructorResult(t, results[1], connAddress1)
@@ -111,7 +111,7 @@ func TestDeposit(t *testing.T) {
 		makeEthDeposit(sender, amount),
 	}
 
-	_, _, snap, _ := runSimpleAssertion(t, messages)
+	_, _, snap := runSimpleAssertion(t, messages)
 	checkBalance(t, snap, sender, amount)
 }
 
@@ -247,7 +247,7 @@ func TestBlocks(t *testing.T) {
 	}
 
 	// Last value returned is not an error type
-	avmLogs, sends, _, _ := runAssertion(t, messages, len(resultTypes), sendCount)
+	avmLogs, sends, _ := runAssertion(t, messages, len(resultTypes), sendCount)
 	results := make([]evm.Result, 0)
 	for _, avmLog := range avmLogs {
 		res, err := evm.NewResultFromValue(avmLog)

--- a/packages/arb-rpc-node/arbostest/arbsys_test.go
+++ b/packages/arb-rpc-node/arbostest/arbsys_test.go
@@ -175,7 +175,7 @@ func TestTransactionCount(t *testing.T) {
 		message.NewInboxMessage(makeTxCountCall(sender), common.Address{}, big.NewInt(19), big.NewInt(0), chainTime),
 	}
 
-	logs, _, _, _ := runAssertion(t, messages, len(messages)-1, 0)
+	logs, _, _ := runAssertion(t, messages, len(messages)-1, 0)
 	results := processTxResults(t, logs)
 
 	checkTxCountResult(t, results[0], big.NewInt(0))
@@ -283,7 +283,7 @@ func TestAddressTable(t *testing.T) {
 		senderSeq++
 	}
 
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 
 	revertedTxCheck(t, results[0])
@@ -407,7 +407,7 @@ func TestArbSysBLS(t *testing.T) {
 		senderSeq++
 	}
 
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 
 	revertedTxCheck(t, results[0])
@@ -475,7 +475,7 @@ func TestArbSysFunctionTable(t *testing.T) {
 		senderSeq++
 	}
 
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 
 	revertedTxCheck(t, results[0])

--- a/packages/arb-rpc-node/arbostest/code_cache_test.go
+++ b/packages/arb-rpc-node/arbostest/code_cache_test.go
@@ -20,45 +20,52 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/offchainlabs/arbitrum/packages/arb-evm/message"
+	"github.com/offchainlabs/arbitrum/packages/arb-rpc-node/arbostestcontracts"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 )
 
 func TestCodeCache(t *testing.T) {
+	skipBelowVersion(t, 8)
 	tx1 := message.Transaction{
 		MaxGas:      big.NewInt(10000000),
 		GasPriceBid: big.NewInt(0),
 		SequenceNum: big.NewInt(0),
-		DestAddress: common.RandAddress(),
+		DestAddress: common.Address{},
 		Payment:     big.NewInt(0),
-		Data:        common.RandBytes(1000),
+		Data:        hexutil.MustDecode(arbostestcontracts.FailedSendBin),
 	}
-	//tx2 := message.Transaction{
-	//	MaxGas:      big.NewInt(10000000),
-	//	GasPriceBid: big.NewInt(0),
-	//	SequenceNum: big.NewInt(1),
-	//	DestAddress: common.Address{},
-	//	Payment:     big.NewInt(0),
-	//	Data:        hexutil.MustDecode(arbostestcontracts.FailedSendBin),
-	//}
+	tx2 := message.Transaction{
+		MaxGas:      big.NewInt(10000000),
+		GasPriceBid: big.NewInt(0),
+		SequenceNum: big.NewInt(1),
+		DestAddress: common.Address{},
+		Payment:     big.NewInt(0),
+		Data:        hexutil.MustDecode(arbostestcontracts.FailedSendBin),
+	}
 
 	messages := []message.Message{
 		message.NewSafeL2Message(tx1),
-		//message.NewSafeL2Message(tx2),
+		message.NewSafeL2Message(tx2),
 	}
 
-	logs, _, _, assertion := runAssertionWithoutPrint(t, makeSimpleInbox(messages), len(messages), 0)
+	logs, _, _ := runAssertionWithoutPrint(t, makeSimpleInbox(messages), len(messages), 0)
 	results := processTxResults(t, logs)
-	//checkConstructorResult(t, results[0], connAddress1)
-	//checkConstructorResult(t, results[1], connAddress2)
-	//if arbosVersion < 8 {
-	//
-	//}
+	checkConstructorResult(t, results[0], connAddress1)
+	checkConstructorResult(t, results[1], connAddress2)
+
+	res1Units := results[0].FeeStats.UnitsUsed
+	res2Units := results[1].FeeStats.UnitsUsed
+
 	t.Log(results[0].FeeStats.UnitsUsed)
-	//t.Log(results[1].FeeStats.UnitsUsed)
-	t.Log("assertion gas", assertion.NumGas)
-	//if results[1].FeeStats.UnitsUsed.L2Storage.Cmp(big.NewInt(0)) != 0 {
-	//	t.Error("l2 storage used should be zero if contract is in cache")
-	//}
-	t.Fatal("error")
+	t.Log(results[1].FeeStats.UnitsUsed)
+
+	if res2Units.L2Storage.Cmp(big.NewInt(0)) != 0 {
+		t.Error("l2 storage used should be zero if contract is in cache")
+	}
+	if new(big.Rat).SetFrac(res2Units.L2Computation, res1Units.L2Computation).Cmp(big.NewRat(3, 4)) > 0 {
+		t.Error("l2 computation too high with caching")
+	}
 }

--- a/packages/arb-rpc-node/arbostest/code_cache_test.go
+++ b/packages/arb-rpc-node/arbostest/code_cache_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestCodeCache(t *testing.T) {
-	skipBelowVersion(t, 8)
+	skipBelowVersion(t, 10)
 	tx1 := message.Transaction{
 		MaxGas:      big.NewInt(10000000),
 		GasPriceBid: big.NewInt(0),

--- a/packages/arb-rpc-node/arbostest/code_cache_test.go
+++ b/packages/arb-rpc-node/arbostest/code_cache_test.go
@@ -51,7 +51,7 @@ func TestCodeCache(t *testing.T) {
 		message.NewSafeL2Message(tx2),
 	}
 
-	logs, _, _ := runAssertionWithoutPrint(t, makeSimpleInbox(messages), len(messages), 0)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 	checkConstructorResult(t, results[0], connAddress1)
 	checkConstructorResult(t, results[1], connAddress2)

--- a/packages/arb-rpc-node/arbostest/code_cache_test.go
+++ b/packages/arb-rpc-node/arbostest/code_cache_test.go
@@ -1,0 +1,64 @@
+/*
+* Copyright 2021, Offchain Labs, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package arbostest
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/offchainlabs/arbitrum/packages/arb-evm/message"
+	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
+)
+
+func TestCodeCache(t *testing.T) {
+	tx1 := message.Transaction{
+		MaxGas:      big.NewInt(10000000),
+		GasPriceBid: big.NewInt(0),
+		SequenceNum: big.NewInt(0),
+		DestAddress: common.RandAddress(),
+		Payment:     big.NewInt(0),
+		Data:        common.RandBytes(1000),
+	}
+	//tx2 := message.Transaction{
+	//	MaxGas:      big.NewInt(10000000),
+	//	GasPriceBid: big.NewInt(0),
+	//	SequenceNum: big.NewInt(1),
+	//	DestAddress: common.Address{},
+	//	Payment:     big.NewInt(0),
+	//	Data:        hexutil.MustDecode(arbostestcontracts.FailedSendBin),
+	//}
+
+	messages := []message.Message{
+		message.NewSafeL2Message(tx1),
+		//message.NewSafeL2Message(tx2),
+	}
+
+	logs, _, _, assertion := runAssertionWithoutPrint(t, makeSimpleInbox(messages), len(messages), 0)
+	results := processTxResults(t, logs)
+	//checkConstructorResult(t, results[0], connAddress1)
+	//checkConstructorResult(t, results[1], connAddress2)
+	//if arbosVersion < 8 {
+	//
+	//}
+	t.Log(results[0].FeeStats.UnitsUsed)
+	//t.Log(results[1].FeeStats.UnitsUsed)
+	t.Log("assertion gas", assertion.NumGas)
+	//if results[1].FeeStats.UnitsUsed.L2Storage.Cmp(big.NewInt(0)) != 0 {
+	//	t.Error("l2 storage used should be zero if contract is in cache")
+	//}
+	t.Fatal("error")
+}

--- a/packages/arb-rpc-node/arbostest/constructor_test.go
+++ b/packages/arb-rpc-node/arbostest/constructor_test.go
@@ -62,7 +62,7 @@ func TestContructor(t *testing.T) {
 	failIfError(t, err)
 
 	messages := []message.Message{l2Message}
-	logs, _, snap, _ := runSimpleAssertion(t, messages)
+	logs, _, snap := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 
 	res := results[0]
@@ -121,7 +121,7 @@ func TestContructorExistingBalance(t *testing.T) {
 		message.NewSafeL2Message(tx),
 	}
 
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 
 	checkConstructorResult(t, results[2], connAddress1)

--- a/packages/arb-rpc-node/arbostest/constructor_test.go
+++ b/packages/arb-rpc-node/arbostest/constructor_test.go
@@ -37,10 +37,10 @@ import (
 
 var constructorData = hexutil.MustDecode(arbostestcontracts.FibonacciBin)
 
-func TestContructor(t *testing.T) {
+func TestConstructor(t *testing.T) {
 	client, pks := test.SimulatedBackend(t)
 
-	tx := types.NewContractCreation(0, big.NewInt(0), 1000000, big.NewInt(0), constructorData)
+	tx := types.NewContractCreation(0, big.NewInt(0), 5000000, big.NewInt(0), constructorData)
 	signedTx, err := types.SignTx(tx, types.HomesteadSigner{}, pks[0])
 	failIfError(t, err)
 
@@ -98,7 +98,7 @@ func TestContructor(t *testing.T) {
 	}
 }
 
-func TestContructorExistingBalance(t *testing.T) {
+func TestConstructorExistingBalance(t *testing.T) {
 	factoryABI, err := abi.JSON(strings.NewReader(arbostestcontracts.CloneFactoryABI))
 	failIfError(t, err)
 

--- a/packages/arb-rpc-node/arbostest/create2_test.go
+++ b/packages/arb-rpc-node/arbostest/create2_test.go
@@ -99,7 +99,7 @@ func TestCreate2(t *testing.T) {
 		message.NewInboxMessage(message.NewSafeL2Message(existsCloneTx), sender, big.NewInt(4), big.NewInt(0), chainTime),
 	}
 
-	logs, _, snap, _ := runAssertion(t, inboxMessages, 4, 0)
+	logs, _, snap := runAssertion(t, inboxMessages, 4, 0)
 	results := processTxResults(t, logs)
 
 	allResultsSucceeded(t, results)

--- a/packages/arb-rpc-node/arbostest/deposit_test.go
+++ b/packages/arb-rpc-node/arbostest/deposit_test.go
@@ -144,7 +144,7 @@ func TestDepositEthTx(t *testing.T) {
 		tx4,
 		message.NewSafeL2Message(getBalance5),
 	}
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 
 	checkConstructorResult(t, results[0], connAddress1)

--- a/packages/arb-rpc-node/arbostest/evmOps_test.go
+++ b/packages/arb-rpc-node/arbostest/evmOps_test.go
@@ -108,7 +108,7 @@ func TestEVMOps(t *testing.T) {
 		message.NewSafeL2Message(tx7),
 	}
 
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 	allResultsSucceeded(t, results)
 	checkConstructorResult(t, results[0], connAddress1)

--- a/packages/arb-rpc-node/arbostest/fee_test.go
+++ b/packages/arb-rpc-node/arbostest/fee_test.go
@@ -334,7 +334,7 @@ func TestFees(t *testing.T) {
 
 	processMessages := func(ib *InboxBuilder, index int, aggregator common.Address) ([]*evm.TxResult, *snapshot.Snapshot, *big.Int) {
 		t.Helper()
-		logs, _, snap, _ := runAssertionWithoutPrint(t, ib.Messages, math.MaxInt32, 0)
+		logs, _, snap := runAssertionWithoutPrint(t, ib.Messages, math.MaxInt32, 0)
 		rawResults := extractTxResults(t, logs)
 		allResultsSucceeded(t, rawResults[:len(rawResults)-len(rawTxes)])
 		results := rawResults[len(rawResults)-len(rawTxes):]

--- a/packages/arb-rpc-node/arbostest/gas_test.go
+++ b/packages/arb-rpc-node/arbostest/gas_test.go
@@ -86,7 +86,7 @@ func TestGas(t *testing.T) {
 		message.NewSafeL2Message(store2FuncCallTx),
 	}
 
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 
 	allResultsSucceeded(t, results)

--- a/packages/arb-rpc-node/arbostest/helper_test.go
+++ b/packages/arb-rpc-node/arbostest/helper_test.go
@@ -38,6 +38,8 @@ import (
 	"github.com/offchainlabs/arbitrum/packages/arb-util/value"
 )
 
+const printArbOSLog = false
+
 func initMsg(t *testing.T, options []message.ChainConfigOption) message.Init {
 	params := protocol.ChainParams{
 		StakeRequirement:          big.NewInt(0),
@@ -206,9 +208,11 @@ func runSimpleAssertion(t *testing.T, messages []message.Message) ([]value.Value
 func runAssertion(t *testing.T, inboxMessages []inbox.InboxMessage, logCount int, sendCount int) ([]value.Value, [][]byte, *snapshot.Snapshot) {
 	t.Helper()
 	logs, sends, snap := runAssertionWithoutPrint(t, inboxMessages, logCount, sendCount)
-	//testCase, err := inbox.TestVectorJSON(inboxMessages, logs, sends)
-	//failIfError(t, err)
-	//t.Log(string(testCase))
+	if printArbOSLog {
+		testCase, err := inbox.TestVectorJSON(inboxMessages, logs, sends)
+		failIfError(t, err)
+		t.Log(string(testCase))
+	}
 	return logs, sends, snap
 }
 
@@ -225,7 +229,8 @@ func runAssertionWithoutPrint(t *testing.T, inboxMessages []inbox.InboxMessage, 
 	var sends [][]byte
 	for i, msg := range inboxMessages {
 		t.Log("Message", i)
-		assertion, _, _ := mach.ExecuteAssertion(10000000000, false, []inbox.InboxMessage{msg}, false)
+		assertion, _, _, err := mach.ExecuteAssertion(10000000000, false, []inbox.InboxMessage{msg}, false)
+		failIfError(t, err)
 		logs = append(logs, assertion.Logs...)
 		sends = append(sends, assertion.Sends...)
 

--- a/packages/arb-rpc-node/arbostest/helper_test.go
+++ b/packages/arb-rpc-node/arbostest/helper_test.go
@@ -205,33 +205,52 @@ func runSimpleAssertion(t *testing.T, messages []message.Message) ([]value.Value
 
 func runAssertion(t *testing.T, inboxMessages []inbox.InboxMessage, logCount int, sendCount int) ([]value.Value, [][]byte, *snapshot.Snapshot) {
 	t.Helper()
-	logs, sends, snap, assertion := runAssertionWithoutPrint(t, inboxMessages, logCount, sendCount)
-	testCase, err := inbox.TestVectorJSON(inboxMessages, assertion.Logs, assertion.Sends)
-	failIfError(t, err)
-	t.Log(string(testCase))
+	logs, sends, snap := runAssertionWithoutPrint(t, inboxMessages, logCount, sendCount)
+	//testCase, err := inbox.TestVectorJSON(inboxMessages, logs, sends)
+	//failIfError(t, err)
+	//t.Log(string(testCase))
 	return logs, sends, snap
 }
 
-func runAssertionWithoutPrint(t *testing.T, inboxMessages []inbox.InboxMessage, logCount int, sendCount int) ([]value.Value, [][]byte, *snapshot.Snapshot, *protocol.ExecutionAssertion) {
+func runAssertionWithoutPrint(t *testing.T, inboxMessages []inbox.InboxMessage, logCount int, sendCount int) ([]value.Value, [][]byte, *snapshot.Snapshot) {
 	t.Helper()
 	if inboxMessages[0].Kind != message.InitType {
 		t.Fatal("inbox must start with init message")
 	}
 	cmach, err := cmachine.New(*arbosfile)
 	failIfError(t, err)
-	mach := arbosmachine.New(cmach)
+	mach := arbosmachine.NewTestMachine(t, cmach)
 
-	_, _, _, err = mach.ExecuteAssertion(10000000000, false, inboxMessages[:1], false)
-	failIfError(t, err)
-	assertion, _, _, err := mach.ExecuteAssertion(10000000000, false, inboxMessages[1:], false)
-	failIfError(t, err)
+	var logs []value.Value
+	var sends [][]byte
+	for i, msg := range inboxMessages {
+		t.Log("Message", i)
+		assertion, _, _ := mach.ExecuteAssertion(10000000000, false, []inbox.InboxMessage{msg}, false)
+		logs = append(logs, assertion.Logs...)
+		sends = append(sends, assertion.Sends...)
 
-	if logCount != math.MaxInt32 && len(assertion.Logs) != logCount {
-		t.Fatal("unexpected log count ", len(assertion.Logs), "instead of", logCount)
+		if len(assertion.Logs) != 1 {
+			continue
+		}
+		res, err := evm.NewTxResultFromValue(assertion.Logs[0])
+		if err != nil {
+			continue
+		}
+		uncountedComputation := new(big.Int).Sub(new(big.Int).SetUint64(assertion.NumGas), res.FeeStats.UnitsUsed.L2Computation)
+		chargeRatio := new(big.Rat).SetFrac(res.FeeStats.UnitsUsed.L2Computation, new(big.Int).SetUint64(assertion.NumGas))
+		// Note: These ratio's were set based on measurements to prevent any regressions
+		// If in the future arbos tries to provide a stronger bound on unmetered computation, this can be adjusted
+		if arbosVersion >= 8 && chargeRatio.Cmp(big.NewRat(7, 10)) < 0 && uncountedComputation.Cmp(big.NewInt(300000)) > 0 {
+			t.Errorf("didn't charge enough for tx %v=%v (%v uncharged)", chargeRatio, chargeRatio.FloatString(2), uncountedComputation)
+		}
 	}
 
-	if len(assertion.Sends) != sendCount {
-		t.Fatal("unxpected send count ", len(assertion.Sends), "instead of", sendCount)
+	if logCount != math.MaxInt32 && len(logs) != logCount {
+		t.Fatal("unexpected log count ", len(logs), "instead of", logCount)
+	}
+
+	if len(sends) != sendCount {
+		t.Fatal("unxpected send count ", len(sends), "instead of", sendCount)
 	}
 
 	var snap *snapshot.Snapshot
@@ -244,7 +263,7 @@ func runAssertionWithoutPrint(t *testing.T, inboxMessages []inbox.InboxMessage, 
 		snap, err = snapshot.NewSnapshot(mach.Clone(), lastMessage.ChainTime, message.ChainAddressToID(chain), seq)
 		test.FailIfError(t, err)
 	}
-	return assertion.Logs, assertion.Sends, snap, assertion
+	return logs, sends, snap
 }
 
 type InboxBuilder struct {

--- a/packages/arb-rpc-node/arbostest/helper_test.go
+++ b/packages/arb-rpc-node/arbostest/helper_test.go
@@ -198,27 +198,32 @@ func failIfError(t *testing.T, err error) {
 	}
 }
 
-func runSimpleAssertion(t *testing.T, messages []message.Message) ([]value.Value, [][]byte, *snapshot.Snapshot, *protocol.ExecutionAssertion) {
+func runSimpleAssertion(t *testing.T, messages []message.Message) ([]value.Value, [][]byte, *snapshot.Snapshot) {
 	t.Helper()
 	return runAssertion(t, makeSimpleInbox(t, messages), len(messages), 0)
 }
 
-func runAssertion(t *testing.T, inboxMessages []inbox.InboxMessage, logCount int, sendCount int) ([]value.Value, [][]byte, *snapshot.Snapshot, *protocol.ExecutionAssertion) {
+func runAssertion(t *testing.T, inboxMessages []inbox.InboxMessage, logCount int, sendCount int) ([]value.Value, [][]byte, *snapshot.Snapshot) {
 	t.Helper()
 	logs, sends, snap, assertion := runAssertionWithoutPrint(t, inboxMessages, logCount, sendCount)
 	testCase, err := inbox.TestVectorJSON(inboxMessages, assertion.Logs, assertion.Sends)
 	failIfError(t, err)
 	t.Log(string(testCase))
-	return logs, sends, snap, assertion
+	return logs, sends, snap
 }
 
 func runAssertionWithoutPrint(t *testing.T, inboxMessages []inbox.InboxMessage, logCount int, sendCount int) ([]value.Value, [][]byte, *snapshot.Snapshot, *protocol.ExecutionAssertion) {
 	t.Helper()
+	if inboxMessages[0].Kind != message.InitType {
+		t.Fatal("inbox must start with init message")
+	}
 	cmach, err := cmachine.New(*arbosfile)
 	failIfError(t, err)
 	mach := arbosmachine.New(cmach)
 
-	assertion, _, _, err := mach.ExecuteAssertion(10000000000, false, inboxMessages, false)
+	_, _, _, err = mach.ExecuteAssertion(10000000000, false, inboxMessages[:1], false)
+	failIfError(t, err)
+	assertion, _, _, err := mach.ExecuteAssertion(10000000000, false, inboxMessages[1:], false)
 	failIfError(t, err)
 
 	if logCount != math.MaxInt32 && len(assertion.Logs) != logCount {

--- a/packages/arb-rpc-node/arbostest/init_test.go
+++ b/packages/arb-rpc-node/arbostest/init_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/offchainlabs/arbitrum/packages/arb-avm-cpp/cmachine"
+	"github.com/offchainlabs/arbitrum/packages/arb-node-core/test"
 	"github.com/offchainlabs/arbitrum/packages/arb-rpc-node/arbosmachine"
 )
 
@@ -27,7 +28,7 @@ func TestInit(t *testing.T) {
 	cmach, err := cmachine.New(*arbosfile)
 	failIfError(t, err)
 	mach := arbosmachine.New(cmach)
-	assertion, _, _ := mach.ExecuteAssertion(10000000000, false, nil, false)
-
+	assertion, _, _, err := mach.ExecuteAssertion(10000000000, false, nil, false)
+	test.FailIfError(t, err)
 	t.Log("Startup used", assertion.NumGas, "gas")
 }

--- a/packages/arb-rpc-node/arbostest/init_test.go
+++ b/packages/arb-rpc-node/arbostest/init_test.go
@@ -17,12 +17,17 @@
 package arbostest
 
 import (
-	"github.com/offchainlabs/arbitrum/packages/arb-util/inbox"
 	"testing"
+
+	"github.com/offchainlabs/arbitrum/packages/arb-avm-cpp/cmachine"
+	"github.com/offchainlabs/arbitrum/packages/arb-rpc-node/arbosmachine"
 )
 
 func TestInit(t *testing.T) {
-	_, _, _, assertion := runAssertion(t, []inbox.InboxMessage{}, 0, 0)
+	cmach, err := cmachine.New(*arbosfile)
+	failIfError(t, err)
+	mach := arbosmachine.New(cmach)
+	assertion, _, _ := mach.ExecuteAssertion(10000000000, false, nil, false)
 
 	t.Log("Startup used", assertion.NumGas, "gas")
 }

--- a/packages/arb-rpc-node/arbostest/l2_test.go
+++ b/packages/arb-rpc-node/arbostest/l2_test.go
@@ -74,7 +74,7 @@ func testBasicTx(t *testing.T, msg message.AbstractL2Message, msg2 message.Abstr
 		l2Message2,
 	}
 
-	logs, _, snap, _ := runSimpleAssertion(t, messages)
+	logs, _, snap := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 
 	allResultsSucceeded(t, results)
@@ -270,7 +270,7 @@ func TestUnsignedTx(t *testing.T) {
 		message.NewSafeL2Message(tx2),
 	}
 
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 	allResultsSucceeded(t, results)
 	for i, result := range results[1:] {
@@ -347,7 +347,7 @@ func TestBatch(t *testing.T) {
 	}
 	messages = append(messages, message.NewSafeL2Message(msg))
 
-	logs, _, _, _ := runAssertion(t, makeSimpleInbox(t, messages), len(messages)+len(txes)-1, 0)
+	logs, _, _ := runAssertion(t, makeSimpleInbox(t, messages), len(messages)+len(txes)-1, 0)
 	results := processTxResults(t, logs)
 
 	for i, result := range results[len(messages)-1:] {
@@ -450,7 +450,7 @@ func TestCompressedECDSATx(t *testing.T) {
 		)
 	}
 
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	verifyTxLogs(t, signer, txes, logs[1:])
 }
 
@@ -473,7 +473,7 @@ func TestCall(t *testing.T) {
 		message.NewSafeL2Message(tx1),
 		message.NewSafeL2Message(tx2),
 	}
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 	allResultsSucceeded(t, results)
 	checkConstructorResult(t, results[0], connAddress1)

--- a/packages/arb-rpc-node/arbostest/l2_test.go
+++ b/packages/arb-rpc-node/arbostest/l2_test.go
@@ -52,7 +52,7 @@ func testBasicTx(t *testing.T, msg message.AbstractL2Message, msg2 message.Abstr
 	var param common.Hash
 	copy(param[12:], connAddress1.Bytes())
 	createTx2 := message.Transaction{
-		MaxGas:      big.NewInt(1000000),
+		MaxGas:      big.NewInt(10000000),
 		GasPriceBid: big.NewInt(0),
 		SequenceNum: big.NewInt(1),
 		DestAddress: common.Address{},
@@ -389,7 +389,7 @@ func generateTestTransactions(t *testing.T, chain common.Address) []*types.Trans
 	signedTx2, err := types.SignTx(tx2, types.HomesteadSigner{}, pk)
 	failIfError(t, err)
 
-	tx3 := types.NewContractCreation(2, big.NewInt(0), 1000000, big.NewInt(0), hexutil.MustDecode(arbostestcontracts.FibonacciBin))
+	tx3 := types.NewContractCreation(2, big.NewInt(0), 3000000, big.NewInt(0), hexutil.MustDecode(arbostestcontracts.FibonacciBin))
 	signedTx3, err := types.SignTx(tx3, types.NewEIP155Signer(message.ChainAddressToID(chain)), pk)
 	failIfError(t, err)
 	return []*types.Transaction{signedTx, signedTx2, signedTx3}

--- a/packages/arb-rpc-node/arbostest/minimum_gas_test.go
+++ b/packages/arb-rpc-node/arbostest/minimum_gas_test.go
@@ -50,7 +50,7 @@ func TestMinimumGas(t *testing.T) {
 		message.NewSafeL2Message(tx1),
 		message.NewSafeL2Message(tx2),
 	}
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 	incoming := extractIncomingMessages(t, results)
 	l2Messages := filterL2Messages(t, incoming)

--- a/packages/arb-rpc-node/arbostest/nested_send_test.go
+++ b/packages/arb-rpc-node/arbostest/nested_send_test.go
@@ -58,7 +58,7 @@ func TestFailedNestedSend(t *testing.T) {
 		message.NewSafeL2Message(sendTx),
 	}
 
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 	checkConstructorResult(t, results[1], connAddress1)
 	revertedTxCheck(t, results[2])
@@ -90,7 +90,7 @@ func TestRevertedNestedCall(t *testing.T) {
 		message.NewSafeL2Message(tx2),
 		message.NewSafeL2Message(tx3),
 	}
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 	checkConstructorResult(t, results[0], connAddress1)
 	succeededTxCheck(t, results[1])

--- a/packages/arb-rpc-node/arbostest/owner_deploy_test.go
+++ b/packages/arb-rpc-node/arbostest/owner_deploy_test.go
@@ -46,7 +46,7 @@ func TestOwnerDeployCorrectCode(t *testing.T) {
 		l2Tx, err := message.NewL2Message(message.NewCompressedECDSAFromEth(tx))
 		test.FailIfError(t, err)
 		messages := []message.Message{l2Tx}
-		logs, _, snap, _ := runSimpleAssertion(t, messages)
+		logs, _, snap := runSimpleAssertion(t, messages)
 		results := processTxResults(t, logs)
 		allResultsSucceeded(t, results)
 		t.Log(results[0])
@@ -66,7 +66,7 @@ func TestOwnerDeployCorrectCode(t *testing.T) {
 		ib := &InboxBuilder{}
 		ib.AddMessage(initMsg(t, nil), chain, big.NewInt(0), chainTime)
 		ib.AddMessage(message.NewSafeL2Message(ownerTx), owner, big.NewInt(0), chainTime)
-		logs, _, snap, _ := runAssertion(t, ib.Messages, len(ib.Messages)-1, 0)
+		logs, _, snap := runAssertion(t, ib.Messages, len(ib.Messages)-1, 0)
 		results := processTxResults(t, logs)
 		allResultsSucceeded(t, results)
 		t.Log(results[0])
@@ -105,7 +105,7 @@ func TestOwnerDeployCorrectDeploy(t *testing.T) {
 	ib.AddMessage(initMsg(t, nil), chain, big.NewInt(0), chainTime)
 	ib.AddMessage(makeEthDeposit(owner, big.NewInt(1000)), sender, big.NewInt(0), chainTime)
 	ib.AddMessage(message.NewSafeL2Message(ownerTx), owner, big.NewInt(0), chainTime)
-	logs, _, snap, _ := runAssertion(t, ib.Messages, len(ib.Messages)-1, 0)
+	logs, _, snap := runAssertion(t, ib.Messages, len(ib.Messages)-1, 0)
 	results := processTxResults(t, logs)
 	correctConnAddress := crypto.CreateAddress(sender.ToEthAddress(), nonce)
 	checkConstructorResult(t, results[1], common.NewAddressFromEth(correctConnAddress))

--- a/packages/arb-rpc-node/arbostest/owner_test.go
+++ b/packages/arb-rpc-node/arbostest/owner_test.go
@@ -68,7 +68,7 @@ func TestOwner(t *testing.T) {
 		message.NewInboxMessage(message.NewSafeL2Message(tx3), sender, big.NewInt(2), big.NewInt(0), chainTime),
 	}
 
-	logs, _, _, _ := runAssertion(t, messages, len(messages)-1, 0)
+	logs, _, _ := runAssertion(t, messages, len(messages)-1, 0)
 	results := processTxResults(t, logs)
 	// Transfer from non-owner fails
 	revertedTxCheck(t, results[0])

--- a/packages/arb-rpc-node/arbostest/precompiles_test.go
+++ b/packages/arb-rpc-node/arbostest/precompiles_test.go
@@ -63,7 +63,7 @@ func testPrecompile(t *testing.T, precompileNum byte, data []byte, correct []byt
 	}
 
 	messages := []message.Message{message.NewSafeL2Message(tx)}
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 
 	res := results[0]

--- a/packages/arb-rpc-node/arbostest/revert_test.go
+++ b/packages/arb-rpc-node/arbostest/revert_test.go
@@ -51,7 +51,7 @@ func TestRevert(t *testing.T) {
 		message.NewSafeL2Message(revertsTx),
 	}
 
-	logs, _, _, _ := runSimpleAssertion(t, messages)
+	logs, _, _ := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 
 	checkConstructorResult(t, results[0], connAddress1)

--- a/packages/arb-rpc-node/arbostest/storage_test.go
+++ b/packages/arb-rpc-node/arbostest/storage_test.go
@@ -64,7 +64,7 @@ func TestGetStorageAt(t *testing.T) {
 		message.NewInboxMessage(message.NewSafeL2Message(failGetStorageAtTx), sender, big.NewInt(3), big.NewInt(0), chainTime),
 	}
 
-	logs, _, _, _ := runAssertion(t, inboxMessages, 3, 0)
+	logs, _, _ := runAssertion(t, inboxMessages, 3, 0)
 	results := processTxResults(t, logs)
 
 	constructorRes := results[0]

--- a/packages/arb-rpc-node/arbostest/transfer_test.go
+++ b/packages/arb-rpc-node/arbostest/transfer_test.go
@@ -68,7 +68,7 @@ func TestTransfer(t *testing.T) {
 		message.NewSafeL2Message(connCallTx),
 	}
 
-	logs, _, snap, _ := runSimpleAssertion(t, messages)
+	logs, _, snap := runSimpleAssertion(t, messages)
 	results := processTxResults(t, logs)
 
 	allResultsSucceeded(t, results)


### PR DESCRIPTION
- Merge https://github.com/OffchainLabs/arb-os/pull/425
- Adds general testing to all of the arbos test suite that the amount of gas used while processing a transaction is within a bounded limit of the amount of l2 computation charged to the user
- Add specific testing for code caching
- Output debugprints as test logs instead of regular logs so that they're nicely interspersed with other test logs