### PR TITLE
Don't copy nonexistent address

### DIFF
--- a/packages/arb-evm/evm/incoming.go
+++ b/packages/arb-evm/evm/incoming.go
@@ -51,9 +51,18 @@ func GetTransaction(res *TxResult) (*ProcessedTx, error) {
 		return nil, errors.New("message not convertible to receipt")
 	}
 	l2Type := l2msg.L2Type()
+
+	tx := ethMsg.AsEthTx()
+	if res.ResultCode == ReturnCode && ethMsg.AsEthTx().To() == nil && len(res.ReturnData) == 0 {
+		ethMsg, ok := ethMsg.(message.ContractTransaction)
+		if ok {
+			// If we're in a successful retryable send to the 0 address, it wasn't treated as contract construction
+			tx = ethMsg.AsNonConstructorTx()
+		}
+	}
 	return &ProcessedTx{
 		Result:    res,
-		Tx:        ethMsg.AsEthTx(),
+		Tx:        tx,
 		Kind:      msg.Kind,
 		L2Subtype: &l2Type,
 	}, nil

--- a/packages/arb-evm/evm/incoming.go
+++ b/packages/arb-evm/evm/incoming.go
@@ -53,7 +53,7 @@ func GetTransaction(res *TxResult) (*ProcessedTx, error) {
 	l2Type := l2msg.L2Type()
 
 	tx := ethMsg.AsEthTx()
-	if res.ResultCode == ReturnCode && ethMsg.AsEthTx().To() == nil && len(res.ReturnData) == 0 {
+	if res.ResultCode == ReturnCode && tx.To() == nil && len(res.ReturnData) == 0 {
 		ethMsg, ok := ethMsg.(message.ContractTransaction)
 		if ok {
 			// If we're in a successful retryable send to the 0 address, it wasn't treated as contract construction

--- a/packages/arb-evm/evm/result.go
+++ b/packages/arb-evm/evm/result.go
@@ -275,7 +275,11 @@ func (r *TxResult) ToEthReceipt(blockHash common.Hash) *types.Receipt {
 			if msg, ok := msg.(message.AbstractTransaction); ok {
 				emptyAddress := common.Address{}
 				if msg.Destination() == emptyAddress {
-					copy(contractAddress[:], r.ReturnData[12:])
+					if len(r.ReturnData) == 32 {
+						copy(contractAddress[:], r.ReturnData[12:])
+					} else {
+						logger.Warn().Str("txresult", r.String()).Msg("incorrect returndata size in ToEthReceipt")
+					}
 				}
 			}
 		}

--- a/packages/arb-evm/message/l2Message.go
+++ b/packages/arb-evm/message/l2Message.go
@@ -312,6 +312,10 @@ func (t ContractTransaction) AsEthTx() *types.Transaction {
 	}
 }
 
+func (t ContractTransaction) AsNonConstructorTx() *types.Transaction {
+	return types.NewTransaction(0, t.DestAddress.ToEthAddress(), t.Payment, t.MaxGas.Uint64(), t.GasPriceBid, t.Data)
+}
+
 type Call struct {
 	BasicTx
 }


### PR DESCRIPTION
If TxResult returndata isn't large enough to be an address, don't try and copy address out of it