### PR TITLE
Add missing message delivery mutex

### DIFF
--- a/packages/arb-node-core/monitor/inboxReader.go
+++ b/packages/arb-node-core/monitor/inboxReader.go
@@ -405,6 +405,8 @@ func (ir *InboxReader) deliverQueueItems() {
 		for _, item := range ir.sequencerFeedQueue {
 			queueItems = append(queueItems, item.BatchItem)
 		}
+		ir.MessageDeliveryMutex.Lock()
+		defer ir.MessageDeliveryMutex.Unlock()
 		prevAcc := ir.sequencerFeedQueue[0].PrevAcc
 		logger.Debug().Str("prevAcc", prevAcc.String()).Str("acc", queueItems[len(queueItems)-1].Accumulator.String()).Int("count", len(queueItems)).Msg("delivering broadcast feed items")
 		ir.sequencerFeedQueue = []broadcaster.SequencerFeedItem{}


### PR DESCRIPTION
This should only matter if the sequencer is connected to a feed with its own txs