### PR TITLE
Wait for fireblocks confirmation of tx before exposing receipt

### DIFF
--- a/packages/arb-node-core/ethbridge/auth.go
+++ b/packages/arb-node-core/ethbridge/auth.go
@@ -172,8 +172,13 @@ func NewFireblocksTransactAuthAdvanced(
 				Msg("fireblocks transaction failed when getting receipt")
 			return nil, errors.Wrapf(err, "fireblocks transaction failed when getting receipt: %s", details.Status)
 		}
+		if fb.IsTransactionStatusCompletedSuccessfully(details.Status) {
+			// The transaction is marked as completed in Fireblocks. Get the actual tx receipt.
+			return client.TransactionReceipt(ctx, tx.Hash())
+		}
 
-		return client.TransactionReceipt(ctx, tx.Hash())
+		// The transaction is still pending in Fireblocks. Don't expose the tx receipt yet, even if it exists.
+		return nil, nil
 	}
 
 	transactAuth := &TransactAuth{

--- a/packages/arb-util/fireblocks/fireblocks.go
+++ b/packages/arb-util/fireblocks/fireblocks.go
@@ -23,7 +23,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/rs/zerolog"
 	"io"
 	"io/ioutil"
 	"math/big"
@@ -32,6 +31,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/rs/zerolog"
 
 	"github.com/golang-jwt/jwt"
 	"github.com/pkg/errors"
@@ -59,6 +60,7 @@ const (
 	Rejected                      = "REJECTED"
 	Blocked                       = "BLOCKED"
 	Failed                        = "FAILED"
+	Completed                     = "COMPLETED"
 )
 
 type Fireblocks struct {
@@ -485,11 +487,15 @@ func (fb *Fireblocks) GetTransactionByExternalId(externalId string) (*Transactio
 }
 
 func (fb *Fireblocks) IsTransactionStatusFailed(status string) bool {
-	if len(status) == 0 || status == Cancelled || status == Rejected || status == Blocked || status == Failed {
-		return true
-	}
+	return len(status) == 0 ||
+		status == Cancelled ||
+		status == Rejected ||
+		status == Blocked ||
+		status == Failed
+}
 
-	return false
+func (fb *Fireblocks) IsTransactionStatusCompletedSuccessfully(status string) bool {
+	return status == Completed
 }
 
 func (fb *Fireblocks) CancelTransaction(txid string) error {


### PR DESCRIPTION
This should get rid of the internal errors we've seen and make transacting with fireblocks smoother