### PR TITLE
Fix querying the latest block racing with a reorg

### DIFF
--- a/packages/arb-rpc-node/txdb/txdb.go
+++ b/packages/arb-rpc-node/txdb/txdb.go
@@ -504,7 +504,7 @@ func (db *TxDB) LatestBlock() (*machine.BlockInfo, error) {
 		if err != nil {
 			return nil, err
 		}
-		if blockData.BlockLog < totalLogCount {
+		if blockData != nil && blockData.BlockLog < totalLogCount {
 			return blockData, nil
 		}
 		blockCount--


### PR DESCRIPTION
This would previously result in a "method handler crashed"