### PR TITLE
Cleanup SIGUSR1 signal handling

### DIFF
--- a/packages/arb-avm-cpp/cavm/carbcore.cpp
+++ b/packages/arb-avm-cpp/cavm/carbcore.cpp
@@ -51,6 +51,11 @@ int arbCoreMachineIdle(CArbCore* arbcore_ptr) {
     return arb_core->machineIdle();
 }
 
+void arbCoreSaveRocksdbCheckpoint(CArbCore* arbcore_ptr) {
+    auto arb_core = static_cast<ArbCore*>(arbcore_ptr);
+    arb_core->triggerSaveRocksdbCheckpoint();
+}
+
 void* arbCoreMachineMessagesRead(CArbCore* arbcore_ptr) {
     auto arb_core = static_cast<ArbCore*>(arbcore_ptr);
     return returnUint256(arb_core->machineMessagesRead());

--- a/packages/arb-avm-cpp/cavm/carbcore.h
+++ b/packages/arb-avm-cpp/cavm/carbcore.h
@@ -25,6 +25,7 @@ extern "C" {
 int arbCoreStartThread(CArbCore* arbcore_ptr);
 void arbCoreAbortThread(CArbCore* arbcore_ptr);
 int arbCoreMachineIdle(CArbCore* arbcore_ptr);
+void arbCoreSaveRocksdbCheckpoint(CArbCore* arbcore_ptr);
 void* arbCoreMachineMessagesRead(CArbCore* arbcore_ptr);
 int arbCoreMessagesStatus(CArbCore* arbcore_ptr);
 char* arbCoreMessagesClearError(CArbCore* arbcore_ptr);

--- a/packages/arb-avm-cpp/cmachine/arbcore.go
+++ b/packages/arb-avm-cpp/cmachine/arbcore.go
@@ -68,6 +68,11 @@ func (ac *ArbCore) MachineIdle() bool {
 	return status == 1
 }
 
+func (ac *ArbCore) SaveRocksdbCheckpoint() {
+	defer runtime.KeepAlive(ac)
+	C.arbCoreSaveRocksdbCheckpoint(ac.c)
+}
+
 func (ac *ArbCore) MachineMessagesRead() *big.Int {
 	defer runtime.KeepAlive(ac)
 	return receiveBigInt(C.arbCoreMachineMessagesRead(ac.c))

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
@@ -107,6 +107,7 @@ class ArbCore {
     // Core thread input
     std::atomic<bool> save_checkpoint{false};
     rocksdb::Status save_checkpoint_status;
+    std::atomic<bool> trigger_save_rocksdb_checkpoint;
 
     // Core thread holds mutex only during reorg.
     // Routines accessing database for log entries will need to acquire mutex
@@ -236,6 +237,10 @@ class ArbCore {
     template <class T>
     std::unique_ptr<T> getMachine(uint256_t machineHash,
                                   ValueCache& value_cache);
+
+   public:
+    // To trigger saving database copy
+    void triggerSaveRocksdbCheckpoint();
 
    private:
     template <class T>

--- a/packages/arb-node-core/monitor/inboxReader.go
+++ b/packages/arb-node-core/monitor/inboxReader.go
@@ -115,7 +115,12 @@ func (ir *InboxReader) Start(parentCtx context.Context, inboxReaderDelayBlocks i
 			}
 			justErrored = true
 			logger.Warn().Stack().Err(err).Msg("Failed to read inbox messages")
-			<-time.After(time.Second * 2)
+
+			select {
+			case <-ctx.Done():
+				break
+			case <-time.After(time.Second * 2):
+			}
 		}
 	}()
 	ir.cancelFunc = cancelFunc

--- a/packages/arb-node-core/monitor/monitor.go
+++ b/packages/arb-node-core/monitor/monitor.go
@@ -19,6 +19,9 @@ package monitor
 import (
 	"context"
 	"math/big"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -142,5 +145,28 @@ func (m *Monitor) StartInboxReader(
 	}
 	reader.Start(ctx, inboxReaderConfig.DelayBlocks)
 	m.Reader = reader
+	m.listenForSignal(ctx)
 	return reader, nil
+}
+
+func (m *Monitor) listenForSignal(ctx context.Context) {
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGUSR1)
+	go func() {
+		defer close(signalChan)
+		for {
+			select {
+			case <-ctx.Done():
+				break
+			case sig := <-signalChan:
+				switch sig {
+				case syscall.SIGUSR1:
+					logger.Info().Msg("triggering save of rocksdb checkpoint")
+					m.Core.SaveRocksdbCheckpoint()
+				default:
+					logger.Info().Str("signal", sig.String()).Msg("caught unexpected signal")
+				}
+			}
+		}
+	}()
 }

--- a/packages/arb-util/core/lookup.go
+++ b/packages/arb-util/core/lookup.go
@@ -85,6 +85,9 @@ type ArbCoreLookup interface {
 	// UpdateCheckpointPruningGas updates the gas value such that all checkpoints with less gas
 	// will be pruned
 	UpdateCheckpointPruningGas(gas *big.Int)
+
+	// SaveRocksdbCheckpoint tells rocksdb to save a copy of the current database state
+	SaveRocksdbCheckpoint()
 }
 
 type ArbCoreInbox interface {


### PR DESCRIPTION
* Move signal handler from C++ to Go code for more consistency.
* Ensure that current machine checkpoint is saved to database before rocksdb checkpoint is created
* Only perform database pruning when saving checkpoint to avoid spending too much time pruning database.