### PR TITLE
Gas estimate tests sometimes fail due to underflow

### DIFF
--- a/packages/arb-rpc-node/dev/estimate_test.go
+++ b/packages/arb-rpc-node/dev/estimate_test.go
@@ -63,7 +63,7 @@ func TestZeroPriceGasEstimationCall(t *testing.T) {
 		t.Fatal("EstimateGas returned 0")
 	}
 
-	if math.Abs(float64(fundedGas-unfundedGas)) > 100 {
+	if math.Abs(float64(fundedGas)-float64(unfundedGas)) > 100 {
 		t.Fatal("EstimateGas depends on balance", fundedGas, unfundedGas)
 	}
 }
@@ -92,7 +92,7 @@ func TestZeroPriceGasEstimationDeploy(t *testing.T) {
 		t.Fatal("EstimateGas returned 0")
 	}
 
-	if math.Abs(float64(fundedGas-unfundedGas)) > 100 {
+	if math.Abs(float64(fundedGas)-float64(unfundedGas)) > 100 {
 		t.Fatal("EstimateGas depends on balance", fundedGas, unfundedGas)
 	}
 }


### PR DESCRIPTION
If `unfundedGas` > `fundedGas` then we have an underflow in these tests. This sometimes caused the tests to fail.