### PR TITLE
Process and rpc metrics

### DIFF
--- a/packages/arb-node-core/cmd/arb-validator/arb-validator.go
+++ b/packages/arb-node-core/cmd/arb-validator/arb-validator.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
 	"io/ioutil"
 	golog "log"
 	"math/big"
@@ -83,9 +84,10 @@ func startup() error {
 
 	const largeChannelBuffer = 200
 	healthChan := make(chan nodehealth.Log, largeChannelBuffer)
+	prometheusRegistry := prometheus.NewRegistry()
 
 	go func() {
-		err := nodehealth.StartNodeHealthCheck(ctx, healthChan)
+		err := nodehealth.StartNodeHealthCheck(ctx, healthChan, prometheusRegistry)
 		if err != nil {
 			log.Error().Err(err).Msg("healthcheck server failed")
 		}
@@ -258,7 +260,7 @@ func startup() error {
 		return errors.Errorf("Initial machine hash loaded from arbos.mexe doesn't match chain's initial machine hash: chain %v, arbCore %v", hexutil.Encode(chainMachineHash[:]), initialMachineHash)
 	}
 
-	reader, err := staker.NewInboxReader(ctx, bridge, arbCore, healthChan)
+	reader, err := staker.NewInboxReader(ctx, bridge, arbCore, healthChan, prometheusRegistry)
 	if err != nil {
 		return errors.Wrap(err, "failed to create inbox reader")
 	}

--- a/packages/arb-node-core/nodehealth/nodehealth.go
+++ b/packages/arb-node-core/nodehealth/nodehealth.go
@@ -174,7 +174,7 @@ type Log struct {
 }
 
 // Default configuration values for the healthcheck server
-func newConfig() *configStruct {
+func newConfig(prometheusRegistry *prometheus.Registry) *configStruct {
 	config := configStruct{}
 	const init = false
 
@@ -201,7 +201,7 @@ func newConfig() *configStruct {
 
 	//Load configuration into struct
 	config.prometheusHistograms = make(map[string]*prometheus.HistogramVec)
-	config.prometheusRegistry = prometheus.NewRegistry()
+	config.prometheusRegistry = prometheusRegistry
 
 	config.init = init
 	config.healthcheckRPC = healthcheckRPC
@@ -909,12 +909,12 @@ func startHealthCheck(ctx context.Context, config *configStruct, state *healthSt
 }
 
 // NodeHealthCheck Create a node healthcheck that listens on the given channel
-func StartNodeHealthCheck(ctx context.Context, logMsgChan <-chan Log) error {
+func StartNodeHealthCheck(ctx context.Context, logMsgChan <-chan Log, prometheusRegistry *prometheus.Registry) error {
 	//Create the configuration struct
 	state := newHealthState()
 
 	//Load the default configuration
-	config := newConfig()
+	config := newConfig(prometheusRegistry)
 
 	//Start the channel logger
 	go logger(ctx, config, state, logMsgChan)

--- a/packages/arb-node-core/nodehealth/nodehealth_test.go
+++ b/packages/arb-node-core/nodehealth/nodehealth_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
 	"io/ioutil"
 	"math/big"
 	"net/http"
@@ -178,8 +179,8 @@ func startUpDelayTest(testConfig *testConfigStruct, healthChan chan Log) error {
 }
 
 //Initialize the nodehealth server
-func initNodeHealthCheck(ctx context.Context, healthChan chan Log) {
-	go StartNodeHealthCheck(ctx, healthChan)
+func initNodeHealthCheck(ctx context.Context, healthChan chan Log, prometheusRegistry *prometheus.Registry) {
+	go StartNodeHealthCheck(ctx, healthChan, prometheusRegistry)
 	setNodeHealthBaseConfig(healthChan)
 	setOpenEthereumEndpoint(healthChan)
 	Init(healthChan)
@@ -659,7 +660,8 @@ func TestNodeHealth(t *testing.T) {
 
 	//Start the healthcheck server with a background context for testing
 	ctx, cancel := context.WithCancel(context.Background())
-	go StartNodeHealthCheck(ctx, healthChan)
+	prometheusRegistry := prometheus.NewRegistry()
+	go StartNodeHealthCheck(ctx, healthChan, prometheusRegistry)
 
 	//Test the startup delay works properly
 	err := startUpDelayTest(testConfig, healthChan)
@@ -676,7 +678,8 @@ func TestNodeHealth(t *testing.T) {
 	//Restart the healthcheck server with a fresh context and healthchan
 	ctx, cancel = context.WithCancel(context.Background())
 	healthChan = make(chan Log, testConfig.bufferSize)
-	go StartNodeHealthCheck(ctx, healthChan)
+	prometheusRegistry = prometheus.NewRegistry()
+	go StartNodeHealthCheck(ctx, healthChan, prometheusRegistry)
 
 	//Test the server doesn't bind when the healthcheck is disabled
 	err = disableHealthcheckTest(testConfig, healthChan)
@@ -689,7 +692,8 @@ func TestNodeHealth(t *testing.T) {
 	time.Sleep(5 * time.Second) //TCP Timeout
 	ctx, cancel = context.WithCancel(context.Background())
 	healthChan = make(chan Log, testConfig.bufferSize)
-	go StartNodeHealthCheck(ctx, healthChan)
+	prometheusRegistry = prometheus.NewRegistry()
+	go StartNodeHealthCheck(ctx, healthChan, prometheusRegistry)
 
 	//Test the server removes the primary healthcheck when it is disabled
 	err = disablePrimaryCheckTest(testConfig, healthChan)
@@ -702,7 +706,8 @@ func TestNodeHealth(t *testing.T) {
 	time.Sleep(5 * time.Second) //TCP Timeout
 	ctx, cancel = context.WithCancel(context.Background())
 	healthChan = make(chan Log, testConfig.bufferSize)
-	go StartNodeHealthCheck(ctx, healthChan)
+	prometheusRegistry = prometheus.NewRegistry()
+	go StartNodeHealthCheck(ctx, healthChan, prometheusRegistry)
 
 	//Test the server removes the OpenEthereum healthcheck when it is disabled
 	err = disableOpenEthereumCheckTest(testConfig, healthChan)
@@ -715,7 +720,8 @@ func TestNodeHealth(t *testing.T) {
 	time.Sleep(5 * time.Second) //TCP Timeout
 	ctx, cancel = context.WithCancel(context.Background())
 	healthChan = make(chan Log, testConfig.bufferSize)
-	go StartNodeHealthCheck(ctx, healthChan)
+	prometheusRegistry = prometheus.NewRegistry()
+	go StartNodeHealthCheck(ctx, healthChan, prometheusRegistry)
 
 	//Test the healthcheck can disable both OpenEthereum and primary check
 	err = disableOpenEthereumPrimaryCheckTest(testConfig, healthChan)
@@ -734,7 +740,8 @@ func TestNodeHealth(t *testing.T) {
 	time.Sleep(5 * time.Second) //TCP Timeout
 	ctx, cancel = context.WithCancel(context.Background())
 	healthChan = make(chan Log, testConfig.bufferSize)
-	go StartNodeHealthCheck(ctx, healthChan)
+	prometheusRegistry = prometheus.NewRegistry()
+	go StartNodeHealthCheck(ctx, healthChan, prometheusRegistry)
 
 	//OpenEthereum failure test
 	err = openethereumFailureTest(testConfig, healthChan)
@@ -747,7 +754,8 @@ func TestNodeHealth(t *testing.T) {
 	time.Sleep(5 * time.Second) //TCP Timeout
 	ctx, cancel = context.WithCancel(context.Background())
 	healthChan = make(chan Log, testConfig.bufferSize)
-	go StartNodeHealthCheck(ctx, healthChan)
+	prometheusRegistry = prometheus.NewRegistry()
+	go StartNodeHealthCheck(ctx, healthChan, prometheusRegistry)
 
 	//Primary failure test
 	err = primaryFailureTest(testConfig, healthChan)
@@ -760,7 +768,8 @@ func TestNodeHealth(t *testing.T) {
 	time.Sleep(5 * time.Second) //TCP Timeout
 	ctx, cancel = context.WithCancel(context.Background())
 	healthChan = make(chan Log, testConfig.bufferSize)
-	go StartNodeHealthCheck(ctx, healthChan)
+	prometheusRegistry = prometheus.NewRegistry()
+	go StartNodeHealthCheck(ctx, healthChan, prometheusRegistry)
 
 	//Test InboxReader catch up status
 	err = inboxReaderCatchUpTest(testConfig, healthChan)

--- a/packages/arb-node-core/staker/monitor.go
+++ b/packages/arb-node-core/staker/monitor.go
@@ -18,6 +18,7 @@ package staker
 
 import (
 	"context"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -69,7 +70,7 @@ func (m *Monitor) Close() {
 	m.Storage.CloseArbStorage()
 }
 
-func (m *Monitor) StartInboxReader(ctx context.Context, ethurl string, rollupAddress common.Address, healthChan chan nodehealth.Log) (*InboxReader, error) {
+func (m *Monitor) StartInboxReader(ctx context.Context, ethurl string, rollupAddress common.Address, healthChan chan nodehealth.Log, prometheusRegistry *prometheus.Registry) (*InboxReader, error) {
 	ethClient, err := ethutils.NewRPCEthClient(ethurl)
 	if err != nil {
 		return nil, err
@@ -86,7 +87,7 @@ func (m *Monitor) StartInboxReader(ctx context.Context, ethurl string, rollupAdd
 	if err != nil {
 		return nil, err
 	}
-	reader, err := NewInboxReader(ctx, bridgeWatcher, m.Core, healthChan)
+	reader, err := NewInboxReader(ctx, bridgeWatcher, m.Core, healthChan, prometheusRegistry)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/arb-rpc-node/dev/fees_test.go
+++ b/packages/arb-rpc-node/dev/fees_test.go
@@ -18,6 +18,7 @@ package dev
 
 import (
 	"context"
+	"github.com/prometheus/client_golang/prometheus"
 	"math/big"
 	"strings"
 	"testing"
@@ -95,9 +96,18 @@ func setupFeeChain(t *testing.T) (*Backend, *web3.Server, *web3.EthClient, *bind
 		t.Fatal(err)
 	}
 
-	web3Server := web3.NewServer(srv, true)
+	methodCallCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "arbitrum",
+			Subsystem: "rpc",
+			Name:      "call",
+		},
+		[]string{"method", "success"},
+	)
 
-	client := web3.NewEthClient(srv, true)
+	web3Server := web3.NewServer(srv, true, methodCallCounter)
+
+	client := web3.NewEthClient(srv, true, methodCallCounter)
 
 	arbAggregator, err := arboscontracts.NewArbAggregator(arbos.ARB_AGGREGATOR_ADDRESS, client)
 	test.FailIfError(t, err)

--- a/packages/arb-rpc-node/dev/l2ToL1Tx_test.go
+++ b/packages/arb-rpc-node/dev/l2ToL1Tx_test.go
@@ -19,6 +19,7 @@ package dev
 import (
 	"bytes"
 	"context"
+	"github.com/prometheus/client_golang/prometheus"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -51,7 +52,16 @@ func TestL2ToL1Tx(t *testing.T) {
 	backend, db, srv, cancelDevNode := NewTestDevNode(t, *arbosfile, config, common.RandAddress(), nil)
 	defer cancelDevNode()
 
-	client := web3.NewEthClient(srv, true)
+	methodCallCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "arbitrum",
+			Subsystem: "rpc",
+			Name:      "call",
+		},
+		[]string{"method", "success"},
+	)
+
+	client := web3.NewEthClient(srv, true, methodCallCounter)
 	arbSys, err := arboscontracts.NewArbSys(arbos.ARB_SYS_ADDRESS, client)
 	if err != nil {
 		t.Fatal(err)

--- a/packages/arb-rpc-node/dev/upgrade_test.go
+++ b/packages/arb-rpc-node/dev/upgrade_test.go
@@ -18,6 +18,7 @@ package dev
 
 import (
 	"encoding/json"
+	"github.com/prometheus/client_golang/prometheus"
 	"io/ioutil"
 	"math/big"
 	"path/filepath"
@@ -82,7 +83,16 @@ func TestUpgrade(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client := web3.NewEthClient(srv, true)
+	methodCallCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "arbitrum",
+			Subsystem: "rpc",
+			Name:      "call",
+		},
+		[]string{"method", "success"},
+	)
+
+	client := web3.NewEthClient(srv, true, methodCallCounter)
 	arbOwner, err := arboscontracts.NewArbOwner(arbos.ARB_OWNER_ADDRESS, client)
 	test.FailIfError(t, err)
 

--- a/packages/arb-rpc-node/go.mod
+++ b/packages/arb-rpc-node/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/offchainlabs/arbitrum/packages/arb-node-core v0.8.0
 	github.com/offchainlabs/arbitrum/packages/arb-util v0.8.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.1.0 // indirect
 	github.com/rs/zerolog v1.21.0
 	github.com/tevino/abool v1.2.0
 )

--- a/packages/arb-rpc-node/web3/accounts.go
+++ b/packages/arb-rpc-node/web3/accounts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -19,9 +20,10 @@ type Accounts struct {
 	addresses   []common.Address
 	privateKeys map[common.Address]*ecdsa.PrivateKey
 	signer      types.Signer
+	counter     *prometheus.CounterVec
 }
 
-func NewAccounts(ethServer *Server, privateKeys []*ecdsa.PrivateKey) *Accounts {
+func NewAccounts(ethServer *Server, privateKeys []*ecdsa.PrivateKey, methodCallCounter *prometheus.CounterVec) *Accounts {
 	keys := make(map[common.Address]*ecdsa.PrivateKey)
 	addresses := make([]common.Address, 0, len(privateKeys))
 	for _, privKey := range privateKeys {
@@ -34,6 +36,7 @@ func NewAccounts(ethServer *Server, privateKeys []*ecdsa.PrivateKey) *Accounts {
 		addresses:   addresses,
 		privateKeys: keys,
 		signer:      types.NewEIP155Signer(new(big.Int).SetUint64(uint64(ethServer.ChainId()))),
+		counter:     methodCallCounter,
 	}
 }
 
@@ -58,6 +61,7 @@ func (s *Accounts) SendTransaction(ctx context.Context, args *SendTransactionArg
 	}
 	privKey, ok := s.privateKeys[sender]
 	if !ok {
+		s.counter.WithLabelValues("eth_sendTransaction", "false").Inc()
 		return common.Hash{}, errors.New("sender does not have unlocked wallet")
 	}
 
@@ -68,6 +72,7 @@ func (s *Accounts) SendTransaction(ctx context.Context, args *SendTransactionArg
 		pendingNum := rpc.PendingBlockNumber
 		rawNonce, err := s.srv.GetTransactionCount(ctx, &sender, &pendingNum)
 		if err != nil {
+			s.counter.WithLabelValues("eth_sendTransaction", "false").Inc()
 			return common.Hash{}, err
 		}
 		nonce = uint64(rawNonce)
@@ -109,33 +114,40 @@ func (s *Accounts) SendTransaction(ctx context.Context, args *SendTransactionArg
 	}
 	signedTx, err := types.SignTx(tx, s.signer, privKey)
 	if err != nil {
+		s.counter.WithLabelValues("eth_sendTransaction", "false").Inc()
 		return [32]byte{}, err
 	}
 
 	if err := s.srv.srv.SendTransaction(ctx, signedTx); err != nil {
+		s.counter.WithLabelValues("eth_sendTransaction", "false").Inc()
 		return [32]byte{}, err
 	}
+	s.counter.WithLabelValues("eth_sendTransaction", "true").Inc()
 	return signedTx.Hash(), nil
 }
 
 func (s *Accounts) Sign(account common.Address, data hexutil.Bytes) (hexutil.Bytes, error) {
 	privKey, ok := s.privateKeys[account]
 	if !ok {
+		s.counter.WithLabelValues("eth_sign", "false").Inc()
 		return nil, errors.New("signer does not have unlocked wallet")
 	}
 	sig, err := crypto.Sign(accounts.TextHash(data), privKey)
 	if err != nil {
+		s.counter.WithLabelValues("eth_sign", "false").Inc()
 		return nil, err
 	}
 	sig[64] += 27
+	s.counter.WithLabelValues("eth_sign", "true").Inc()
 	return sig, nil
 }
 
 type PersonalAccounts struct {
 	privateKeys map[common.Address]*ecdsa.PrivateKey
+	counter     *prometheus.CounterVec
 }
 
-func NewPersonalAccounts(privateKeys []*ecdsa.PrivateKey) *PersonalAccounts {
+func NewPersonalAccounts(privateKeys []*ecdsa.PrivateKey, counter *prometheus.CounterVec) *PersonalAccounts {
 	keys := make(map[common.Address]*ecdsa.PrivateKey)
 	for _, privKey := range privateKeys {
 		addr := crypto.PubkeyToAddress(privKey.PublicKey)
@@ -143,6 +155,7 @@ func NewPersonalAccounts(privateKeys []*ecdsa.PrivateKey) *PersonalAccounts {
 	}
 	return &PersonalAccounts{
 		privateKeys: keys,
+		counter:     counter,
 	}
 }
 
@@ -150,12 +163,15 @@ func (s *PersonalAccounts) Sign(data hexutil.Bytes, account common.Address, _ *h
 	// Password ignored
 	privKey, ok := s.privateKeys[account]
 	if !ok {
+		s.counter.WithLabelValues("personal_sign", "false").Inc()
 		return nil, errors.New("signer does not have unlocked wallet")
 	}
 	sig, err := crypto.Sign(accounts.TextHash(data), privKey)
 	if err != nil {
+		s.counter.WithLabelValues("personal_sign", "false").Inc()
 		return nil, err
 	}
 	sig[64] += 27
+	s.counter.WithLabelValues("personal_sign", "true").Inc()
 	return sig, nil
 }

--- a/packages/arb-rpc-node/web3/arb.go
+++ b/packages/arb-rpc-node/web3/arb.go
@@ -20,10 +20,12 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/offchainlabs/arbitrum/packages/arb-rpc-node/aggregator"
 	"github.com/offchainlabs/arbitrum/packages/arb-rpc-node/batcher"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type Arb struct {
-	srv *aggregator.Server
+	srv     *aggregator.Server
+	counter *prometheus.CounterVec
 }
 
 func (a *Arb) GetAggregator() *batcher.AggregatorInfo {
@@ -33,5 +35,6 @@ func (a *Arb) GetAggregator() *batcher.AggregatorInfo {
 		tmp := agg.ToEthAddress()
 		ret = &tmp
 	}
+	a.counter.WithLabelValues("arb_getAggregator", "false").Inc()
 	return &batcher.AggregatorInfo{Address: ret}
 }

--- a/packages/arb-rpc-node/web3/ethclient.go
+++ b/packages/arb-rpc-node/web3/ethclient.go
@@ -2,6 +2,7 @@ package web3
 
 import (
 	"context"
+	"github.com/prometheus/client_golang/prometheus"
 	"math/big"
 	"time"
 
@@ -23,9 +24,9 @@ type EthClient struct {
 	filter *filters.PublicFilterAPI
 }
 
-func NewEthClient(srv *aggregator.Server, ganacheMode bool) *EthClient {
+func NewEthClient(srv *aggregator.Server, ganacheMode bool, methodCallCounter *prometheus.CounterVec) *EthClient {
 	return &EthClient{
-		srv:    NewServer(srv, ganacheMode),
+		srv:    NewServer(srv, ganacheMode, methodCallCounter),
 		events: filters.NewEventSystem(srv, false),
 		filter: filters.NewPublicFilterAPI(srv, false, 2*time.Minute),
 	}

--- a/packages/arb-rpc-node/web3/net.go
+++ b/packages/arb-rpc-node/web3/net.go
@@ -17,13 +17,16 @@
 package web3
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
 	"strconv"
 )
 
 type Net struct {
 	chainId uint64
+	counter *prometheus.CounterVec
 }
 
 func (net *Net) Version() string {
+	net.counter.WithLabelValues("net_version", "true").Inc()
 	return strconv.FormatUint(net.chainId, 10)
 }

--- a/packages/arb-rpc-node/web3/web3.go
+++ b/packages/arb-rpc-node/web3/web3.go
@@ -19,9 +19,11 @@ package web3
 import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type Web3 struct {
+	counter *prometheus.CounterVec
 }
 
 func (web3 *Web3) ClientVersion() string {
@@ -29,5 +31,6 @@ func (web3 *Web3) ClientVersion() string {
 }
 
 func (web3 *Web3) Sha3(data hexutil.Bytes) hexutil.Bytes {
+	web3.counter.WithLabelValues("web3_sha3", "true")
 	return crypto.Keccak256(data)
 }


### PR DESCRIPTION
Add standard Go and Process metrics.
Weave in RPC calls along with success/fail results.

(follow on to pr #1104)