### PR TITLE
Remove "patent pending"

### DIFF
--- a/packages/arb-avm-cpp/README.md
+++ b/packages/arb-avm-cpp/README.md
@@ -1,6 +1,6 @@
 # arb-avm-cpp
 
-Arbitrum technologies are patent pending. This repository is offered under the Apache 2.0 license. See LICENSE for details.
+This repository is offered under the Apache 2.0 license. See LICENSE for details.
 
 ## Bulding and testing
 

--- a/packages/arb-bridge-eth/README.md
+++ b/packages/arb-bridge-eth/README.md
@@ -7,4 +7,4 @@ sudo docker build -t arb-bridge-eth .
 sudo docker run -p 7545:7545 -it arb-bridge-eth
 ```
 
-Arbitrum technologies are patent pending. This repository is offered under the Apache 2.0 license. See LICENSE for details.
+This repository is offered under the Apache 2.0 license. See LICENSE for details.

--- a/packages/arb-util/README.md
+++ b/packages/arb-util/README.md
@@ -1,3 +1,3 @@
 # arb-util
 
-Arbitrum technologies are patent pending. This repository is offered under the Apache 2.0 license. See LICENSE for details.
+This repository is offered under the Apache 2.0 license. See LICENSE for details.


### PR DESCRIPTION
Followup to https://github.com/OffchainLabs/arbitrum/pull/808

My understanding is that [Arbitrum is no longer "patent pending"](https://twitter.com/arbitrum/status/1367216325219786755?lang=en). This PR removes this language from the package readmes.