### PR TITLE
Do not log errors interacting with already closed broadcaster connection

### DIFF
--- a/packages/arb-node-core/cmd/arb-validator/arb-validator.go
+++ b/packages/arb-node-core/cmd/arb-validator/arb-validator.go
@@ -149,6 +149,8 @@ func startup() error {
 		strategy = staker.StakeLatestStrategy
 	} else if strategyString == "Defensive" {
 		strategy = staker.DefensiveStrategy
+	} else if strategyString == "Watchtower" {
+		strategy = staker.WatchtowerStrategy
 	} else {
 		return errors.New("unsupported strategy specified. Currently supported: MakeNodes, StakeLatest")
 	}

--- a/packages/arb-node-core/cmdhelp/wallet.go
+++ b/packages/arb-node-core/cmdhelp/wallet.go
@@ -193,16 +193,18 @@ func openKeystore(description string, walletPath string, walletPassword *string)
 		if err != nil {
 			return nil, &accounts.Account{}, err
 		}
+
+		logger.Info().Hex("address", account.Address.Bytes()).Str("description", description).Msg("created new wallet")
 	} else {
 		account = ks.Accounts()[0]
+
+		logger.Info().Hex("address", account.Address.Bytes()).Str("description", description).Msg("used existing wallet")
 	}
 
 	err := ks.Unlock(account, password)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	logger.Info().Hex("address", account.Address.Bytes()).Str("description", description).Msg("created new wallet")
 
 	return ks, &account, nil
 }

--- a/packages/arb-util/wsbroadcastserver/clientconnection.go
+++ b/packages/arb-util/wsbroadcastserver/clientconnection.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -74,7 +75,9 @@ func (cc *ClientConnection) Start(parentCtx context.Context) {
 			case data := <-cc.out:
 				err := cc.writeRaw(data)
 				if err != nil {
-					logger.Error().Err(err).Str("client", cc.Name).Msg("error writing data to client")
+					if !strings.Contains(err.Error(), "use of closed network connection") {
+						logger.Error().Err(err).Str("client", cc.Name).Msg("error writing data to client")
+					}
 					cc.clientManager.Remove(cc)
 					for {
 						// Consume and ignore channel data until client properly stopped to prevent deadlock

--- a/packages/arb-util/wsbroadcastserver/clientconnection.go
+++ b/packages/arb-util/wsbroadcastserver/clientconnection.go
@@ -22,7 +22,6 @@ import (
 	"math/rand"
 	"net"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -75,9 +74,7 @@ func (cc *ClientConnection) Start(parentCtx context.Context) {
 			case data := <-cc.out:
 				err := cc.writeRaw(data)
 				if err != nil {
-					if !strings.Contains(err.Error(), "use of closed network connection") {
-						logger.Error().Err(err).Str("client", cc.Name).Msg("error writing data to client")
-					}
+					logError(err, "error writing data to client")
 					cc.clientManager.Remove(cc)
 					for {
 						// Consume and ignore channel data until client properly stopped to prevent deadlock

--- a/packages/arb-util/wsbroadcastserver/clientmanager.go
+++ b/packages/arb-util/wsbroadcastserver/clientmanager.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -199,7 +200,7 @@ func (cm *ClientManager) verifyClients() {
 	logger.Debug().Int("count", len(cm.clientPtrMap)).Msg("pinging clients")
 	for client := range cm.clientPtrMap {
 		err := client.Ping()
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
 			logger.Error().Err(err).Str("name", client.Name).Msg("error pinging client")
 		}
 	}
@@ -235,7 +236,7 @@ func (cm *ClientManager) Start(parentCtx context.Context) {
 				}
 			case bm := <-cm.broadcastChan:
 				err := cm.doBroadcast(bm)
-				if err != nil {
+				if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
 					logger.Error().Err(err).Msg("failed to do broadcast")
 				}
 			case <-pingInterval.C:

--- a/packages/arb-util/wsbroadcastserver/clientmanager.go
+++ b/packages/arb-util/wsbroadcastserver/clientmanager.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"net"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -200,8 +199,8 @@ func (cm *ClientManager) verifyClients() {
 	logger.Debug().Int("count", len(cm.clientPtrMap)).Msg("pinging clients")
 	for client := range cm.clientPtrMap {
 		err := client.Ping()
-		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-			logger.Error().Err(err).Str("name", client.Name).Msg("error pinging client")
+		if err != nil {
+			logError(err, "error pinging client")
 		}
 	}
 }
@@ -236,8 +235,8 @@ func (cm *ClientManager) Start(parentCtx context.Context) {
 				}
 			case bm := <-cm.broadcastChan:
 				err := cm.doBroadcast(bm)
-				if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-					logger.Error().Err(err).Msg("failed to do broadcast")
+				if err != nil {
+					logError(err, "failed to do a broadcast")
 				}
 			case <-pingInterval.C:
 				cm.verifyClients()

--- a/packages/arb-util/wsbroadcastserver/utils.go
+++ b/packages/arb-util/wsbroadcastserver/utils.go
@@ -10,6 +10,12 @@ import (
 	"time"
 )
 
+func logError(err error, msg string) {
+	if !strings.Contains(err.Error(), "use of closed network connection") {
+		logger.Error().Err(err).Msg(msg)
+	}
+}
+
 func ReadData(ctx context.Context, conn net.Conn, idleTimeout time.Duration, state ws.State) ([]byte, ws.OpCode, error) {
 	controlHandler := wsutil.ControlFrameHandler(conn, state)
 	reader := wsutil.Reader{
@@ -23,8 +29,8 @@ func ReadData(ctx context.Context, conn net.Conn, idleTimeout time.Duration, sta
 	// Remove timeout when leaving this function
 	defer func(conn net.Conn) {
 		err := conn.SetReadDeadline(time.Time{})
-		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-			logger.Error().Err(err).Msg("error removing read deadline")
+		if err != nil {
+			logError(err, "error removing read deadline")
 		}
 	}(conn)
 

--- a/packages/arb-util/wsbroadcastserver/utils.go
+++ b/packages/arb-util/wsbroadcastserver/utils.go
@@ -24,7 +24,7 @@ func ReadData(ctx context.Context, conn net.Conn, idleTimeout time.Duration, sta
 	defer func(conn net.Conn) {
 		err := conn.SetReadDeadline(time.Time{})
 		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-			logger.Error().Err(err).Msg("error removing read deadline")
+			logger.Warn().Err(err).Msg("error removing read deadline")
 		}
 	}(conn)
 

--- a/packages/arb-util/wsbroadcastserver/utils.go
+++ b/packages/arb-util/wsbroadcastserver/utils.go
@@ -24,7 +24,7 @@ func ReadData(ctx context.Context, conn net.Conn, idleTimeout time.Duration, sta
 	defer func(conn net.Conn) {
 		err := conn.SetReadDeadline(time.Time{})
 		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-			logger.Warn().Err(err).Msg("error removing read deadline")
+			logger.Error().Err(err).Msg("error removing read deadline")
 		}
 	}(conn)
 


### PR DESCRIPTION
Broadcaster works with multiple threads, so it is possible that a connection was closed in one thread but another thread is still trying to send to it.