### PR TITLE
Linter fixes

### DIFF
--- a/packages/arb-avm-cpp/CMakeLists.txt
+++ b/packages/arb-avm-cpp/CMakeLists.txt
@@ -243,6 +243,7 @@ if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/cavm" AND NOT AVM_FUZZER)
             " $<TARGET_LINKER_FILE:OpenSSL::Crypto>"
             " $<TARGET_LINKER_FILE:RocksDB::RocksDB>"
             " $<TARGET_LINKER_FILE:ethash::keccak>"
+            " $<TARGET_LINKER_FILE:Boost::filesystem>"
             " ${GPROF_LIBRARY}"
             " ${MALLOC_LIBRARY}"
             " ${GMP_LIBRARY}"

--- a/packages/arb-avm-cpp/CMakeLists.txt
+++ b/packages/arb-avm-cpp/CMakeLists.txt
@@ -222,37 +222,6 @@ if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/avm")
 endif()
 if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/cavm" AND NOT AVM_FUZZER)
     add_subdirectory(cavm)
-
-    get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-    if (NOT _isMultiConfig)
-        set(INFILE ${PROJECT_SOURCE_DIR}/cmachine/flags.go.in)
-        set(MIDDLEFILE ${PROJECT_BINARY_DIR}/cmachine/flags.go.tmp)
-        set(OUTFILE ${PROJECT_SOURCE_DIR}/cmachine/flags.go)
-
-        set(C_LIBRARY_PATH ${PROJECT_BINARY_DIR}/lib)
-        set(CFLAGS "-I.")
-        string(CONCAT LDFLAGS
-            " -L${C_LIBRARY_PATH}"
-            " -L${ETHASH_LIB_FOLDER}"
-            " $<TARGET_LINKER_FILE:cavm>"
-            " $<TARGET_LINKER_FILE:data_storage>"
-            " $<TARGET_LINKER_FILE:avm>"
-            " $<TARGET_LINKER_FILE:avm_values>"
-            " $<TARGET_LINKER_FILE:ff>"
-            " $<TARGET_LINKER_FILE:secp256k1>"
-            " $<TARGET_LINKER_FILE:OpenSSL::Crypto>"
-            " $<TARGET_LINKER_FILE:RocksDB::RocksDB>"
-            " $<TARGET_LINKER_FILE:ethash::keccak>"
-            " $<TARGET_LINKER_FILE:Boost::filesystem>"
-            " ${GPROF_LIBRARY}"
-            " ${MALLOC_LIBRARY}"
-            " ${GMP_LIBRARY}"
-            " ${GMPXX_LIBRARY}"
-        )
-        configure_file( ${INFILE} ${MIDDLEFILE} )
-        file(GENERATE OUTPUT ${OUTFILE} INPUT ${MIDDLEFILE})
-    endif()
-
 endif()
 if(AVM_FUZZER)
     add_subdirectory(fuzz_target)

--- a/packages/arb-avm-cpp/CMakeLists.txt
+++ b/packages/arb-avm-cpp/CMakeLists.txt
@@ -156,6 +156,7 @@ endif()
 
 find_package(OpenSSL REQUIRED)
 
+set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost 1.65 COMPONENTS filesystem system REQUIRED)
 if(NOT TARGET Boost::boost)
     add_library(Boost::boost IMPORTED INTERFACE)

--- a/packages/arb-avm-cpp/cavm/CMakeLists.txt
+++ b/packages/arb-avm-cpp/cavm/CMakeLists.txt
@@ -56,3 +56,33 @@ target_compile_options(cavm PRIVATE -Wall -Wextra -Wpedantic)
 target_link_libraries(cavm PUBLIC data_storage avm)
 
 source_group(cavm FILES ${LIB_HEADERS} ${LIB_SOURCES})
+
+get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if (NOT _isMultiConfig)
+    set(INFILE ${PROJECT_SOURCE_DIR}/../cmachine/flags.go.in)
+    set(MIDDLEFILE ${PROJECT_BINARY_DIR}/../cmachine/flags.go.tmp)
+    set(OUTFILE ${PROJECT_SOURCE_DIR}/../cmachine/flags.go)
+
+    set(C_LIBRARY_PATH ${PROJECT_BINARY_DIR}/../lib)
+    set(CFLAGS "-I.")
+    string(CONCAT LDFLAGS
+        " -L${C_LIBRARY_PATH}"
+        " -L${ETHASH_LIB_FOLDER}"
+        " $<TARGET_LINKER_FILE:cavm>"
+        " $<TARGET_LINKER_FILE:data_storage>"
+        " $<TARGET_LINKER_FILE:avm>"
+        " $<TARGET_LINKER_FILE:avm_values>"
+        " $<TARGET_LINKER_FILE:ff>"
+        " $<TARGET_LINKER_FILE:secp256k1>"
+        " $<TARGET_LINKER_FILE:OpenSSL::Crypto>"
+        " $<TARGET_LINKER_FILE:RocksDB::RocksDB>"
+        " $<TARGET_LINKER_FILE:ethash::keccak>"
+        " $<TARGET_LINKER_FILE:Boost::filesystem>"
+        " ${GPROF_LIBRARY}"
+        " ${MALLOC_LIBRARY}"
+        " ${GMP_LIBRARY}"
+        " ${GMPXX_LIBRARY}"
+    )
+    configure_file( ${INFILE} ${MIDDLEFILE} )
+    file(GENERATE OUTPUT ${OUTFILE} INPUT ${MIDDLEFILE})
+endif()

--- a/packages/arb-avm-cpp/data_storage/CMakeLists.txt
+++ b/packages/arb-avm-cpp/data_storage/CMakeLists.txt
@@ -92,7 +92,7 @@ target_include_directories(data_storage PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../external
 )
 
-target_link_libraries(data_storage PUBLIC avm avm_values cavm Threads::Threads OpenSSL::Crypto)
+target_link_libraries(data_storage PUBLIC avm avm_values cavm Threads::Threads OpenSSL::Crypto Boost::filesystem)
 
 target_code_coverage(data_storage AUTO ALL)
 

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
@@ -51,6 +51,12 @@ struct Slice;
 class ColumnFamilyHandle;
 }  // namespace rocksdb
 
+namespace boost {
+namespace filesystem {
+class path;
+}  // namespace filesystem
+}  // namespace boost
+
 struct InitializeResult {
     rocksdb::Status status;
     bool finished;
@@ -529,7 +535,7 @@ class ArbCore {
         uint256_t& number);
     std::variant<rocksdb::Status, CheckpointVariant> getLastCheckpoint(
         ReadTransaction& tx);
-    void saveRocksdbCheckpoint(const std::filesystem::path& save_rocksdb_path,
+    void saveRocksdbCheckpoint(const boost::filesystem::path& save_rocksdb_path,
                                ReadTransaction& tx);
     void setCoreError(const std::string& message);
     bool threadBody(ThreadDataStruct& thread_data);

--- a/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
@@ -29,6 +29,9 @@
 #include <data_storage/value/value.hpp>
 #include <data_storage/value/valuecache.hpp>
 
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+
 #include <sys/stat.h>
 #include <ethash/keccak.hpp>
 #include <filesystem>
@@ -369,8 +372,9 @@ InitializeResult ArbCore::applyConfig() {
     }
 
     if (coreConfig.database_save_on_startup) {
-        std::filesystem::path save_rocksdb_path(coreConfig.database_save_path);
-        std::filesystem::create_directories(save_rocksdb_path);
+        boost::filesystem::path save_rocksdb_path(
+            coreConfig.database_save_path);
+        boost::filesystem::create_directories(save_rocksdb_path);
         ReadTransaction tx(data_storage);
         saveRocksdbCheckpoint(save_rocksdb_path, tx);
     }
@@ -1850,7 +1854,7 @@ void ArbCore::operator()() {
         thread_data.next_rocksdb_save_timepoint =
             std::chrono::steady_clock::now() +
             std::chrono::seconds(coreConfig.database_save_interval);
-        std::filesystem::create_directories(coreConfig.database_save_path);
+        boost::filesystem::create_directories(coreConfig.database_save_path);
     }
 
     try {
@@ -1878,7 +1882,7 @@ void ArbCore::operator()() {
 #endif
 }
 void ArbCore::saveRocksdbCheckpoint(
-    const std::filesystem::path& save_rocksdb_path,
+    const boost::filesystem::path& save_rocksdb_path,
     ReadTransaction& tx) {
     struct stat info;
     if ((stat(save_rocksdb_path.c_str(), &info) != 0) &&

--- a/packages/arb-avm-cpp/gotest/gotest.go
+++ b/packages/arb-avm-cpp/gotest/gotest.go
@@ -34,6 +34,9 @@ func OpCodeTestDir() (string, error) {
 
 func OpCodeTestFiles() ([]string, error) {
 	testCaseDir, err := OpCodeTestDir()
+	if err != nil {
+		return nil, err
+	}
 	files, err := ioutil.ReadDir(testCaseDir)
 	if err != nil {
 		return nil, err

--- a/packages/arb-evm/evm/request.go
+++ b/packages/arb-evm/evm/request.go
@@ -149,11 +149,11 @@ func (a *AggregatorInfo) AsOptionalValue() value.Value {
 			aggVal = inbox.NewIntFromAddress(*a.Aggregator)
 		}
 
-		val := value.NewTuple2(
+		innerVal := value.NewTuple2(
 			newOptional(aggVal),
 			value.NewIntValue(a.CalldataBytes),
 		)
-		tup, _ := value.NewTupleFromSlice([]value.Value{val})
+		tup, _ := value.NewTupleFromSlice([]value.Value{innerVal})
 		val = tup
 	}
 	return newOptional(val)

--- a/packages/arb-rpc-node/batcher/batcher.go
+++ b/packages/arb-rpc-node/batcher/batcher.go
@@ -233,7 +233,6 @@ func (m *Batcher) maybeSubmitBatch(ctx context.Context, maxBatchTime time.Durati
 	if !full && !(len(txes) > 0 && !moreTxesWaiting && time.Since(lastBatch) > maxBatchTime) {
 		return false, nil
 	}
-	lastBatch = time.Now()
 	batchTxes := make([]message.AbstractL2Message, 0, len(txes))
 	for _, tx := range txes {
 		batchTxes = append(batchTxes, message.NewCompressedECDSAFromEth(tx))

--- a/packages/arb-rpc-node/batcher/sequencerBatcher.go
+++ b/packages/arb-rpc-node/batcher/sequencerBatcher.go
@@ -356,7 +356,6 @@ func (b *SequencerBatcher) SendTransaction(ctx context.Context, startTx *types.T
 			batchTxs = append(batchTxs, startTx)
 			resultChans = append(resultChans, startResultChan)
 			l2BatchContents = append(l2BatchContents, message.NewCompressedECDSAFromEth(startTx))
-			batchDataSize += len(startTx.Data())
 			seenOwnTx = true
 		}
 		if len(batchTxs) == 0 {
@@ -415,7 +414,6 @@ func (b *SequencerBatcher) SendTransaction(ctx context.Context, startTx *types.T
 			logger.Info().Str("elapsed", time.Since(start).String()).Msg("after machine idle")
 		}
 
-		var sequencedTxs []*types.Transaction
 		var sequencedBatchItems []inbox.SequencerBatchItem
 
 		newLogCount, err := b.db.GetLogCount()
@@ -443,7 +441,6 @@ func (b *SequencerBatcher) SendTransaction(ctx context.Context, startTx *types.T
 			}
 		}
 		if successCount == len(batchTxs) {
-			sequencedTxs = batchTxs
 			msgCount = new(big.Int).Add(msgCount, big.NewInt(1))
 			prevAcc = txBatchItem.Accumulator
 			sequencedBatchItems = append(sequencedBatchItems, txBatchItem)
@@ -519,7 +516,6 @@ func (b *SequencerBatcher) SendTransaction(ctx context.Context, startTx *types.T
 				msgCount = new(big.Int).Add(msgCount, big.NewInt(1))
 				prevAcc = txBatchItem.Accumulator
 				sequencedBatchItems = append(sequencedBatchItems, txBatchItem)
-				sequencedTxs = append(sequencedTxs, tx)
 				postingCostEstimate := gasCostPerMessage + gasCostPerMessageByte*len(seqMsg.Data)
 				atomic.AddInt64(&b.pendingBatchGasEstimateAtomic, int64(postingCostEstimate))
 				logCount = newLogCount

--- a/packages/arb-rpc-node/cmd/arb-dev-sequencer/arb-dev-sequencer.go
+++ b/packages/arb-rpc-node/cmd/arb-dev-sequencer/arb-dev-sequencer.go
@@ -181,6 +181,9 @@ func startup() error {
 	}
 
 	ownerPrivKey, err := crypto.GenerateKey()
+	if err != nil {
+		return err
+	}
 	l1OwnerAuth, err := bind.NewKeyedTransactorWithChainID(ownerPrivKey, l1ChainId)
 	if err != nil {
 		return err

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -514,8 +514,7 @@ func ParseDBTool() (*Config, error) {
 	}
 
 	err = resolveDirectoryNames(out, wallet)
-
-	return out, nil
+	return out, err
 }
 
 func AddL1PostingStrategyOptions(f *flag.FlagSet, prefix string) {
@@ -1110,7 +1109,9 @@ func endCommonParse(k *koanf.Koanf) (*Config, *Wallet, error) {
 			"wallet.local.password":                     "",
 			"wallet.local.private-key":                  "",
 		}, "."), nil)
-
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "unable overwrite wallet info in config")
+		}
 		c, err := k.Marshal(json.Parser())
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "unable to marshal config file to JSON")


### PR DESCRIPTION
- Switch from `std::filesystem` to `boost:filesystem` for mac compatibility
- Golang linter fixes