### PR TITLE
Include `procps` in docker image

### DIFF
--- a/.circleci/images/dist-base/Dockerfile
+++ b/.circleci/images/dist-base/Dockerfile
@@ -10,6 +10,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y curl cmake git gcc g++ libboost-dev libboost-filesystem-dev \
     lcov make libgmp-dev libssl-dev libusb-dev sudo netcat-openbsd nodejs \
     autotools-dev dh-autoreconf pkg-config libjemalloc-dev \
+    procps \
     libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev libzstd-dev && \
     curl -L https://github.com/facebook/rocksdb/archive/refs/tags/v6.20.3.tar.gz --output rocksdb-6.20.3.tar.gz && \
     tar xf rocksdb-6.20.3.tar.gz && \

--- a/packages/arb-node.Dockerfile
+++ b/packages/arb-node.Dockerfile
@@ -67,7 +67,7 @@ COPY --from=arb-avm-cpp /home/user/.hunter /home/user/.hunter
 RUN cd arb-node-core && go install -v ./cmd/arb-validator && go install -v ./cmd/arb-relay && \
     cd ../arb-rpc-node && go install -v ./cmd/arb-node && go install -v ./cmd/arb-dev-node
 
-FROM offchainlabs/dist-base:0.3.6 as arb-node
+FROM offchainlabs/dist-base:0.3.7 as arb-node
 # Export binary
 
 COPY --chown=user --from=arb-node-builder /home/user/go/bin /home/user/go/bin


### PR DESCRIPTION
Make `top`, `ps`, etc available in docker distribution image