### PR TITLE
Check for duplicate transactions in a batch

### DIFF
--- a/packages/arb-rpc-node/batcher/sequencerBatcher.go
+++ b/packages/arb-rpc-node/batcher/sequencerBatcher.go
@@ -308,6 +308,7 @@ func (b *SequencerBatcher) SendTransaction(ctx context.Context, startTx *types.T
 		var batchDataSize int
 		seenOwnTx := false
 		emptiedQueue := true
+		txHashesSet := make(map[ethcommon.Hash]struct{})
 		// This pattern is safe as we acquired a lock so we are the exclusive reader
 		for len(b.txQueue) > 0 {
 			queueItem := <-b.txQueue
@@ -325,6 +326,12 @@ func (b *SequencerBatcher) SendTransaction(ctx context.Context, startTx *types.T
 				emptiedQueue = false
 				break
 			}
+			txHash := queueItem.tx.Hash()
+			_, txAlreadyInBatch := txHashesSet[txHash]
+			if txAlreadyInBatch {
+				queueItem.resultChan <- errors.New("already known")
+				continue
+			}
 			if queueItem.tx == startTx {
 				seenOwnTx = true
 			}
@@ -332,6 +339,7 @@ func (b *SequencerBatcher) SendTransaction(ctx context.Context, startTx *types.T
 			resultChans = append(resultChans, queueItem.resultChan)
 			l2BatchContents = append(l2BatchContents, message.NewCompressedECDSAFromEth(queueItem.tx))
 			batchDataSize += len(queueItem.tx.Data())
+			txHashesSet[txHash] = struct{}{}
 		}
 		if !seenOwnTx && emptiedQueue && batchDataSize+len(startTx.Data()) <= maxTxDataSize {
 			// Another thread must have encountered an internal error attempting to process startTx

--- a/packages/arb-rpc-node/batcher/sequencerBatcher.go
+++ b/packages/arb-rpc-node/batcher/sequencerBatcher.go
@@ -326,14 +326,14 @@ func (b *SequencerBatcher) SendTransaction(ctx context.Context, startTx *types.T
 				emptiedQueue = false
 				break
 			}
+			if queueItem.tx == startTx {
+				seenOwnTx = true
+			}
 			txHash := queueItem.tx.Hash()
 			_, txAlreadyInBatch := txHashesSet[txHash]
 			if txAlreadyInBatch {
 				queueItem.resultChan <- errors.New("already known")
 				continue
-			}
-			if queueItem.tx == startTx {
-				seenOwnTx = true
 			}
 			batchTxs = append(batchTxs, queueItem.tx)
 			resultChans = append(resultChans, queueItem.resultChan)

--- a/packages/arb-rpc-node/batcher/sequencer_test.go
+++ b/packages/arb-rpc-node/batcher/sequencer_test.go
@@ -299,8 +299,28 @@ func TestSequencerBatcher(t *testing.T) {
 	txs := generateTxs(t, 10, 10, l2ChainId)
 	totalDelayedCount := big.NewInt(1)
 	for i, tx := range txs {
-		if err := batcher.SendTransaction(ctx, tx); err != nil {
-			t.Fatal(err)
+		dupTxCount := 1 + i%4
+		results := make(chan error)
+		for j := 0; j < dupTxCount; j++ {
+			go (func() {
+				results <- batcher.SendTransaction(ctx, tx)
+			})()
+		}
+		errors := 0
+		for j := 0; j < dupTxCount; j++ {
+			err = <-results
+			if err != nil {
+				if err.Error() != "already known" && err.Error() != "invalid transaction nonce" {
+					t.Fatal("unexpected error from sequencer:", err)
+				}
+				errors++
+				if errors == dupTxCount {
+					t.Fatal("all dup txs errored", err)
+				}
+			}
+		}
+		if errors+1 != dupTxCount {
+			t.Fatal("dup txs succeeded: error count", errors, "vs dup tx count", dupTxCount)
 		}
 		delayedCount := 0
 		if i%4 == 0 {

--- a/packages/arb-util/core/lookup.go
+++ b/packages/arb-util/core/lookup.go
@@ -157,7 +157,7 @@ func waitForMessages(db ArbCoreInbox) (MessageStatus, error) {
 			db.PrintCoreThreadBacktrace()
 			nextLog += time.Second * 30
 		}
-		<-time.After(time.Millisecond * 50)
+		<-time.After(time.Millisecond * 1)
 	}
 	return status, nil
 }


### PR DESCRIPTION
Avoids "invalid nonce" issue when duplicate transactions are attempted to be put in the same block. This also matches geth's error message.