### PR TITLE
add looksLikeEthDeposit method to L1TransactionReceipt

### DIFF
--- a/packages/arb-ts/src/lib/message/L1ToL2Message.ts
+++ b/packages/arb-ts/src/lib/message/L1ToL2Message.ts
@@ -183,14 +183,19 @@ export class L1TransactionReceipt implements TransactionReceipt {
     )
   }
 
+  /**
+   * Check if tx is a direct call to a depositEth function (i.e., on the Inbox contract)
+   * @returns
+   */
   public async looksLikeEthDeposit(
     l1SignerOrProvider: SignerOrProvider
   ): Promise<boolean> {
     const l1Provider =
       SignerProviderUtils.getProviderOrThrow(l1SignerOrProvider)
     const txRes = await l1Provider.getTransaction(this.transactionHash)
-    const ethDeposit_FUNCTION_SIG = '0x0f4d14e9'
-    return txRes.data.startsWith(ethDeposit_FUNCTION_SIG)
+    // Function signature for depositEth
+    const depositEth_FUNCTION_SIG = '0x0f4d14e9'
+    return txRes.data.startsWith(depositEth_FUNCTION_SIG)
   }
 
   /**

--- a/packages/arb-ts/src/lib/message/L1ToL2Message.ts
+++ b/packages/arb-ts/src/lib/message/L1ToL2Message.ts
@@ -183,6 +183,16 @@ export class L1TransactionReceipt implements TransactionReceipt {
     )
   }
 
+  public async looksLikeEthDeposit(
+    l1SignerOrProvider: SignerOrProvider
+  ): Promise<boolean> {
+    const l1Provider =
+      SignerProviderUtils.getProviderOrThrow(l1SignerOrProvider)
+    const txRes = await l1Provider.getTransaction(this.transactionHash)
+    const ethDeposit_FUNCTION_SIG = '0x0f4d14e9'
+    return txRes.data.startsWith(ethDeposit_FUNCTION_SIG)
+  }
+
   /**
    * Replaces the wait function with one that returns an L1TransactionReceipt
    * @param contractTransaction


### PR DESCRIPTION
Weird exception to how retryables are normally used, so nice to have this detector 