### PR TITLE
Add extra logging when reorg detected in getMessagesImpl

### DIFF
--- a/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
@@ -475,4 +475,6 @@ uint64_t seconds_since_epoch();
 std::optional<rocksdb::Status> deleteLogsStartingAt(ReadWriteTransaction& tx,
                                                     uint256_t log_index);
 
+std::string optionalUint256ToString(std::optional<uint256_t>& value);
+
 #endif /* arbcore_hpp */

--- a/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
@@ -2048,8 +2048,7 @@ ValueResult<std::vector<RawMessageInfo>> ArbCore::getMessagesImpl(
                 delayed_msg_it->Next();
             }
 
-            if (!delayed_msg_it->status().IsNotFound() &&
-                !delayed_msg_it->status().ok()) {
+            if (!delayed_msg_it->status().ok()) {
                 return {delayed_msg_it->status(), {}};
             }
             if (messages.size() < count &&
@@ -2068,7 +2067,7 @@ ValueResult<std::vector<RawMessageInfo>> ArbCore::getMessagesImpl(
         assert(item.last_sequence_number + 1 == index + messages.size());
     }
 
-    if (!seq_batch_it->status().IsNotFound() && !seq_batch_it->status().ok()) {
+    if (!seq_batch_it->status().ok()) {
         return {seq_batch_it->status(), {}};
     }
     if (needs_consistency_check) {

--- a/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
@@ -973,20 +973,23 @@ rocksdb::Status ArbCore::reorgCheckpoints(
             std::move(std::get<std::unique_ptr<MachineThread>>(
                 nearest_machine_or_status));
 
-        std::cerr << "Loading checkpoint, total gas used: "
-                  << nearest_machine->machine_state.output.arb_gas_used
-                  << ", L1 block: "
-                  << nearest_machine->machine_state.output.l1_block_number
-                  << ", L2 block: "
-                  << nearest_machine->machine_state.output.l2_block_number
-                  << ", log count: "
-                  << nearest_machine->machine_state.output.log_count
-                  << ", timestamp: "
-                  << std::put_time(
-                         std::localtime((time_t*)&nearest_machine->machine_state
-                                            .output.last_inbox_timestamp),
-                         "%c")
-                  << std::endl;
+        std::cerr
+            << "Loading checkpoint, total gas used: "
+            << nearest_machine->machine_state.output.arb_gas_used
+            << ", L1 block: "
+            << nearest_machine->machine_state.output.l1_block_number
+            << ", L2 block: "
+            << nearest_machine->machine_state.output.l2_block_number
+            << ", log count: "
+            << nearest_machine->machine_state.output.log_count
+            << ", messages count: "
+            << nearest_machine->machine_state.output.fully_processed_inbox.count
+            << ", timestamp: "
+            << std::put_time(
+                   std::localtime((time_t*)&nearest_machine->machine_state
+                                      .output.last_inbox_timestamp),
+                   "%c")
+            << std::endl;
 
         checkpoint_it = nullptr;
 
@@ -1367,7 +1370,9 @@ void ArbCore::operator()() {
                             << ", L1 block: " << output.l1_block_number
                             << ", L2 block: "
                             << *last_assertion.sideload_block_number
-                            << ", log count: " << output.log_count << ", took "
+                            << ", log count: " << output.log_count
+                            << ", messages count: "
+                            << output.fully_processed_inbox.count << ", took "
                             << duration
                             << " second(s) to save, inbox timestamp: "
                             << std::put_time(
@@ -3615,7 +3620,9 @@ rocksdb::Status ArbCore::pruneCheckpoints(
                   << machine_output.arb_gas_used
                   << ", L1 block: " << machine_output.l1_block_number
                   << ", L2 block: " << machine_output.l2_block_number
-                  << ", log count: " << machine_output.log_count << ", took "
+                  << ", log count: " << machine_output.log_count
+                  << ", messages count: "
+                  << machine_output.fully_processed_inbox.count << ", took "
                   << duration << " second(s) to prune, inbox timestamp: "
                   << std::put_time(
                          std::localtime(


### PR DESCRIPTION
* Make sure the getMessagesImpl only returns NotFound when reorg is detected
* Add logging when reorg is detected
* Always print extra checkpoint information when reorg occurs