### PR TITLE
Add cancel support in WaitToCatchup

### DIFF
--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -267,7 +267,7 @@ func startup() error {
 	defer db.Close()
 
 	if *waitToCatchUp {
-		inboxReader.WaitToCatchUp()
+		inboxReader.WaitToCatchUp(ctx)
 	}
 
 	batch, err := rpc.SetupBatcher(


### PR DESCRIPTION
Allow program to gracefully shutdown even when catching up with transactions during startup