### PR TITLE
Take extra steps to ensure rocksdb closed gracefully

### DIFF
--- a/packages/arb-avm-cpp/cavm/carbstorage.cpp
+++ b/packages/arb-avm-cpp/cavm/carbstorage.cpp
@@ -109,9 +109,7 @@ void destroyArbStorage(CArbStorage* storage_ptr) {
     if (storage == nullptr) {
         return;
     }
-    std::cerr << "closing ArbStorage:" << std::endl;
     storage->closeArbStorage();
-    std::cerr << "closed ArbStorage:" << std::endl;
     delete static_cast<ArbStorage*>(storage);
 }
 


### PR DESCRIPTION
* Call `SyncWAL()` to write any pending data
* Retry closing database if lingering snapshots haven't been closed yet