### PR TITLE
A few fixes for deploying a local rollup

### DIFF
--- a/packages/arb-bridge-eth/deploy/RollupCreator.ts
+++ b/packages/arb-bridge-eth/deploy/RollupCreator.ts
@@ -20,14 +20,14 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   const RollupCreator = await ethers.getContractFactory('RollupCreator')
   const rollupCreator = RollupCreator.attach(dep.address).connect(deployer)
-  await rollupCreator.setTemplates(
+  await (await rollupCreator.setTemplates(
     bridgeCreator.address,
     rollup.address,
     challengeFactory.address,
     nodeFactory.address,
     RollupAdminFacet.address,
     RollupUserFacet.address
-  )
+  )).wait()
 }
 
 module.exports = func

--- a/packages/arb-bridge-eth/geth/ethbridge.json
+++ b/packages/arb-bridge-eth/geth/ethbridge.json
@@ -11,6 +11,8 @@
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
     "clique": {
       "period": 2,
       "epoch": 30000

--- a/packages/arb-bridge-eth/hardhat.config.ts
+++ b/packages/arb-bridge-eth/hardhat.config.ts
@@ -55,6 +55,32 @@ task('create-chain', 'Creates a rollup chain')
     )
   })
 
+task('update-whitelist-consumers', 'Updates rollup whitelist consumers')
+  .addParam('rollup', 'rollup address')
+  .addParam('oldwhitelist', 'old whitelist address')
+  .addParam('newwhitelist', 'new whitelist address')
+  .addParam('whitelistconsumers', 'list of whitelist consumer addresses')
+  .setAction(async (taskArguments, hre) => {
+    const { ethers } = hre
+    // Assume deployer is the RollupAdmin owner
+    const [deployer] = await ethers.getSigners()
+
+    const RollupAdmin = await ethers.getContractFactory('RollupAdminFacet')
+    const rollupAdmin = RollupAdmin.attach(
+      taskArguments.rollup
+    ).connect(deployer)
+
+    const tx = await rollupAdmin.updateWhitelistConsumers(
+      taskArguments.oldwhitelist,
+      taskArguments.newwhitelist,
+      taskArguments.whitelistconsumers.split(',')
+    )
+
+    await tx.wait()
+
+    console.log(`Whitelist consumers updated to use ${taskArguments.newwhitelist}`)
+  })
+
 task('deposit', 'Deposit coins into ethbridge')
   .addPositionalParam('inboxAddress', "The rollup chain's address")
   .addPositionalParam('privkey', 'The private key of the depositer')

--- a/packages/tools/scripts/setup_validators_demo.ts
+++ b/packages/tools/scripts/setup_validators_demo.ts
@@ -34,6 +34,23 @@ async function setupRollup(
   const file = fs.readFileSync(`../arb-bridge-eth/${fileName}`).toString()
   const ev = JSON.parse(file)
 
+  // Disable whitelist
+  const inbox = Inbox__factory.connect(ev.inboxAddress, provider)
+  const oldWhitelistAddress = await inbox.whitelist()
+  const newWhitelistAddress = "0x0000000000000000000000000000000000000000"
+  const whitelistConsumers = `${ev.inboxAddress.toLowerCase()}`
+
+  execSync(
+    `
+      yarn workspace arb-bridge-eth hardhat update-whitelist-consumers \
+        --rollup ${ev.rollupAddress.toLowerCase()} \
+        --oldwhitelist ${oldWhitelistAddress.toLowerCase()} \
+        --newwhitelist ${newWhitelistAddress.toLowerCase()} \
+        --whitelistconsumers ${whitelistConsumers} \
+        --network ${network}
+    `
+  )
+
   return {
     rollupAddress: ev.rollupAddress,
     inboxAddress: ev.inboxAddress,


### PR DESCRIPTION
65a2adbda6977086b9dcc42eb3f09079d5614f4a adds a `.wait()` call for the tx response from `RollupCreator.setTemplates()` in the `RollupCreator` deploy script. `hardhat-deploy` uses the confirmed nonce as opposed to the pending nonce for each deploy (see https://github.com/wighawag/hardhat-deploy/issues/235). So, the `RollupCreator.setTemplates()` call as-is does not wait for confirmation and the next deploy could use the same nonce. As a result, when I ran `yarn docker:geth` the contract deployment failed when trying to deploy `ValidatorUtils` with a `replacement fee too low` error which I believe was caused by the deploy transaction re-using a previously used nonce (i.e. the one used by `RollupCreator.setTemplates()` which would lead to geth thinking that the deploy transaction is an underpriced replacement transaction.

c2b5b2bc61ed75b740b4b50720950128332c9601 sets the London and Berlin blocks 0 in the genesis file for local geth so that those hardforks are activated by default.

5eeab473d4fa854f5d930a9ac1858739ad6f78ee and 6eac9608280e563ce7a9b9bfaaf18759c3813ccd disable the whitelist for the Inbox contract when deploying a local rollup. Without this change, I ran into whitelist revert errors when calling `depositETH()` on the Inbox.

These are just some of the fixes that I managed to get through while trying to deploy and run a local rollup. At this point, there are still a few problems that prevent me from actually running a local rollup (i.e. the docker-compose.yml generation in `arb_deploy.sh` needs to be updated with the latest CLI flags for arb-node not to mention that it doesn't look like I can run the arb-node amd64 images on my arm64 M1 laptop), but I thought I'd push up some of the fixes I've gone through thus far in case its helpful for others.