### PR TITLE
Refactor broadcast to use one thread per client instead of threadpool

### DIFF
--- a/packages/arb-util/broadcaster/broadcaster.go
+++ b/packages/arb-util/broadcaster/broadcaster.go
@@ -149,7 +149,7 @@ func (b *Broadcaster) Start(ctx context.Context) error {
 		}
 
 		// Register incoming client in clientManager.
-		client := clientManager.Register(safeConn, desc)
+		client := clientManager.Register(ctx, safeConn, desc)
 
 		// Subscribe to events about conn.
 		err = b.poller.Start(desc, func(ev netpoll.Event) {

--- a/packages/arb-util/broadcaster/clientconnection.go
+++ b/packages/arb-util/broadcaster/clientconnection.go
@@ -31,6 +31,7 @@ import (
 	"github.com/mailru/easygo/netpoll"
 )
 
+const MaxSendCount = 10
 const MaxSendQueue = 20
 
 // ClientConnection represents client connection.
@@ -64,6 +65,7 @@ func (cc *ClientConnection) Start(parentCtx context.Context) {
 
 	cc.out = make(chan []byte, MaxSendQueue)
 	go func() {
+		defer cancelFunc()
 		defer close(cc.out)
 		for {
 			select {

--- a/packages/arb-util/broadcaster/clientmanager.go
+++ b/packages/arb-util/broadcaster/clientmanager.go
@@ -20,9 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"math/rand"
 	"net"
-	"strconv"
 	"sync"
 	"time"
 
@@ -62,18 +60,11 @@ func NewClientManager(pool *gopool.Pool, poller netpoll.Poller, settings ClientM
 }
 
 // Register registers new connection as a Client.
-func (cm *ClientManager) Register(conn net.Conn, desc *netpoll.Desc) *ClientConnection {
-	clientConnection := &ClientConnection{
-		clientManager: cm,
-		conn:          conn,
-		desc:          desc,
-		lastHeard:     time.Now(),
-	}
+func (cm *ClientManager) Register(ctx context.Context, conn net.Conn, desc *netpoll.Desc) *ClientConnection {
+	clientConnection := NewClientConnection(conn, desc, cm)
 
 	{
 		cm.mu.Lock()
-
-		clientConnection.name = conn.RemoteAddr().String() + strconv.Itoa(rand.Intn(10))
 
 		cm.clientPtrMap[clientConnection] = true
 
@@ -84,6 +75,7 @@ func (cm *ClientManager) Register(conn net.Conn, desc *netpoll.Desc) *ClientConn
 			_ = clientConnection.write(bm)
 		}
 
+		clientConnection.Start(ctx)
 		cm.mu.Unlock()
 	}
 
@@ -164,8 +156,8 @@ func (cm *ClientManager) Broadcast(prevAcc common.Hash, batchItem inbox.Sequence
 
 	logger.Debug().Hex("acc", batchItem.Accumulator.Bytes()).Msg("sending batch Item")
 
-	w := wsutil.NewWriter(&buf, ws.StateServerSide, ws.OpText)
-	encoder := json.NewEncoder(w)
+	writer := wsutil.NewWriter(&buf, ws.StateServerSide, ws.OpText)
+	encoder := json.NewEncoder(writer)
 
 	var broadcastMessages []*BroadcastFeedMessage
 
@@ -209,7 +201,7 @@ func (cm *ClientManager) Broadcast(prevAcc common.Hash, batchItem inbox.Sequence
 	if err := encoder.Encode(bm); err != nil {
 		return err
 	}
-	if err := w.Flush(); err != nil {
+	if err := writer.Flush(); err != nil {
 		return err
 	}
 
@@ -271,25 +263,22 @@ func (cm *ClientManager) startWriter(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case data := <-cm.out:
-				cm.mu.RLock()
-				// Copy list so data can be written to each client without lock held
-				clientList := make([]*ClientConnection, len(cm.clientPtrMap))
-				var i uint64
+				clientDeleteList := make([]*ClientConnection, 0, len(cm.clientPtrMap))
+				cm.mu.Lock()
+				// Lock mutex while writing to channels to ensure items delivered in order
 				for client := range cm.clientPtrMap {
-					clientList[i] = client
-					i++
+					if len(client.out) > MaxSendQueue {
+						// Queue for client too backed up, so delete after going through all other clients
+						clientDeleteList = append(clientDeleteList, client)
+					} else {
+						client.out <- data
+					}
 				}
-				cm.mu.RUnlock()
+				cm.mu.Unlock()
 
-				for _, c := range clientList {
-					c := c // For closure.
-					cm.pool.Schedule(func() {
-						err := c.writeRaw(data)
-						if err != nil {
-							logger.Warn().Err(err).Str("client", c.name).Msg("error with writeRaw")
-						}
-						logger.Debug().Str("client", c.name).Int("length", len(data)).Msg("batch item sent")
-					})
+				for _, client := range clientDeleteList {
+					logger.Warn().Str("client", client.name).Msg("disconnecting client, queue too large")
+					cm.Remove(client)
 				}
 			}
 		}
@@ -317,6 +306,8 @@ func (cm *ClientManager) remove(clientConnection *ClientConnection) bool {
 	if !cm.clientPtrMap[clientConnection] {
 		return false
 	}
+
+	clientConnection.Stop()
 
 	err := cm.poller.Stop(clientConnection.desc)
 	if err != nil {


### PR DESCRIPTION
Using threadpool to broadcast messages causes race condition that may deliver messages out of order