### PR TITLE
Old db: Attach context to txs queued for sequencing

### DIFF
--- a/packages/arb-rpc-node/batcher/sequencerBatcher.go
+++ b/packages/arb-rpc-node/batcher/sequencerBatcher.go
@@ -56,6 +56,7 @@ type SequencerLockoutManager interface {
 
 type txQueueItem struct {
 	tx         *types.Transaction
+	ctx        context.Context
 	resultChan chan error
 }
 
@@ -284,7 +285,7 @@ func (b *SequencerBatcher) SendTransaction(ctx context.Context, startTx *types.T
 	logger.Info().Str("hash", startTx.Hash().String()).Msg("got user tx")
 
 	startResultChan := make(chan error, 1)
-	b.txQueue <- txQueueItem{tx: startTx, resultChan: startResultChan}
+	b.txQueue <- txQueueItem{tx: startTx, resultChan: startResultChan, ctx: ctx}
 	b.inboxReader.MessageDeliveryMutex.Lock()
 	defer b.inboxReader.MessageDeliveryMutex.Unlock()
 
@@ -312,6 +313,14 @@ func (b *SequencerBatcher) SendTransaction(ctx context.Context, startTx *types.T
 		// This pattern is safe as we acquired a lock so we are the exclusive reader
 		for len(b.txQueue) > 0 {
 			queueItem := <-b.txQueue
+			err = queueItem.ctx.Err()
+			if err != nil {
+				if queueItem.tx == startTx {
+					seenOwnTx = true
+				}
+				queueItem.resultChan <- err
+				continue
+			}
 			if batchDataSize+len(queueItem.tx.Data()) > maxTxDataSize {
 				// This batch would be too large to publish with this tx added.
 				// Put the tx back in the queue so it can be included later.
@@ -349,6 +358,9 @@ func (b *SequencerBatcher) SendTransaction(ctx context.Context, startTx *types.T
 			l2BatchContents = append(l2BatchContents, message.NewCompressedECDSAFromEth(startTx))
 			batchDataSize += len(startTx.Data())
 			seenOwnTx = true
+		}
+		if len(batchTxs) == 0 {
+			break
 		}
 		logger.Info().Int("count", len(l2BatchContents)).Msg("gather user txes")
 


### PR DESCRIPTION
This cherry-picks https://github.com/OffchainLabs/arbitrum/commit/aabfc2500f0013dd613a9e362ad9e04c0e6b28c8 onto the `old-db-sequencer` branch.