### PR TITLE
Fix broadcaster receive data

### DIFF
--- a/packages/arb-util/broadcaster/broadcaster.go
+++ b/packages/arb-util/broadcaster/broadcaster.go
@@ -134,7 +134,8 @@ func (b *Broadcaster) Start(ctx context.Context) error {
 
 			// receive client messages, close on error
 			pool.Schedule(func() {
-				if err := client.Receive(); err != nil {
+				// Ignore any messages sent from client
+				if _, _, err := client.Receive(ctx, b.settings.IOTimeout); err != nil {
 					logger.Warn().Err(err).Str("connection_name", nameConn(safeConn)).Msg("receive error")
 					clientManager.Remove(client)
 					return

--- a/packages/arb-util/broadcaster/utils.go
+++ b/packages/arb-util/broadcaster/utils.go
@@ -1,0 +1,68 @@
+package broadcaster
+
+import (
+	"context"
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+	"io/ioutil"
+	"net"
+	"strings"
+	"time"
+)
+
+func ReadData(ctx context.Context, conn net.Conn, idleTimeout time.Duration, state ws.State) ([]byte, ws.OpCode, error) {
+	controlHandler := wsutil.ControlFrameHandler(conn, state)
+	reader := wsutil.Reader{
+		Source:          conn,
+		State:           state,
+		CheckUTF8:       true,
+		SkipHeaderCheck: false,
+		OnIntermediate:  controlHandler,
+	}
+
+	// Remove timeout when leaving this function
+	defer func(conn net.Conn) {
+		err := conn.SetReadDeadline(time.Time{})
+		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			logger.Error().Err(err).Msg("error removing read deadline")
+		}
+	}(conn)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, 0, nil
+		default:
+		}
+
+		err := conn.SetReadDeadline(time.Now().Add(idleTimeout))
+		if err != nil {
+			return nil, 0, err
+		}
+
+		// Control packet may be returned even if err set
+		header, err := reader.NextFrame()
+		if header.OpCode.IsControl() {
+			// Control packet may be returned even if err set
+			if err2 := controlHandler(header, &reader); err != nil {
+				return nil, 0, err2
+			}
+			continue
+		}
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if header.OpCode != ws.OpText &&
+			header.OpCode != ws.OpBinary {
+			if err := reader.Discard(); err != nil {
+				return nil, 0, err
+			}
+			continue
+		}
+
+		data, err := ioutil.ReadAll(&reader)
+
+		return data, header.OpCode, err
+	}
+}


### PR DESCRIPTION
Broadcastclient had previously been modified to reliably receive data.  The broadcast server data didn't have these changes.  The server doesn't receive any data from client, but under heavy traffic some corner cases can be reached, so better to fix the receive code fully.