### PR TITLE
Fix build and test types

### DIFF
--- a/packages/arb-bridge-eth/package.json
+++ b/packages/arb-bridge-eth/package.json
@@ -17,8 +17,8 @@
   },
   "scripts": {
     "postinstall": "$npm_execpath run clean:build",
-    "clean:build": "$npm_execpath run hardhat:prod clean && $npm_execpath run hardhat:prod compile",
-    "build": "$npm_execpath run hardhat:prod compile",
+    "clean:build": "$npm_execpath run hardhat:prod clean && $npm_execpath run build",
+    "build": "if [[ $PWD == */packages/arb-bridge-eth ]]; then $npm_execpath run hardhat:dev compile; else $npm_execpath run hardhat:prod compile; fi",
     "test": "$npm_execpath run hardhat:dev test test/*.spec.ts",
     "test:ci": "CI=true $npm_execpath run test",
     "test:gas": "REPORT_GAS=true $npm_execpath run test",

--- a/packages/arb-bridge-eth/test/executionproof.spec.ts
+++ b/packages/arb-bridge-eth/test/executionproof.spec.ts
@@ -23,7 +23,9 @@ import { TransactionReceipt } from '@ethersproject/providers'
 import { expect, assert } from 'chai'
 import {
   Bridge,
-  IOneStepProof,
+  OneStepProof,
+  OneStepProof2,
+  OneStepProofHash,
   OneStepProofTester,
   SequencerInbox,
 } from '../build/types'
@@ -54,7 +56,7 @@ interface Proof {
 }
 
 let ospTester: OneStepProofTester
-let executors: IOneStepProof[]
+let executors: (OneStepProof | OneStepProof2 | OneStepProofHash)[]
 let bridge: Bridge
 let sequencerInbox: SequencerInbox
 
@@ -77,15 +79,15 @@ describe('OneStepProof', function () {
     await ospTester.deployed()
 
     const OneStepProof = await ethers.getContractFactory('OneStepProof')
-    const osp1 = (await OneStepProof.deploy()) as IOneStepProof
+    const osp1 = await OneStepProof.deploy()
     await osp1.deployed()
 
     const OneStepProof2 = await ethers.getContractFactory('OneStepProof2')
-    const osp2 = (await OneStepProof2.deploy()) as IOneStepProof
+    const osp2 = await OneStepProof2.deploy()
     await osp2.deployed()
 
     const OneStepProofHash = await ethers.getContractFactory('OneStepProofHash')
-    const osp3 = (await OneStepProofHash.deploy()) as IOneStepProof
+    const osp3 = await OneStepProofHash.deploy()
     await osp3.deployed()
 
     executors = [osp1, osp2, osp3]

--- a/packages/arb-bridge-peripherals/package.json
+++ b/packages/arb-bridge-peripherals/package.json
@@ -4,8 +4,8 @@
   "license": "Apache-2.0",
   "scripts": {
     "postinstall": "$npm_execpath run clean:build",
-    "clean:build": "$npm_execpath run hardhat:prod clean && $npm_execpath run hardhat:prod compile",
-    "build": "$npm_execpath run hardhat:prod compile",
+    "clean:build": "$npm_execpath run hardhat:prod clean && $npm_execpath run build",
+    "build": "if [[ $PWD == */packages/arb-bridge-peripherals ]]; then $npm_execpath run hardhat:dev compile; else $npm_execpath run hardhat:prod compile; fi",
     "test:e2e": "$npm_execpath run hardhat:dev test test/*.e2e.ts",
     "test:l1": "$npm_execpath run hardhat:dev test test/*.l1.ts",
     "test:l2": "$npm_execpath run hardhat:dev test test/*.l2.ts --network arbitrum",


### PR DESCRIPTION
This now runs dev compile if inside the monorepo.
When being consumed as a lib the path will instead be in `node_modules` and run the prod build instead