### PR TITLE
Fix replace by fee now that auth doesn't have a gas price

### DIFF
--- a/packages/arb-util/transactauth/chain.go
+++ b/packages/arb-util/transactauth/chain.go
@@ -145,7 +145,7 @@ func WaitForReceiptWithResultsAndReplaceByFee(
 	if transactAuth != nil {
 		attemptRbf := func() (*arbtransaction.ArbTransaction, error) {
 			auth := transactAuth.GetAuth(ctx)
-			if auth.GasPrice.Cmp(arbTx.GasPrice()) <= 0 {
+			if auth.GasPrice != nil && auth.GasPrice.Cmp(arbTx.GasPrice()) <= 0 {
 				return arbTx, nil
 			}
 			var rawTx *types.Transaction


### PR DESCRIPTION
This check isn't necessary, it's just a fail fast mechanism. There are better checks about the gas price increase later in the method.