### PR TITLE
Preserve up to two batches worth of feed messages

### DIFF
--- a/packages/arb-util/broadcastclient/broadcastclient_test.go
+++ b/packages/arb-util/broadcastclient/broadcastclient_test.go
@@ -246,6 +246,9 @@ func TestBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
 	// Confirmed Accumulator will also broadcast to the clients.
 	b.ConfirmedAccumulator(feedItem1.BatchItem.Accumulator) // remove the first message we generated
 
+	// Send next accumulator because only previous accumulator is sent to clients
+	b.ConfirmedAccumulator(feedItem2.BatchItem.Accumulator) // remove the first message we generated
+
 	updateTimeout := time.After(2 * time.Second)
 	for {
 		if b.MessageCacheCount() == 1 { // should have left the second message
@@ -259,7 +262,8 @@ func TestBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
 		}
 	}
 
-	b.ConfirmedAccumulator(feedItem2.BatchItem.Accumulator) // remove the second message we generated
+	// Send second accumulator again so that the previously added accumulator is sent
+	b.ConfirmedAccumulator(feedItem2.BatchItem.Accumulator)
 
 	updateTimeout = time.After(2 * time.Second)
 	for {

--- a/packages/arb-util/broadcaster/broadcaster_test.go
+++ b/packages/arb-util/broadcaster/broadcaster_test.go
@@ -65,7 +65,8 @@ func TestBroadcasterSendsConfirmedAccumulatorMessages(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	// Confirmed Accumulator will also broadcast to the clients.
+	// Only previous accumulator will also broadcast to the clients, so send twice for test
+	b.ConfirmedAccumulator(feedItem.BatchItem.Accumulator) // remove the first message we generated
 	b.ConfirmedAccumulator(feedItem.BatchItem.Accumulator) // remove the first message we generated
 
 	acc := <-accumulatorConfirmed

--- a/packages/arb-util/broadcaster/clientmanager.go
+++ b/packages/arb-util/broadcaster/clientmanager.go
@@ -46,7 +46,6 @@ type ClientManager struct {
 	broadcastChan     chan BroadcastMessage
 	clientAction      chan ClientConnectionAction
 	settings          configuration.FeedOutput
-	confirmedAcc      common.Hash
 	prevConfirmedAcc  common.Hash
 }
 
@@ -164,8 +163,7 @@ func (cm *ClientManager) confirmedAccumulator(accumulator common.Hash) {
 		cm.broadcastChan <- bm
 	}
 
-	cm.prevConfirmedAcc = cm.confirmedAcc
-	cm.confirmedAcc = accumulator
+	cm.prevConfirmedAcc = accumulator
 }
 
 // Broadcast sends batch item to all clients.

--- a/packages/arb-util/broadcaster/clientmanager.go
+++ b/packages/arb-util/broadcaster/clientmanager.go
@@ -148,7 +148,11 @@ func (cm *ClientManager) ClientCount() int32 {
 }
 
 func (cm *ClientManager) confirmedAccumulator(accumulator common.Hash) {
-	logger.Debug().Hex("acc", accumulator.Bytes()).Msg("confirming accumulator")
+	logger.
+		Debug().
+		Hex("prevAcc", cm.prevConfirmedAcc.Bytes()).
+		Hex("newAcc", accumulator.Bytes()).
+		Msg("confirming previous accumulator")
 
 	var emptyHash common.Hash
 	if cm.prevConfirmedAcc != emptyHash {
@@ -156,7 +160,7 @@ func (cm *ClientManager) confirmedAccumulator(accumulator common.Hash) {
 			Version: 1,
 			ConfirmedAccumulator: ConfirmedAccumulator{
 				IsConfirmed: true,
-				Accumulator: accumulator,
+				Accumulator: cm.prevConfirmedAcc,
 			},
 		}
 


### PR DESCRIPTION
To better work around synchronization race conditions, preserver two batches worth of sequencer feed messages to send to clients on connect/reconnect to better handle synchronization race conditions