### PR TITLE
Fix infinite recursion

### DIFF
--- a/packages/arb-util/broadcastclient/broadcastclient.go
+++ b/packages/arb-util/broadcastclient/broadcastclient.go
@@ -116,9 +116,7 @@ func (bc *BroadcastClient) startBackgroundReader(ctx context.Context, messageRec
 				}
 				logger.Error().Err(err).Int("opcode", int(op)).Msgf("error calling ReadServerData")
 				_ = bc.conn.Close()
-				// Starts up a new backgroundReader
 				bc.RetryConnect(ctx, messageReceiver)
-				return
 			}
 
 			res := broadcaster.BroadcastMessage{}

--- a/packages/arb-util/broadcastclient/broadcastclient.go
+++ b/packages/arb-util/broadcastclient/broadcastclient.go
@@ -19,6 +19,7 @@ package broadcastclient
 import (
 	"context"
 	"encoding/json"
+	"github.com/pkg/errors"
 	"math/big"
 	"net"
 	"sync"
@@ -63,7 +64,14 @@ func NewBroadcastClient(websocketUrl string, lastInboxSeqNum *big.Int) *Broadcas
 
 func (bc *BroadcastClient) Connect(ctx context.Context) (chan broadcaster.BroadcastFeedMessage, error) {
 	messageReceiver := make(chan broadcaster.BroadcastFeedMessage)
-	return bc.connect(ctx, messageReceiver)
+	_, err := bc.connect(ctx, messageReceiver)
+	if err != nil {
+		return nil, err
+	}
+
+	bc.startBackgroundReader(ctx, messageReceiver)
+
+	return messageReceiver, nil
 }
 
 func (bc *BroadcastClient) connect(ctx context.Context, messageReceiver chan broadcaster.BroadcastFeedMessage) (chan broadcaster.BroadcastFeedMessage, error) {
@@ -80,7 +88,7 @@ func (bc *BroadcastClient) connect(ctx context.Context, messageReceiver chan bro
 	conn, _, _, err := timeoutDialer.Dial(ctx, bc.websocketUrl)
 	if err != nil {
 		logger.Warn().Err(err).Msg("broadcast client unable to connect")
-		return nil, err
+		return nil, errors.Wrap(err, "broadcast client unable to connect")
 	}
 
 	bc.connMutex.Lock()
@@ -88,8 +96,6 @@ func (bc *BroadcastClient) connect(ctx context.Context, messageReceiver chan bro
 	bc.connMutex.Unlock()
 
 	logger.Info().Msg("Connected")
-
-	bc.startBackgroundReader(ctx, messageReceiver)
 
 	return messageReceiver, nil
 }

--- a/packages/arb-util/broadcaster/broadcaster_test.go
+++ b/packages/arb-util/broadcaster/broadcaster_test.go
@@ -75,7 +75,7 @@ func TestBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
 	wg.Wait()
 
 	// give the above connections time to reconnect
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	// Confirmed Accumulator will also broadcast to the clients.
 	err = b.ConfirmedAccumulator(feedItem1.BatchItem.Accumulator) // remove the first message we generated


### PR DESCRIPTION
Remove possibility of infinite recursion when connection error in broadcastclient.

Also increase sleep in unit test, will refactor to remove sleep completely later.