### PR TITLE
DIfferent default persistent storage per chain

### DIFF
--- a/packages/arb-avm-cpp/cmachine/storage.go
+++ b/packages/arb-avm-cpp/cmachine/storage.go
@@ -59,7 +59,7 @@ func (s *ArbStorage) Initialize(contractPath string) error {
 	success := C.initializeArbStorage(s.c, cContractPath)
 
 	if success == 0 {
-		return errors.Errorf("failed to initialize storage with mexe %v", contractPath)
+		return errors.Errorf("failed to initialize storage with mexe '%v', possibly incorrect L1 node?", contractPath)
 	}
 	return nil
 }

--- a/packages/arb-node-core/cmd/arb-relay/arb-relay.go
+++ b/packages/arb-node-core/cmd/arb-relay/arb-relay.go
@@ -72,7 +72,7 @@ func startup() error {
 	ctx, cancelFunc, cancelChan := cmdhelp.CreateLaunchContext()
 	defer cancelFunc()
 
-	config, err := configuration.ParseFeed(ctx)
+	config, err := configuration.ParseFeed()
 	if err != nil || len(config.Feed.Input.URL) == 0 {
 		fmt.Printf("\n")
 		fmt.Printf("Sample usage: arb-relay --conf=<filename> \n")

--- a/packages/arb-node-core/cmd/arb-relay/arb-relay.go
+++ b/packages/arb-node-core/cmd/arb-relay/arb-relay.go
@@ -94,7 +94,7 @@ func startup() error {
 		return errors.New("Missing --feed.input.url")
 	}
 
-	if config.PProf.Enable {
+	if config.PProfEnable {
 		go func() {
 			err := http.ListenAndServe("localhost:8081", pprofMux)
 			log.Error().Err(err).Msg("profiling server failed")

--- a/packages/arb-node-core/cmd/arb-relay/arb-relay_test.go
+++ b/packages/arb-node-core/cmd/arb-relay/arb-relay_test.go
@@ -33,15 +33,13 @@ func TestRelayRebroadcasts(t *testing.T) {
 
 	// Start up an Arbitrum sequencer broadcaster
 	broadcasterSettings := configuration.FeedOutput{
-		Addr: "0.0.0.0",
-		HTTP: struct {
-			Timeout time.Duration `koanf:"timeout"`
-		}{2 * time.Second},
-		Port:    "9742",
-		Ping:    5 * time.Second,
-		Timeout: 15 * time.Second,
-		Queue:   1,
-		Workers: 128,
+		Addr:          "0.0.0.0",
+		IOTimeout:     2 * time.Second,
+		Port:          "9742",
+		Ping:          5 * time.Second,
+		ClientTimeout: 15 * time.Second,
+		Queue:         1,
+		Workers:       128,
 	}
 
 	bc := broadcaster.NewBroadcaster(broadcasterSettings)
@@ -58,15 +56,13 @@ func TestRelayRebroadcasts(t *testing.T) {
 			URL:     "ws://127.0.0.1:9742",
 		},
 		Output: configuration.FeedOutput{
-			Addr: "0.0.0.0",
-			HTTP: struct {
-				Timeout time.Duration `koanf:"timeout"`
-			}{2 * time.Second},
-			Port:    "7429",
-			Ping:    5 * time.Second,
-			Timeout: 15 * time.Second,
-			Queue:   1,
-			Workers: 128,
+			Addr:          "0.0.0.0",
+			IOTimeout:     2 * time.Second,
+			Port:          "7429",
+			Ping:          5 * time.Second,
+			ClientTimeout: 15 * time.Second,
+			Queue:         1,
+			Workers:       128,
 		},
 	}
 

--- a/packages/arb-node-core/cmdhelp/wallet.go
+++ b/packages/arb-node-core/cmdhelp/wallet.go
@@ -40,6 +40,7 @@ import (
 func GetKeystore(
 	validatorFolder string,
 	wallet *configuration.Wallet,
+	gasPrice float64,
 	chainId *big.Int,
 ) (*bind.TransactOpts, func([]byte) ([]byte, error), error) {
 	ks := keystore.NewKeyStore(
@@ -86,7 +87,7 @@ func GetKeystore(
 		return nil, nil, err
 	}
 
-	gasPriceAsFloat := 1e9 * wallet.GasPrice
+	gasPriceAsFloat := 1e9 * gasPrice
 	if gasPriceAsFloat < math.MaxInt64 {
 		auth.GasPrice = big.NewInt(int64(gasPriceAsFloat))
 	}

--- a/packages/arb-node.Dockerfile
+++ b/packages/arb-node.Dockerfile
@@ -72,10 +72,10 @@ FROM offchainlabs/cpp-base:0.3.2 as arb-validator
 
 COPY --chown=user --from=arb-validator-builder /home/user/go/bin /home/user/go/bin
 COPY --chown=user arb-os/arb_os/arbos.mexe /home/user/arb-os/arb_os/
-RUN curl https://raw.githubusercontent.com/OffchainLabs/arb-os/48bdb999a703575d26a856499e6eb3e17691e99d/arb_os/arbos.mexe --output /home/user/mainnet.arb1.mexe && \
-    curl https://raw.githubusercontent.com/OffchainLabs/arb-os/26ab8d7c818681c4ee40792aeb12981a8f2c3dfa/arb_os/arbos.mexe --output /home/user/testnet.rinkeby.mexe && \
-    mkdir /home/user/state && \
-    chown 1000:1000 /home/user/state
+RUN mkdir -p /home/user/.arbitrum && \
+    chown 1000:1000 /home/user/.arbitrum && \
+    curl https://raw.githubusercontent.com/OffchainLabs/arb-os/48bdb999a703575d26a856499e6eb3e17691e99d/arb_os/arbos.mexe --output /home/user/.arbitrum/mainnet.arb1.mexe && \
+    curl https://raw.githubusercontent.com/OffchainLabs/arb-os/26ab8d7c818681c4ee40792aeb12981a8f2c3dfa/arb_os/arbos.mexe --output /home/user/.arbitrum/testnet.rinkeby.mexe
 
 ENTRYPOINT ["/home/user/go/bin/arb-node"]
 EXPOSE 8547 8548

--- a/packages/arb-rpc-node/cmd/arb-dev-sequencer/arb-dev-sequencer.go
+++ b/packages/arb-rpc-node/cmd/arb-dev-sequencer/arb-dev-sequencer.go
@@ -285,15 +285,13 @@ func startup() error {
 		CreateBatchBlockInterval:   big.NewInt(*createBatchBlockInterval),
 	}
 	settings := configuration.FeedOutput{
-		Addr: "127.0.0.1",
-		HTTP: struct {
-			Timeout time.Duration `koanf:"timeout"`
-		}{2 * time.Second},
-		Port:    "9642",
-		Ping:    5 * time.Second,
-		Timeout: 15 * time.Second,
-		Queue:   1,
-		Workers: 2,
+		Addr:          "127.0.0.1",
+		IOTimeout:     2 * time.Second,
+		Port:          "9642",
+		Ping:          5 * time.Second,
+		ClientTimeout: 15 * time.Second,
+		Queue:         1,
+		Workers:       2,
 	}
 
 	db, txDBErrChan, err := txdb.New(ctx, mon.Core, mon.Storage.GetNodeStore(), 100*time.Millisecond)

--- a/packages/arb-util/broadcastclient/broadcastclient_test.go
+++ b/packages/arb-util/broadcastclient/broadcastclient_test.go
@@ -14,15 +14,13 @@ func TestReceiveMessages(t *testing.T) {
 	ctx := context.Background()
 
 	settings := configuration.FeedOutput{
-		Addr: "0.0.0.0",
-		HTTP: struct {
-			Timeout time.Duration `koanf:"timeout"`
-		}{2 * time.Second},
-		Port:    "9742",
-		Ping:    5 * time.Second,
-		Timeout: 20 * time.Second,
-		Queue:   1,
-		Workers: 128,
+		Addr:          "0.0.0.0",
+		IOTimeout:     2 * time.Second,
+		Port:          "9742",
+		Ping:          5 * time.Second,
+		ClientTimeout: 20 * time.Second,
+		Queue:         1,
+		Workers:       128,
 	}
 
 	messageCount := 1000
@@ -93,15 +91,13 @@ func TestServerClientDisconnect(t *testing.T) {
 	ctx := context.Background()
 
 	settings := configuration.FeedOutput{
-		Addr: "0.0.0.0",
-		HTTP: struct {
-			Timeout time.Duration `koanf:"timeout"`
-		}{2 * time.Second},
-		Port:    "9743",
-		Ping:    1 * time.Second,
-		Timeout: 2 * time.Second,
-		Queue:   1,
-		Workers: 128,
+		Addr:          "0.0.0.0",
+		IOTimeout:     2 * time.Second,
+		Port:          "9743",
+		Ping:          1 * time.Second,
+		ClientTimeout: 2 * time.Second,
+		Queue:         1,
+		Workers:       128,
 	}
 
 	b := broadcaster.NewBroadcaster(settings)
@@ -151,15 +147,13 @@ func TestBroadcastClientReconnectsOnServerDisconnect(t *testing.T) {
 	ctx := context.Background()
 
 	settings := configuration.FeedOutput{
-		Addr: "0.0.0.0",
-		HTTP: struct {
-			Timeout time.Duration `koanf:"timeout"`
-		}{2 * time.Second},
-		Port:    "9743",
-		Ping:    50 * time.Second,
-		Timeout: 150 * time.Second,
-		Queue:   1,
-		Workers: 128,
+		Addr:          "0.0.0.0",
+		IOTimeout:     2 * time.Second,
+		Port:          "9743",
+		Ping:          50 * time.Second,
+		ClientTimeout: 150 * time.Second,
+		Queue:         1,
+		Workers:       128,
 	}
 
 	b1 := broadcaster.NewBroadcaster(settings)
@@ -191,15 +185,13 @@ func TestBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
 	ctx := context.Background()
 
 	settings := configuration.FeedOutput{
-		Addr: "0.0.0.0",
-		HTTP: struct {
-			Timeout time.Duration `koanf:"timeout"`
-		}{2 * time.Second},
-		Port:    "9842",
-		Ping:    5 * time.Second,
-		Timeout: 15 * time.Second,
-		Queue:   1,
-		Workers: 128,
+		Addr:          "0.0.0.0",
+		IOTimeout:     2 * time.Second,
+		Port:          "9842",
+		Ping:          5 * time.Second,
+		ClientTimeout: 15 * time.Second,
+		Queue:         1,
+		Workers:       128,
 	}
 
 	b := broadcaster.NewBroadcaster(settings)

--- a/packages/arb-util/broadcaster/broadcaster.go
+++ b/packages/arb-util/broadcaster/broadcaster.go
@@ -88,7 +88,7 @@ func (b *Broadcaster) Start(ctx context.Context) error {
 	// Called below in accept() loop.
 	handle := func(conn net.Conn) {
 
-		safeConn := deadliner{conn, b.settings.HTTP.Timeout}
+		safeConn := deadliner{conn, b.settings.IOTimeout}
 
 		// Zero-copy upgrade to WebSocket connection.
 		hs, err := ws.Upgrade(safeConn)

--- a/packages/arb-util/broadcaster/broadcaster_test.go
+++ b/packages/arb-util/broadcaster/broadcaster_test.go
@@ -36,15 +36,13 @@ func TestBroadcasterSendsConfirmedAccumulatorMessages(t *testing.T) {
 	ctx := context.Background()
 
 	broadcasterSettings := configuration.FeedOutput{
-		Addr: "0.0.0.0",
-		HTTP: struct {
-			Timeout time.Duration `koanf:"timeout"`
-		}{2 * time.Second},
-		Port:    "9642",
-		Ping:    5 * time.Second,
-		Timeout: 20 * time.Second,
-		Queue:   1,
-		Workers: 128,
+		Addr:          "0.0.0.0",
+		IOTimeout:     2 * time.Second,
+		Port:          "9642",
+		Ping:          5 * time.Second,
+		ClientTimeout: 20 * time.Second,
+		Queue:         1,
+		Workers:       128,
 	}
 
 	b := NewBroadcaster(broadcasterSettings)
@@ -158,15 +156,13 @@ func TestBroadcasterRespondsToPing(t *testing.T) {
 	ctx := context.Background()
 
 	broadcasterSettings := configuration.FeedOutput{
-		Addr: "0.0.0.0",
-		HTTP: struct {
-			Timeout time.Duration `koanf:"timeout"`
-		}{2 * time.Second},
-		Port:    "9643",
-		Ping:    5 * time.Second,
-		Timeout: 20 * time.Second,
-		Queue:   1,
-		Workers: 128,
+		Addr:          "0.0.0.0",
+		IOTimeout:     2 * time.Second,
+		Port:          "9643",
+		Ping:          5 * time.Second,
+		ClientTimeout: 20 * time.Second,
+		Queue:         1,
+		Workers:       128,
 	}
 
 	b := NewBroadcaster(broadcasterSettings)
@@ -218,15 +214,13 @@ func TestBroadcasterReorganizesCacheBasedOnAccumulator(t *testing.T) {
 	defer cancelFunc()
 
 	broadcasterSettings := configuration.FeedOutput{
-		Addr: "0.0.0.0",
-		HTTP: struct {
-			Timeout time.Duration `koanf:"timeout"`
-		}{2 * time.Second},
-		Port:    "9642",
-		Ping:    5 * time.Second,
-		Timeout: 30 * time.Second,
-		Queue:   1,
-		Workers: 128,
+		Addr:          "0.0.0.0",
+		IOTimeout:     2 * time.Second,
+		Port:          "9642",
+		Ping:          5 * time.Second,
+		ClientTimeout: 30 * time.Second,
+		Queue:         1,
+		Workers:       128,
 	}
 
 	b := NewBroadcaster(broadcasterSettings)

--- a/packages/arb-util/broadcaster/broadcasterload_test.go
+++ b/packages/arb-util/broadcaster/broadcasterload_test.go
@@ -37,15 +37,13 @@ func TestBroadcasterLoad(t *testing.T) {
 	ctx := context.Background()
 
 	broadcasterSettings := configuration.FeedOutput{
-		Addr: "0.0.0.0",
-		HTTP: struct {
-			Timeout time.Duration `koanf:"timeout"`
-		}{2 * time.Second},
-		Port:    "9942",
-		Ping:    5 * time.Second,
-		Timeout: 15 * time.Second,
-		Queue:   1,
-		Workers: 128,
+		Addr:          "0.0.0.0",
+		IOTimeout:     2 * time.Second,
+		Port:          "9942",
+		Ping:          5 * time.Second,
+		ClientTimeout: 15 * time.Second,
+		Queue:         1,
+		Workers:       128,
 	}
 
 	b := NewBroadcaster(broadcasterSettings)

--- a/packages/arb-util/broadcaster/clientmanager.go
+++ b/packages/arb-util/broadcaster/clientmanager.go
@@ -262,7 +262,7 @@ func (cm *ClientManager) verifyClients() {
 	deadClientList := make([]*ClientConnection, 0, clientConnectionCount)
 	for client := range cm.clientPtrMap {
 		diff := time.Since(client.GetLastHeard())
-		if diff > cm.settings.Timeout {
+		if diff > cm.settings.ClientTimeout {
 			deadClientList = append(deadClientList, client)
 		}
 	}

--- a/packages/arb-util/broadcaster/clientmanager.go
+++ b/packages/arb-util/broadcaster/clientmanager.go
@@ -257,7 +257,6 @@ func (cm *ClientManager) doBroadcast(bm *BroadcastMessage) error {
 // verifyClients should be called every cm.settings.ClientPingInterval
 func (cm *ClientManager) verifyClients() {
 	clientConnectionCount := len(cm.clientPtrMap)
-	logger.Debug().Int("feed_client_count", clientConnectionCount).Send()
 
 	// Create list of clients to clients to remove
 	deadClientList := make([]*ClientConnection, 0, clientConnectionCount)

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 )
 
@@ -282,14 +283,27 @@ func Parse(ctx context.Context) (*Config, *Wallet, *ethutils.RPCEthClient, *big.
 	}
 
 	// Make persistent storage directory relative to home directory if not already absolute
-	out.Persistent.Storage.Path = path.Join(homeDir, out.Persistent.Storage.Path)
+	if !filepath.IsAbs(out.Persistent.Storage.Path) {
+		out.Persistent.Storage.Path = path.Join(homeDir, out.Persistent.Storage.Path)
+	}
+	err = os.MkdirAll(out.Persistent.Storage.Path, os.ModePerm)
+	if err != nil {
+		return nil, nil, nil, nil, errors.Wrap(err, "Unable to create storage directory")
+	}
 
 	// Make chain directory relative to persistent storage directory if not already absolute
-	out.Persistent.Chain.Path = path.Join(out.Persistent.Storage.Path, out.Persistent.Chain.Path)
+	if !filepath.IsAbs(out.Persistent.Chain.Path) {
+		out.Persistent.Chain.Path = path.Join(out.Persistent.Storage.Path, out.Persistent.Chain.Path)
+	}
+	err = os.MkdirAll(out.Persistent.Chain.Path, os.ModePerm)
+	if err != nil {
+		return nil, nil, nil, nil, errors.Wrap(err, "Unable to create chain directory")
+	}
 
 	// Make db directory relative to chain directory if not already absolute
-	out.Persistent.Database.Path = path.Join(out.Persistent.Chain.Path, out.Persistent.Database.Path)
-
+	if !filepath.IsAbs(out.Persistent.Database.Path) {
+		out.Persistent.Database.Path = path.Join(out.Persistent.Chain.Path, out.Persistent.Database.Path)
+	}
 	err = os.MkdirAll(out.Persistent.Database.Path, os.ModePerm)
 	if err != nil {
 		return nil, nil, nil, nil, errors.Wrap(err, "Unable to create database directory")

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -199,13 +199,7 @@ func Parse(ctx context.Context) (*Config, *Wallet, *ethutils.RPCEthClient, *big.
 		return nil, nil, nil, nil, err
 	}
 
-	rollupAddress, _ := f.GetString("rollup.address")
-
-	l1URL, err := f.GetString("l1.url")
-	if err != nil {
-		return nil, nil, nil, nil, errors.Wrap(err, "error getting --l1.url")
-	}
-
+	l1URL := k.String("l1.url")
 	if len(l1URL) == 0 {
 		return nil, nil, nil, nil, errors.New("required parameter --l1.url is missing")
 	}
@@ -231,7 +225,7 @@ func Parse(ctx context.Context) (*Config, *Wallet, *ethutils.RPCEthClient, *big.
 	}
 	logger.Debug().Str("chainid", l1ChainId.String()).Msg("connected to l1 chain")
 
-	if len(rollupAddress) == 0 {
+	if len(k.String("rollup.address")) == 0 {
 		if l1ChainId.Cmp(big.NewInt(1)) == 0 {
 			err := k.Load(confmap.Provider(map[string]interface{}{
 				"bridge.utils.address":     "0x84efa170dc6d521495d7942e372b8e4b2fb918ec",

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -296,6 +296,9 @@ func Parse(ctx context.Context) (*Config, *Wallet, *ethutils.RPCEthClient, *big.
 		out.Rollup.Machine.Filename = path.Join(out.Persistent.Storage.Path, "arbos.mexe")
 	}
 
+	// Make machine relative to home directory if not already absolute
+	out.Rollup.Machine.Filename = path.Join(homeDir, out.Rollup.Machine.Filename)
+
 	return out, wallet, l1Client, l1ChainId, nil
 }
 

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -321,7 +321,7 @@ func Parse(ctx context.Context) (*Config, *Wallet, *ethutils.RPCEthClient, *big.
 	return out, wallet, l1Client, l1ChainId, nil
 }
 
-func ParseFeed(ctx context.Context) (*Config, error) {
+func ParseFeed() (*Config, error) {
 	f := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 	k, err := beginCommonParse(f)


### PR DESCRIPTION
Make `~/.arbitrum/<chain name>` the default directory to store database and keys