### PR TITLE
Handle missing cursor properly

### DIFF
--- a/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
@@ -410,14 +410,9 @@ class ArbCore {
     std::variant<rocksdb::Status, ExecutionCursor> getExecutionCursorAtBlock(
         const uint256_t& block_number,
         bool allow_slow_lookup);
-    std::variant<rocksdb::Status, ExecutionCursor> getClosestExecutionCursor(
+    std::variant<rocksdb::Status, ExecutionCursor> findCloserExecutionCursor(
         ReadTransaction& tx,
-        uint256_t& total_gas_used,
-        bool allow_slow_lookup);
-    rocksdb::Status findCloserExecutionCursor(
-        ReadTransaction& tx,
-        ExecutionCursor& execution_cursor,
-        std::optional<uint256_t> current_gas,
+        std::optional<ExecutionCursor> execution_cursor,
         uint256_t& total_gas_used,
         bool allow_slow_lookup);
 

--- a/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
@@ -2096,7 +2096,7 @@ rocksdb::Status ArbCore::advanceExecutionCursor(
     {
         ReadSnapshotTransaction tx(data_storage);
         auto result = findCloserExecutionCursor(
-            tx, execution_cursor, total_gas_used, allow_slow_lookup);
+            tx, std::move(execution_cursor), total_gas_used, allow_slow_lookup);
         if (std::holds_alternative<rocksdb::Status>(result)) {
             return std::get<rocksdb::Status>(result);
         }
@@ -2260,7 +2260,7 @@ ArbCore::findCloserExecutionCursor(
 
         if (existing_gas_used.value() == total_gas_used) {
             // Nothing needs to be done
-            return rocksdb::Status::OK();
+            return execution_cursor.value();
         }
     }
 


### PR DESCRIPTION
If archive support is not enabled, handle missing execution cursor properly