### PR TITLE
Add parameters to control sleep length

### DIFF
--- a/packages/arb-avm-cpp/cavm/carbstorage.cpp
+++ b/packages/arb-avm-cpp/cavm/carbstorage.cpp
@@ -39,11 +39,14 @@ CArbStorage* createArbStorage(const char* db_path,
         arb_core_config.checkpoint_load_gas_cost;
     coreConfig.min_gas_checkpoint_frequency =
         arb_core_config.min_gas_checkpoint_frequency;
-    coreConfig.basic_sideload_cache_interval = arb_core_config.basic_cache_interval;
+    coreConfig.basic_sideload_cache_interval =
+        arb_core_config.basic_cache_interval;
     coreConfig.basic_sideload_cache_size = arb_core_config.basic_cache_size;
     coreConfig.lru_sideload_cache_size = arb_core_config.lru_cache_size;
     coreConfig.timed_cache_expiration_seconds =
         arb_core_config.cache_expiration_seconds;
+    coreConfig.idle_sleep_milliseconds =
+        arb_core_config.idle_sleep_milliseconds;
     coreConfig.seed_cache_on_startup = arb_core_config.seed_cache_on_startup;
     coreConfig.debug = arb_core_config.debug;
     coreConfig.save_rocksdb_interval = arb_core_config.save_rocksdb_interval;

--- a/packages/arb-avm-cpp/cavm/carbstorage.h
+++ b/packages/arb-avm-cpp/cavm/carbstorage.h
@@ -32,6 +32,7 @@ typedef struct {
     int32_t basic_cache_size;
     int32_t lru_cache_size;
     int32_t cache_expiration_seconds;
+    int32_t idle_sleep_milliseconds;
     int32_t seed_cache_on_startup;
     int32_t debug;
     int32_t save_rocksdb_interval;

--- a/packages/arb-avm-cpp/cmachine/storage.go
+++ b/packages/arb-avm-cpp/cmachine/storage.go
@@ -53,6 +53,7 @@ func NewArbStorage(dbPath string, coreConfig *configuration.Core) (*ArbStorage, 
 	defer C.free(unsafe.Pointer(cSaveRocksdbPath))
 
 	cacheExpirationSeconds := int(coreConfig.Cache.TimedExpire.Seconds())
+	sleepMilliseconds := int(coreConfig.IdleSleep.Milliseconds())
 	saveRocksdbIntervalSeconds := int(coreConfig.SaveRocksdbInterval.Seconds())
 	cConfig := C.CArbCoreConfig{
 		message_process_count:         C.int(coreConfig.MessageProcessCount),
@@ -62,6 +63,7 @@ func NewArbStorage(dbPath string, coreConfig *configuration.Core) (*ArbStorage, 
 		basic_cache_size:              C.int(coreConfig.Cache.BasicSize),
 		lru_cache_size:                C.int(coreConfig.Cache.LRUSize),
 		cache_expiration_seconds:      C.int(cacheExpirationSeconds),
+		idle_sleep_milliseconds:       C.int(sleepMilliseconds),
 		seed_cache_on_startup:         boolToCInt(coreConfig.Cache.SeedOnStartup),
 		debug:                         boolToCInt(coreConfig.Debug),
 		save_rocksdb_interval:         C.int(saveRocksdbIntervalSeconds),

--- a/packages/arb-avm-cpp/cmachine/storage.go
+++ b/packages/arb-avm-cpp/cmachine/storage.go
@@ -68,10 +68,10 @@ func NewArbStorage(dbPath string, coreConfig *configuration.Core) (*ArbStorage, 
 		save_rocksdb_path:             cSaveRocksdbPath,
 		lazy_load_core_machine:        boolToCInt(coreConfig.LazyLoadCoreMachine),
 		lazy_load_archive_queries:     boolToCInt(coreConfig.LazyLoadArchiveQueries),
-		profile_reorg_to:              C.int(coreConfig.Profile.ReorgTo),
-		profile_run_until:             C.int(coreConfig.Profile.RunUntil),
-		profile_load_count:            C.int(coreConfig.Profile.LoadCount),
-		profile_reset_db_except_inbox: boolToCInt(coreConfig.Profile.ResetAllExceptInbox),
+		profile_reorg_to:              C.int(coreConfig.Test.ReorgTo),
+		profile_run_until:             C.int(coreConfig.Test.RunUntil),
+		profile_load_count:            C.int(coreConfig.Test.LoadCount),
+		profile_reset_db_except_inbox: boolToCInt(coreConfig.Test.ResetAllExceptInbox),
 	}
 
 	cArbStorage := C.createArbStorage(cDbPath, cConfig)

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
@@ -82,6 +82,9 @@ struct ArbCoreConfig {
     // How long to keep machines in memory cache
     uint32_t timed_cache_expiration_seconds{20 * 60};
 
+    // Number of milliseconds to sleep when idle
+    uint32_t idle_sleep_milliseconds;
+
     // Seed cache on startup by forcing re-execution from timed_cache_expiration
     bool seed_cache_on_startup{false};
 

--- a/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
@@ -1135,7 +1135,8 @@ void ArbCore::operator()() {
         if (!machineIdle() || message_data_status != MESSAGES_READY) {
             // Machine is already running or no new messages, so sleep for a
             // short while
-            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(coreConfig.idle_sleep_milliseconds));
         }
     }
 

--- a/packages/arb-rpc-node/cmd/arb-dev-sequencer/arb-dev-sequencer.go
+++ b/packages/arb-rpc-node/cmd/arb-dev-sequencer/arb-dev-sequencer.go
@@ -303,7 +303,7 @@ func startup() error {
 		InboxReader: inboxReader,
 	}
 
-	db, txDBErrChan, err := txdb.New(ctx, mon.Core, mon.Storage.GetNodeStore(), 100*time.Millisecond, &config.Node)
+	db, txDBErrChan, err := txdb.New(ctx, mon.Core, mon.Storage.GetNodeStore(), &config.Node)
 	if err != nil {
 		return errors.Wrap(err, "error opening txdb")
 	}

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -284,7 +284,7 @@ func startup() error {
 	nodeStore := mon.Storage.GetNodeStore()
 	metricsConfig.RegisterNodeStoreMetrics(nodeStore)
 	metricsConfig.RegisterArbCoreMetrics(mon.Core)
-	db, txDBErrChan, err := txdb.New(ctx, mon.Core, nodeStore, 100*time.Millisecond, &config.Node.Cache)
+	db, txDBErrChan, err := txdb.New(ctx, mon.Core, nodeStore, 100*time.Millisecond, &config.Node)
 	if err != nil {
 		return errors.Wrap(err, "error opening txdb")
 	}

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -284,7 +284,7 @@ func startup() error {
 	nodeStore := mon.Storage.GetNodeStore()
 	metricsConfig.RegisterNodeStoreMetrics(nodeStore)
 	metricsConfig.RegisterArbCoreMetrics(mon.Core)
-	db, txDBErrChan, err := txdb.New(ctx, mon.Core, nodeStore, 100*time.Millisecond, &config.Node)
+	db, txDBErrChan, err := txdb.New(ctx, mon.Core, nodeStore, &config.Node)
 	if err != nil {
 		return errors.Wrap(err, "error opening txdb")
 	}

--- a/packages/arb-rpc-node/dev/dev.go
+++ b/packages/arb-rpc-node/dev/dev.go
@@ -51,11 +51,7 @@ import (
 var logger = log.With().Caller().Stack().Str("component", "dev").Logger()
 
 func NewDevNode(ctx context.Context, dir string, arbosPath string, chainId *big.Int, agg common.Address, initialL1Height uint64) (*Backend, *txdb.TxDB, func(), <-chan error, error) {
-	nodeCacheConfig := configuration.NodeCache{
-		AllowSlowLookup: true,
-		LRUSize:         1000,
-		TimedExpire:     20 * time.Minute,
-	}
+	nodeConfig := configuration.DefaultNodeSettings()
 	coreConfig := configuration.DefaultCoreSettings()
 
 	mon, err := monitor.NewMonitor(dir, arbosPath, coreConfig)
@@ -69,7 +65,7 @@ func NewDevNode(ctx context.Context, dir string, arbosPath string, chainId *big.
 		return nil, nil, nil, nil, err
 	}
 
-	db, errChan, err := txdb.New(ctx, mon.Core, mon.Storage.GetNodeStore(), 10*time.Millisecond, &nodeCacheConfig)
+	db, errChan, err := txdb.New(ctx, mon.Core, mon.Storage.GetNodeStore(), 10*time.Millisecond, nodeConfig)
 	if err != nil {
 		mon.Close()
 		return nil, nil, nil, nil, errors.Wrap(err, "error opening txdb")
@@ -383,7 +379,7 @@ func (b *Backend) PendingSnapshot() (*snapshot.Snapshot, error) {
 	return nil, nil
 }
 
-func (b *Backend) Start(ctx context.Context) {
+func (b *Backend) Start(_ context.Context) {
 }
 
 type L1BlockInfo struct {

--- a/packages/arb-rpc-node/dev/dev.go
+++ b/packages/arb-rpc-node/dev/dev.go
@@ -65,7 +65,7 @@ func NewDevNode(ctx context.Context, dir string, arbosPath string, chainId *big.
 		return nil, nil, nil, nil, err
 	}
 
-	db, errChan, err := txdb.New(ctx, mon.Core, mon.Storage.GetNodeStore(), 10*time.Millisecond, nodeConfig)
+	db, errChan, err := txdb.New(ctx, mon.Core, mon.Storage.GetNodeStore(), nodeConfig)
 	if err != nil {
 		mon.Close()
 		return nil, nil, nil, nil, errors.Wrap(err, "error opening txdb")

--- a/packages/arb-rpc-node/txdb/txdb.go
+++ b/packages/arb-rpc-node/txdb/txdb.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-	"time"
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
@@ -71,7 +70,6 @@ func New(
 	ctx context.Context,
 	arbCore core.ArbCore,
 	as machine.NodeStore,
-	updateFrequency time.Duration,
 	nodeConfig *configuration.Node,
 ) (*TxDB, <-chan error, error) {
 	var snapshotLRUCache *lru.Cache
@@ -102,7 +100,7 @@ func New(
 		snapshotTimedCache: snapshotTimedCache,
 		allowSlowLookup:    nodeConfig.Cache.AllowSlowLookup,
 	}
-	logReader := core.NewLogReader(db, arbCore, big.NewInt(0), big.NewInt(int64(nodeConfig.LogProcessCount)), updateFrequency)
+	logReader := core.NewLogReader(db, arbCore, big.NewInt(0), big.NewInt(int64(nodeConfig.LogProcessCount)), nodeConfig.LogIdleSleep)
 	errChan := logReader.Start(ctx)
 	db.logReader = logReader
 	return db, errChan, nil

--- a/packages/arb-rpc-node/txdb/txdb.go
+++ b/packages/arb-rpc-node/txdb/txdb.go
@@ -72,25 +72,25 @@ func New(
 	arbCore core.ArbCore,
 	as machine.NodeStore,
 	updateFrequency time.Duration,
-	cacheConfig *configuration.NodeCache,
+	nodeConfig *configuration.Node,
 ) (*TxDB, <-chan error, error) {
 	var snapshotLRUCache *lru.Cache
 	var blockInfoLRUCache *lru.Cache
-	if cacheConfig.LRUSize > 0 {
+	if nodeConfig.Cache.LRUSize > 0 {
 		var err error
-		snapshotLRUCache, err = lru.New(cacheConfig.LRUSize)
+		snapshotLRUCache, err = lru.New(nodeConfig.Cache.LRUSize)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
-	if cacheConfig.BlockInfoLRUSize > 0 {
+	if nodeConfig.Cache.BlockInfoLRUSize > 0 {
 		var err error
-		blockInfoLRUCache, err = lru.New(cacheConfig.BlockInfoLRUSize)
+		blockInfoLRUCache, err = lru.New(nodeConfig.Cache.BlockInfoLRUSize)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
-	snapshotTimedCache, err := blockcache.New(cacheConfig.TimedInitialSize, cacheConfig.TimedExpire)
+	snapshotTimedCache, err := blockcache.New(nodeConfig.Cache.TimedInitialSize, nodeConfig.Cache.TimedExpire)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -100,9 +100,9 @@ func New(
 		snapshotLRUCache:   snapshotLRUCache,
 		blockInfoLRUCache:  blockInfoLRUCache,
 		snapshotTimedCache: snapshotTimedCache,
-		allowSlowLookup:    cacheConfig.AllowSlowLookup,
+		allowSlowLookup:    nodeConfig.Cache.AllowSlowLookup,
 	}
-	logReader := core.NewLogReader(db, arbCore, big.NewInt(0), big.NewInt(10), updateFrequency)
+	logReader := core.NewLogReader(db, arbCore, big.NewInt(0), big.NewInt(int64(nodeConfig.LogProcessCount)), updateFrequency)
 	errChan := logReader.Start(ctx)
 	db.logReader = logReader
 	return db, errChan, nil

--- a/packages/arb-util/core/logreader.go
+++ b/packages/arb-util/core/logreader.go
@@ -66,12 +66,6 @@ func bigIntAsString(val *big.Int) string {
 
 func (lr *LogReader) getLogs(ctx context.Context) error {
 	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
-		}
-
 		err := lr.cursor.LogsCursorRequest(lr.cursorIndex, lr.maxCount)
 		if err != nil {
 			return err
@@ -104,7 +98,11 @@ func (lr *LogReader) getLogs(ctx context.Context) error {
 			}
 
 			// No new logs or errors so give some time for new logs to be added
-			time.Sleep(lr.sleepTime)
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(lr.sleepTime):
+			}
 		}
 
 		logger.Debug().
@@ -128,12 +126,6 @@ func (lr *LogReader) getLogs(ctx context.Context) error {
 		}
 
 		for {
-			select {
-			case <-ctx.Done():
-				return nil
-			default:
-			}
-
 			status, err := lr.cursor.LogsCursorConfirmReceived(lr.cursorIndex)
 			if err != nil {
 				return err
@@ -163,6 +155,19 @@ func (lr *LogReader) getLogs(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
+
+			// No new logs or errors so give some time for new logs to be added
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(lr.sleepTime):
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(lr.sleepTime):
 		}
 	}
 }


### PR DESCRIPTION
For easier performance tuning, add the following parameters:
* `--core.idle-sleep` - amount of time to sleep when core thread is idle
* `--node.log-idle-sleep` - amount of time to sleep between collecting logs

Also added missing sleeps in log loop to prevent spinning too fast.