### PR TITLE
L1GatewayRouter refund address entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://offchainlabs.com/",
   "scripts": {
-    "audit:ci": "audit-ci -l -a 1006805 1006806 1006865 1006896 1006899 1064613 1064693 1064692",
+    "audit:ci": "audit-ci -l -a 1006805 1006806 1006865 1006896 1006899",
     "install:deps": "./scripts/install-deps",
     "install:validator": "./scripts/install-validator",
     "update:abi": "yarn go:generate && yarn workspace arb-ts update:abi",
@@ -70,9 +70,7 @@
     "ansi-regex": "^5.0.1",
     "lodash": "4.17.21",
     "underscore": "1.12.1",
-    "node-fetch": "^2.6.7",
-    "yargs-parser": "20.2.2",
-    "follow-redirects": "^1.14.7",
-    "minimist": "^1.2.6"
+    "node-fetch": "2.6.1",
+    "yargs-parser": "20.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://offchainlabs.com/",
   "scripts": {
-    "audit:ci": "audit-ci -l -a 1006805 1006806 1006865 1006896 1006899",
+    "audit:ci": "audit-ci -l -a 1006805 1006806 1006865 1006896 1006899 1064613 1064693 1064692",
     "install:deps": "./scripts/install-deps",
     "install:validator": "./scripts/install-validator",
     "update:abi": "yarn go:generate && yarn workspace arb-ts update:abi",
@@ -70,7 +70,9 @@
     "ansi-regex": "^5.0.1",
     "lodash": "4.17.21",
     "underscore": "1.12.1",
-    "node-fetch": "2.6.1",
-    "yargs-parser": "20.2.2"
+    "node-fetch": "^2.6.7",
+    "yargs-parser": "20.2.2",
+    "follow-redirects": "^1.14.7",
+    "minimist": "^1.2.6"
   }
 }

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/gateway/L2ArbitrumGateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/gateway/L2ArbitrumGateway.sol
@@ -124,6 +124,18 @@ abstract contract L2ArbitrumGateway is L2ArbitrumMessenger, TokenGateway {
         return outboundTransfer(_l1Token, _to, _amount, 0, 0, _data);
     }
 
+    function outboundTransferCustomRefund(
+        address _l1Token,
+        address _to,
+        address, /* _refundTo */
+        uint256 _amount,
+        uint256, /* _maxGas */
+        uint256, /* _gasPriceBid */
+        bytes calldata _data
+    ) public payable virtual override returns (bytes memory res) {
+        return outboundTransfer(_l1Token, _to, _amount, 0, 0, _data);
+    }
+
     /**
      * @notice Initiates a token withdrawal from Arbitrum to Ethereum
      * @param _l1Token l1 address of token

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol
@@ -173,6 +173,9 @@ abstract contract L1ArbitrumGateway is L1ArbitrumMessenger, TokenGateway {
             );
     }
 
+    /**
+     * @notice DEPRECATED - look at createOutboundTxCustomRefund instead
+     */
     function createOutboundTx(
         address _from,
         uint256 _tokenAmount,
@@ -180,21 +183,13 @@ abstract contract L1ArbitrumGateway is L1ArbitrumMessenger, TokenGateway {
         uint256 _gasPriceBid,
         uint256 _maxSubmissionCost,
         bytes memory _outboundCalldata
-    ) internal virtual returns (uint256) {
+    ) internal returns (uint256) {
         return createOutboundTxCustomRefund(_from, _from, _tokenAmount, _maxGas, _gasPriceBid, _maxSubmissionCost, _outboundCalldata);
     }
 
     /**
-     * @notice Deposit ERC20 token from Ethereum into Arbitrum. If L2 side hasn't been deployed yet, includes name/symbol/decimals data for initial L2 deploy. Initiate by GatewayRouter.
-     * @param _l1Token L1 address of ERC20
-     * @param _to account to be credited with the tokens in the L2 (can be the user's L2 account or a contract)
-     * @param _amount Token Amount
-     * @param _maxGas Max gas deducted from user's L2 balance to cover L2 execution
-     * @param _gasPriceBid Gas price for L2 execution
-     * @param _data encoded data from router and user
-     * @return res abi encoded inbox sequence number
+     * @notice DEPRECATED - look at outboundTransferCustomRefund instead
      */
-    //  * @param maxSubmissionCost Max gas deducted from user's L2 balance to cover base submission fee
     function outboundTransfer(
         address _l1Token,
         address _to,
@@ -202,7 +197,7 @@ abstract contract L1ArbitrumGateway is L1ArbitrumMessenger, TokenGateway {
         uint256 _maxGas,
         uint256 _gasPriceBid,
         bytes calldata _data
-    ) public payable virtual override returns (bytes memory res) {
+    ) public payable override returns (bytes memory res) {
         return outboundTransferCustomRefund(
             _l1Token,
             _to,

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol
@@ -142,6 +142,9 @@ abstract contract L1ArbitrumGateway is L1ArbitrumMessenger, TokenGateway {
         IERC20(_l1Token).safeTransfer(_dest, _amount);
     }
 
+    /**
+     * @dev Only excess gas is refunded to the _refundTo account, l2 call value is always returned to the _to account
+     */
     function createOutboundTxCustomRefund(
         address _refundTo,
         address _from,
@@ -212,8 +215,8 @@ abstract contract L1ArbitrumGateway is L1ArbitrumMessenger, TokenGateway {
     /**
      * @notice Deposit ERC20 token from Ethereum into Arbitrum. If L2 side hasn't been deployed yet, includes name/symbol/decimals data for initial L2 deploy. Initiate by GatewayRouter.
      * @param _l1Token L1 address of ERC20
+     * @param _refundTo account to be credited with the excess gas refund in the L2, subject to L2 alias rewrite if its a L1 contract
      * @param _to account to be credited with the tokens in the L2 (can be the user's L2 account or a contract)
-     * @param _refundTo account to be credited with the excess gas refund in the L2 (can be the user's L2 account or a contract)
      * @param _amount Token Amount
      * @param _maxGas Max gas deducted from user's L2 balance to cover L2 execution
      * @param _gasPriceBid Gas price for L2 execution

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1CustomGateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1CustomGateway.sol
@@ -57,15 +57,16 @@ contract L1CustomGateway is L1ArbitrumExtendedGateway, ICustomGateway {
 
     // end of inline reentrancy guard
 
-    function outboundTransfer(
+    function outboundTransferCustomRefund(
         address _l1Token,
+        address _refundTo,
         address _to,
         uint256 _amount,
         uint256 _maxGas,
         uint256 _gasPriceBid,
         bytes calldata _data
     ) public payable override nonReentrant returns (bytes memory res) {
-        return super.outboundTransfer(_l1Token, _to, _amount, _maxGas, _gasPriceBid, _data);
+        return super.outboundTransferCustomRefund(_l1Token, _refundTo, _to, _amount, _maxGas, _gasPriceBid, _data);
     }
 
     function finalizeInboundTransfer(

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1ERC20Gateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1ERC20Gateway.sol
@@ -54,15 +54,16 @@ contract L1ERC20Gateway is L1ArbitrumExtendedGateway {
 
     // end of inline reentrancy guard
 
-    function outboundTransfer(
+    function outboundTransferCustomRefund(
         address _l1Token,
+        address _refundTo,
         address _to,
         uint256 _amount,
         uint256 _maxGas,
         uint256 _gasPriceBid,
         bytes calldata _data
     ) public payable override nonReentrant returns (bytes memory res) {
-        return super.outboundTransfer(_l1Token, _to, _amount, _maxGas, _gasPriceBid, _data);
+        return super.outboundTransferCustomRefund(_l1Token, _refundTo, _to, _amount, _maxGas, _gasPriceBid, _data);
     }
 
     function finalizeInboundTransfer(

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
@@ -227,6 +227,8 @@ contract L1GatewayRouter is WhitelistConsumer, L1ArbitrumMessenger, GatewayRoute
         // eth in flight in order to pay for L2 gas costs
         // this check prevents users from misconfiguring the msg.value
         uint256 _maxSubmissionCost;
+        // assembly code block below is the gas optimized version of
+        // _maxSubmissionCost = abi.decode(_data, (uint256, bytes));
         assembly {
             _maxSubmissionCost := mload(add(_data, 0x20))
         }

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
@@ -243,8 +243,8 @@ contract L1GatewayRouter is WhitelistConsumer, L1ArbitrumMessenger, GatewayRoute
 
     function outboundTransferCustomRefund(
         address _token,
-        address _to,
         address _refundTo,
+        address _to,
         uint256 _amount,
         uint256 _maxGas,
         uint256 _gasPriceBid,
@@ -264,7 +264,7 @@ contract L1GatewayRouter is WhitelistConsumer, L1ArbitrumMessenger, GatewayRoute
         require(msg.value == expectedEth, "WRONG_ETH_VALUE");
 
         // will revert if msg.sender is not whitelisted
-        return super.outboundTransferCustomRefund(_token, _to, _refundTo, _amount, _maxGas, _gasPriceBid, _data);
+        return super.outboundTransferCustomRefund(_token, _refundTo, _to, _amount, _maxGas, _gasPriceBid, _data);
     }
 
     modifier onlyCounterpartGateway() override {

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
@@ -253,6 +253,18 @@ contract L1GatewayRouter is WhitelistConsumer, L1ArbitrumMessenger, GatewayRoute
         return super.outboundTransfer(_token, _to, _amount, _maxGas, _gasPriceBid, _data);
     }
 
+    /**
+     * @notice Deposit ERC20 token from Ethereum into Arbitrum using the registered or otherwise default gateway
+     * @dev Some legacy gateway might not have the outboundTransferCustomRefund method and will revert, in such case use outboundTransfer instead
+     * @param _token L1 address of ERC20
+     * @param _refundTo account to be credited with the excess gas refund in the L2, subject to L2 alias rewrite if its a L1 contract
+     * @param _to account to be credited with the tokens in the L2 (can be the user's L2 account or a contract)
+     * @param _amount Token Amount
+     * @param _maxGas Max gas deducted from user's L2 balance to cover L2 execution
+     * @param _gasPriceBid Gas price for L2 execution
+     * @param _data encoded data from router and user
+     * @return res abi encoded inbox sequence number
+     */
     function outboundTransferCustomRefund(
         address _token,
         address _refundTo,

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
@@ -241,6 +241,32 @@ contract L1GatewayRouter is WhitelistConsumer, L1ArbitrumMessenger, GatewayRoute
         return super.outboundTransfer(_token, _to, _amount, _maxGas, _gasPriceBid, _data);
     }
 
+    function outboundTransferCustomRefund(
+        address _token,
+        address _to,
+        address _refundTo,
+        uint256 _amount,
+        uint256 _maxGas,
+        uint256 _gasPriceBid,
+        bytes calldata _data
+    ) public payable override onlyWhitelisted returns (bytes memory) {
+        // _refundTo is subject to L2 alias rewrite
+        require(_refundTo != address(0), "INVALID_REFUND_ADDR");
+        // when sending a L1 to L2 transaction, we expect the user to send
+        // eth in flight in order to pay for L2 gas costs
+        // this check prevents users from misconfiguring the msg.value
+        (uint256 _maxSubmissionCost, ) = abi.decode(_data, (uint256, bytes));
+
+        // here we don't use SafeMath since this validation is to prevent users
+        // from shooting themselves on the foot.
+        uint256 expectedEth = _maxSubmissionCost + (_maxGas * _gasPriceBid);
+        require(_maxSubmissionCost > 0, "NO_SUBMISSION_COST");
+        require(msg.value == expectedEth, "WRONG_ETH_VALUE");
+
+        // will revert if msg.sender is not whitelisted
+        return super.outboundTransferCustomRefund(_token, _to, _refundTo, _amount, _maxGas, _gasPriceBid, _data);
+    }
+
     modifier onlyCounterpartGateway() override {
         // don't expect messages from L2 router
         revert("ONLY_COUNTERPART_GATEWAY");

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
@@ -222,7 +222,7 @@ contract L1GatewayRouter is WhitelistConsumer, L1ArbitrumMessenger, GatewayRoute
         uint256 _maxGas,
         uint256 _gasPriceBid,
         bytes memory _data
-    ) internal {
+    ) internal view {
         // when sending a L1 to L2 transaction, we expect the user to send
         // eth in flight in order to pay for L2 gas costs
         // this check prevents users from misconfiguring the msg.value
@@ -246,7 +246,7 @@ contract L1GatewayRouter is WhitelistConsumer, L1ArbitrumMessenger, GatewayRoute
         uint256 _maxGas,
         uint256 _gasPriceBid,
         bytes calldata _data
-    ) public payable override onlyWhitelisted returns (bytes memory) {
+    ) public payable override returns (bytes memory) {
         _outboundTransferChecks(_maxGas, _gasPriceBid, _data);
 
         // will revert if msg.sender is not whitelisted
@@ -261,7 +261,7 @@ contract L1GatewayRouter is WhitelistConsumer, L1ArbitrumMessenger, GatewayRoute
         uint256 _maxGas,
         uint256 _gasPriceBid,
         bytes calldata _data
-    ) public payable override onlyWhitelisted returns (bytes memory) {
+    ) public payable override returns (bytes memory) {
         // _refundTo is subject to L2 alias rewrite
         require(_refundTo != address(0), "INVALID_REFUND_ADDR");
         _outboundTransferChecks(_maxGas, _gasPriceBid, _data);

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
@@ -45,7 +45,8 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
         l2Weth = _l2Weth;
     }
 
-    function createOutboundTx(
+    function createOutboundTxCustomRefund(
+        address _refundTo,
         address _from,
         uint256 _tokenAmount,
         uint256 _maxGas,

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
@@ -55,9 +55,10 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
         bytes memory _outboundCalldata
     ) internal override returns (uint256) {
         return
-            sendTxToL2(
+            sendTxToL2CustomRefund(
                 inbox,
                 counterpartGateway,
+                _refundTo,
                 _from,
                 // msg.value does not include weth withdrawn from user, we need to add in that amount
                 msg.value + _tokenAmount,

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/GatewayRouter.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/GatewayRouter.sol
@@ -103,6 +103,18 @@ abstract contract GatewayRouter is TokenGateway {
             );
     }
 
+    /**
+     * @notice Bridge ERC20 token using the registered or otherwise default gateway
+     * @dev Some legacy gateway might not have the outboundTransferCustomRefund method and will revert, in such case use outboundTransfer instead
+     * @param _token L1 address of ERC20
+     * @param _refundTo account to be credited with the excess gas refund in the L2, subject to L2 alias rewrite if its a L1 contract
+     * @param _to account to be credited with the tokens in the L2 (can be the user's L2 account or a contract)
+     * @param _amount Token Amount
+     * @param _maxGas Max gas deducted from user's L2 balance to cover L2 execution
+     * @param _gasPriceBid Gas price for L2 execution
+     * @param _data encoded data from router and user
+     * @return res abi encoded inbox sequence number
+     */
     function outboundTransferCustomRefund(
         address _token,
         address _refundTo,

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/GatewayRouter.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/GatewayRouter.sol
@@ -83,6 +83,8 @@ abstract contract GatewayRouter is TokenGateway {
         uint256 _gasPriceBid,
         bytes calldata _data
     ) public payable virtual override returns (bytes memory) {
+        // this function is kept instead of delegating to outboundTransferCustomRefund to allow 
+        // compatibility with older gateways that did not implement outboundTransferCustomRefund
         address gateway = getGateway(_token);
         bytes memory gatewayData = GatewayMessageHandler.encodeFromRouterToGateway(
             msg.sender,
@@ -103,8 +105,8 @@ abstract contract GatewayRouter is TokenGateway {
 
     function outboundTransferCustomRefund(
         address _token,
-        address _to,
         address _refundTo,
+        address _to,
         uint256 _amount,
         uint256 _maxGas,
         uint256 _gasPriceBid,
@@ -120,8 +122,8 @@ abstract contract GatewayRouter is TokenGateway {
         return
             ITokenGateway(gateway).outboundTransferCustomRefund{ value: msg.value }(
                 _token,
-                _to,
                 _refundTo,
+                _to,
                 _amount,
                 _maxGas,
                 _gasPriceBid,

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/GatewayRouter.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/GatewayRouter.sol
@@ -101,6 +101,34 @@ abstract contract GatewayRouter is TokenGateway {
             );
     }
 
+    function outboundTransferCustomRefund(
+        address _token,
+        address _to,
+        address _refundTo,
+        uint256 _amount,
+        uint256 _maxGas,
+        uint256 _gasPriceBid,
+        bytes calldata _data
+    ) public payable virtual override returns (bytes memory) {
+        address gateway = getGateway(_token);
+        bytes memory gatewayData = GatewayMessageHandler.encodeFromRouterToGateway(
+            msg.sender,
+            _data
+        );
+
+        emit TransferRouted(_token, msg.sender, _to, gateway);
+        return
+            ITokenGateway(gateway).outboundTransferCustomRefund{ value: msg.value }(
+                _token,
+                _to,
+                _refundTo,
+                _amount,
+                _maxGas,
+                _gasPriceBid,
+                gatewayData
+            );
+    }
+
     function getOutboundCalldata(
         address _token,
         address _from,

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/ITokenGateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/ITokenGateway.sol
@@ -48,6 +48,16 @@ interface ITokenGateway {
         bytes calldata _data
     ) external payable returns (bytes memory);
 
+    function outboundTransferCustomRefund(
+        address _token,
+        address _to,
+        address _refundTo,
+        uint256 _amount,
+        uint256 _maxGas,
+        uint256 _gasPriceBid,
+        bytes calldata _data
+    ) external payable returns (bytes memory);
+
     function finalizeInboundTransfer(
         address _token,
         address _from,

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/ITokenGateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/ITokenGateway.sol
@@ -50,8 +50,8 @@ interface ITokenGateway {
 
     function outboundTransferCustomRefund(
         address _token,
-        address _to,
         address _refundTo,
+        address _to,
         uint256 _amount,
         uint256 _maxGas,
         uint256 _gasPriceBid,

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/TokenGateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/TokenGateway.sol
@@ -71,6 +71,16 @@ abstract contract TokenGateway is ITokenGateway {
         bytes calldata _data
     ) external payable virtual override returns (bytes memory);
 
+    function outboundTransferCustomRefund(
+        address _token,
+        address _to,
+        address _refundTo,
+        uint256 _amount,
+        uint256 _maxGas,
+        uint256 _gasPriceBid,
+        bytes calldata _data
+    ) external payable virtual override returns (bytes memory);
+
     function getOutboundCalldata(
         address _token,
         address _from,

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/TokenGateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/TokenGateway.sol
@@ -73,8 +73,8 @@ abstract contract TokenGateway is ITokenGateway {
 
     function outboundTransferCustomRefund(
         address _token,
-        address _to,
         address _refundTo,
+        address _to,
         uint256 _amount,
         uint256 _maxGas,
         uint256 _gasPriceBid,

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/test/GatewayTest.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/test/GatewayTest.sol
@@ -47,9 +47,10 @@ abstract contract L1ArbitrumTestMessenger is L1ArbitrumMessenger {
         shouldUseInbox = _shouldUseInbox;
     }
 
-    function sendTxToL2(
+    function sendTxToL2CustomRefund(
         address, /* _inbox */
         address _to,
+        address, /*_refundTo */
         address, /* _user */
         uint256, /* _l1CallValue */
         uint256 _l2CallValue,
@@ -123,9 +124,10 @@ abstract contract L2ArbitrumTestMessenger is L2ArbitrumMessenger {
 }
 
 contract L1GatewayTester is L1ArbitrumTestMessenger, L1ERC20Gateway {
-    function sendTxToL2(
+    function sendTxToL2CustomRefund(
         address _inbox,
         address _to,
+        address _refundTo,
         address _user,
         uint256 _l1CallValue,
         uint256 _l2CallValue,
@@ -135,9 +137,10 @@ contract L1GatewayTester is L1ArbitrumTestMessenger, L1ERC20Gateway {
         bytes memory _data
     ) internal virtual override(L1ArbitrumMessenger, L1ArbitrumTestMessenger) returns (uint256) {
         return
-            L1ArbitrumTestMessenger.sendTxToL2(
+            L1ArbitrumTestMessenger.sendTxToL2CustomRefund(
                 _inbox,
                 _to,
+                _refundTo,
                 _user,
                 _l1CallValue,
                 _l2CallValue,
@@ -203,9 +206,10 @@ contract L2GatewayTester is L2ArbitrumTestMessenger, L2ERC20Gateway {
 }
 
 contract L1CustomGatewayTester is L1ArbitrumTestMessenger, L1CustomGateway {
-    function sendTxToL2(
+    function sendTxToL2CustomRefund(
         address _inbox,
         address _to,
+        address _refundTo,
         address _user,
         uint256 _l1CallValue,
         uint256 _l2CallValue,
@@ -215,9 +219,10 @@ contract L1CustomGatewayTester is L1ArbitrumTestMessenger, L1CustomGateway {
         bytes memory _data
     ) internal virtual override(L1ArbitrumMessenger, L1ArbitrumTestMessenger) returns (uint256) {
         return
-            L1ArbitrumTestMessenger.sendTxToL2(
+            L1ArbitrumTestMessenger.sendTxToL2CustomRefund(
                 _inbox,
                 _to,
+                _refundTo,
                 _user,
                 _l1CallValue,
                 _l2CallValue,
@@ -261,9 +266,10 @@ contract L2CustomGatewayTester is L2ArbitrumTestMessenger, L2CustomGateway {
 }
 
 contract L1WethGatewayTester is L1ArbitrumTestMessenger, L1WethGateway {
-    function sendTxToL2(
+    function sendTxToL2CustomRefund(
         address _inbox,
         address _to,
+        address _refundTo,
         address _user,
         uint256 _l1CallValue,
         uint256 _l2CallValue,
@@ -273,9 +279,10 @@ contract L1WethGatewayTester is L1ArbitrumTestMessenger, L1WethGateway {
         bytes memory _data
     ) internal virtual override(L1ArbitrumMessenger, L1ArbitrumTestMessenger) returns (uint256) {
         return
-            L1ArbitrumTestMessenger.sendTxToL2(
+            L1ArbitrumTestMessenger.sendTxToL2CustomRefund(
                 _inbox,
                 _to,
+                _refundTo,
                 _user,
                 _l1CallValue,
                 _l2CallValue,
@@ -323,9 +330,10 @@ contract L2WethGatewayTester is L2ArbitrumTestMessenger, L2WethGateway {
 }
 
 contract L1GatewayRouterTester is L1ArbitrumTestMessenger, L1GatewayRouter {
-    function sendTxToL2(
+    function sendTxToL2CustomRefund(
         address _inbox,
         address _to,
+        address _refundTo,
         address _user,
         uint256 _l1CallValue,
         uint256 _l2CallValue,
@@ -335,9 +343,10 @@ contract L1GatewayRouterTester is L1ArbitrumTestMessenger, L1GatewayRouter {
         bytes memory _data
     ) internal virtual override(L1ArbitrumMessenger, L1ArbitrumTestMessenger) returns (uint256) {
         return
-            L1ArbitrumTestMessenger.sendTxToL2(
+            L1ArbitrumTestMessenger.sendTxToL2CustomRefund(
                 _inbox,
                 _to,
+                _refundTo,
                 _user,
                 _l1CallValue,
                 _l2CallValue,

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/test/InboxMock.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/test/InboxMock.sol
@@ -26,18 +26,20 @@ contract InboxMock {
     address l2ToL1SenderMock = address(0);
 
     event TicketData(uint256 maxSubmissionCost);
+    event RefundAddresses(address excessFeeRefundAddress,address callValueRefundAddress);
 
     function createRetryableTicket(
         address, /* destAddr */
         uint256, /* l2CallValue */
         uint256 maxSubmissionCost,
-        address, /* excessFeeRefundAddress */
-        address, /* callValueRefundAddress */
+        address excessFeeRefundAddress,
+        address callValueRefundAddress,
         uint256, /* maxGas */
         uint256, /* gasPriceBid */
         bytes calldata /* data */
     ) external payable returns (uint256) {
         emit TicketData(maxSubmissionCost);
+        emit RefundAddresses(excessFeeRefundAddress,callValueRefundAddress);
         return 0;
     }
 

--- a/packages/arb-bridge-peripherals/test/gatewayRouter.l1.ts
+++ b/packages/arb-bridge-peripherals/test/gatewayRouter.l1.ts
@@ -83,7 +83,7 @@ describe('Bridge peripherals layer 1', () => {
     )
   })
 
-  it.only('should submit the correct sender to inbox', async function () {
+  it('should submit the correct sender to inbox', async function () {
     const L1ERC20Gateway = await ethers.getContractFactory('L1ERC20Gateway')
     const l1ERC20Gateway = await L1ERC20Gateway.deploy()
 
@@ -139,7 +139,7 @@ describe('Bridge peripherals layer 1', () => {
     )
   })
 
-  it.only('should submit the custom refund address to inbox', async function () {
+  it('should submit the custom refund address to inbox', async function () {
     const L1ERC20Gateway = await ethers.getContractFactory('L1ERC20Gateway')
     const l1ERC20Gateway = await L1ERC20Gateway.deploy()
 

--- a/packages/arb-bridge-peripherals/test/gatewayRouter.l1.ts
+++ b/packages/arb-bridge-peripherals/test/gatewayRouter.l1.ts
@@ -82,4 +82,117 @@ describe('Bridge peripherals layer 1', () => {
       'Invalid submission cost'
     )
   })
+
+  it.only('should submit the correct sender to inbox', async function () {
+    const L1ERC20Gateway = await ethers.getContractFactory('L1ERC20Gateway')
+    const l1ERC20Gateway = await L1ERC20Gateway.deploy()
+
+    await l1ERC20Gateway.initialize(
+      l2Address,
+      testBridge.address,
+      inbox.address,
+      '0x0000000000000000000000000000000000000000000000000000000000000001', // cloneable proxy hash
+      accounts[0].address // beaconProxyFactory
+    )
+
+    await testBridge.setDefaultGateway(
+      l1ERC20Gateway.address,
+      maxGas,
+      gasPrice,
+      maxSubmissionCost
+    )
+
+    const Token = await ethers.getContractFactory('TestERC20')
+    const token = await Token.deploy()
+    const tokenAmount = 100
+    await token.mint()
+    await token.approve(l1ERC20Gateway.address, tokenAmount)
+
+    const data = ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'bytes'],
+      [maxSubmissionCost, '0x']
+    )
+
+    const tx = await testBridge.outboundTransfer(
+      token.address,
+      accounts[0].address,
+      tokenAmount,
+      maxGas,
+      gasPrice,
+      data,
+      {
+        value: maxSubmissionCost + maxGas * gasPrice
+      }
+    )
+
+    const receipt = await tx.wait()
+    // TxToL2(address,address,uint256,bytes)
+    const expectedTopic =
+      '0xc1d1490cf25c3b40d600dfb27c7680340ed1ab901b7e8f3551280968a3b372b0'
+    const logs = receipt.events
+      .filter((curr: any) => curr.topics[0] === expectedTopic)
+      .map((curr: any) => l1ERC20Gateway.interface.parseLog(curr))
+    assert.equal(
+      logs[0].args._from,
+      accounts[0].address,
+      'Invalid from address'
+    )
+  })
+
+  it.only('should submit the custom refund address to inbox', async function () {
+    const L1ERC20Gateway = await ethers.getContractFactory('L1ERC20Gateway')
+    const l1ERC20Gateway = await L1ERC20Gateway.deploy()
+
+    await l1ERC20Gateway.initialize(
+      l2Address,
+      testBridge.address,
+      inbox.address,
+      '0x0000000000000000000000000000000000000000000000000000000000000001', // cloneable proxy hash
+      accounts[0].address // beaconProxyFactory
+    )
+
+    await testBridge.setDefaultGateway(
+      l1ERC20Gateway.address,
+      maxGas,
+      gasPrice,
+      maxSubmissionCost
+    )
+
+    const Token = await ethers.getContractFactory('TestERC20')
+    const token = await Token.deploy()
+    const tokenAmount = 100
+    await token.mint()
+    await token.approve(l1ERC20Gateway.address, tokenAmount)
+
+    const data = ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'bytes'],
+      [maxSubmissionCost, '0x']
+    )
+
+    const tx = await testBridge.outboundTransferCustomRefund(
+      token.address,
+      accounts[0].address,
+      accounts[1].address,
+      tokenAmount,
+      maxGas,
+      gasPrice,
+      data,
+      {
+        value: maxSubmissionCost + maxGas * gasPrice
+      }
+    )
+
+    const receipt = await tx.wait()
+    // TxToL2(address,address,uint256,bytes)
+    const expectedTopic =
+      '0xc1d1490cf25c3b40d600dfb27c7680340ed1ab901b7e8f3551280968a3b372b0'
+    const logs = receipt.events
+      .filter((curr: any) => curr.topics[0] === expectedTopic)
+      .map((curr: any) => l1ERC20Gateway.interface.parseLog(curr))
+    assert.equal(
+      logs[0].args._from,
+      accounts[1].address,
+      'Invalid from address'
+    )
+  })
 })

--- a/packages/arb-bridge-peripherals/test/gatewayRouter.l1.ts
+++ b/packages/arb-bridge-peripherals/test/gatewayRouter.l1.ts
@@ -19,7 +19,6 @@ import { ethers } from 'hardhat'
 import { assert, expect } from 'chai'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { Contract, ContractFactory } from 'ethers'
-import { InboxMock__factory } from '../build/types'
 
 describe('Bridge peripherals layer 1', () => {
   let accounts: SignerWithAddress[]
@@ -122,7 +121,7 @@ describe('Bridge peripherals layer 1', () => {
       gasPrice,
       data,
       {
-        value: maxSubmissionCost + maxGas * gasPrice
+        value: maxSubmissionCost + maxGas * gasPrice,
       }
     )
 
@@ -143,7 +142,6 @@ describe('Bridge peripherals layer 1', () => {
       accounts[0].address,
       'Invalid callValueRefundAddress address'
     )
-
   })
 
   it('should submit the custom refund address to inbox', async function () {
@@ -185,7 +183,7 @@ describe('Bridge peripherals layer 1', () => {
       gasPrice,
       data,
       {
-        value: maxSubmissionCost + maxGas * gasPrice
+        value: maxSubmissionCost + maxGas * gasPrice,
       }
     )
 
@@ -206,6 +204,5 @@ describe('Bridge peripherals layer 1', () => {
       accounts[0].address,
       'Invalid callValueRefundAddress address'
     )
-    
   })
 })

--- a/packages/arb-bridge-peripherals/test/gatewayRouter.l1.ts
+++ b/packages/arb-bridge-peripherals/test/gatewayRouter.l1.ts
@@ -19,6 +19,7 @@ import { ethers } from 'hardhat'
 import { assert, expect } from 'chai'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { Contract, ContractFactory } from 'ethers'
+import { InboxMock__factory } from '../build/types'
 
 describe('Bridge peripherals layer 1', () => {
   let accounts: SignerWithAddress[]
@@ -126,17 +127,23 @@ describe('Bridge peripherals layer 1', () => {
     )
 
     const receipt = await tx.wait()
-    // TxToL2(address,address,uint256,bytes)
+    // RefundAddresses(address,address)
     const expectedTopic =
-      '0xc1d1490cf25c3b40d600dfb27c7680340ed1ab901b7e8f3551280968a3b372b0'
+      '0x70b37e3cd4440bad0fef84e97b8196e82fe9a1ba044f099cbac6cd7f79e8702f'
     const logs = receipt.events
       .filter((curr: any) => curr.topics[0] === expectedTopic)
-      .map((curr: any) => l1ERC20Gateway.interface.parseLog(curr))
+      .map((curr: any) => inbox.interface.parseLog(curr))
     assert.equal(
-      logs[0].args._from,
+      logs[0].args.excessFeeRefundAddress,
       accounts[0].address,
-      'Invalid from address'
+      'Invalid excessFeeRefundAddress address'
     )
+    assert.equal(
+      logs[0].args.callValueRefundAddress,
+      accounts[0].address,
+      'Invalid callValueRefundAddress address'
+    )
+
   })
 
   it('should submit the custom refund address to inbox', async function () {
@@ -171,8 +178,8 @@ describe('Bridge peripherals layer 1', () => {
 
     const tx = await testBridge.outboundTransferCustomRefund(
       token.address,
-      accounts[0].address,
       accounts[1].address,
+      accounts[0].address,
       tokenAmount,
       maxGas,
       gasPrice,
@@ -183,16 +190,22 @@ describe('Bridge peripherals layer 1', () => {
     )
 
     const receipt = await tx.wait()
-    // TxToL2(address,address,uint256,bytes)
+    // RefundAddresses(address,address)
     const expectedTopic =
-      '0xc1d1490cf25c3b40d600dfb27c7680340ed1ab901b7e8f3551280968a3b372b0'
+      '0x70b37e3cd4440bad0fef84e97b8196e82fe9a1ba044f099cbac6cd7f79e8702f'
     const logs = receipt.events
       .filter((curr: any) => curr.topics[0] === expectedTopic)
-      .map((curr: any) => l1ERC20Gateway.interface.parseLog(curr))
+      .map((curr: any) => inbox.interface.parseLog(curr))
     assert.equal(
-      logs[0].args._from,
+      logs[0].args.excessFeeRefundAddress,
       accounts[1].address,
-      'Invalid from address'
+      'Invalid excessFeeRefundAddress address'
     )
+    assert.equal(
+      logs[0].args.callValueRefundAddress,
+      accounts[0].address,
+      'Invalid callValueRefundAddress address'
+    )
+    
   })
 })

--- a/packages/arb-bridge-peripherals/test/wethBridge.l1.ts
+++ b/packages/arb-bridge-peripherals/test/wethBridge.l1.ts
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2019-2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node, mocha */
+import { ethers, waffle } from 'hardhat'
+import { assert, expect } from 'chai'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { Contract, ContractFactory, providers } from 'ethers'
+import { TestWETH9 } from '../build/types'
+
+describe('Bridge peripherals layer 1', () => {
+  let accounts: SignerWithAddress[]
+  let TestBridge: ContractFactory
+  let testBridge: Contract
+
+  let inbox: Contract
+  const maxSubmissionCost = 1
+  const maxGas = 1000000000
+  const gasPrice = 0
+  let l2Address: string
+  let weth: TestWETH9;
+  
+  before(async function () {
+    accounts = await ethers.getSigners()
+    l2Address = accounts[1].address
+
+    TestBridge = await ethers.getContractFactory('L1WethGatewayTester')
+    testBridge = await TestBridge.deploy()
+
+    const Inbox = await ethers.getContractFactory('InboxMock')
+    inbox = await Inbox.deploy()
+
+    const Weth = await ethers.getContractFactory('TestWETH9')
+    weth = await Weth.deploy('weth','weth')
+
+    await testBridge.initialize(
+      l2Address,
+      accounts[0].address,
+      inbox.address,
+      weth.address, // _l1Weth
+      accounts[0].address, // _l2Weth
+    )
+  })
+
+  it('should escrow deposited weth as eth', async function () {
+    // send weth to bridge
+    const wethAmount = 100
+    await weth.deposit({ value: wethAmount })
+    await weth.approve(testBridge.address, wethAmount)
+
+    let data = ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'bytes'],
+      [maxSubmissionCost, '0x']
+    )
+
+    // router usually does this encoding part
+    data = ethers.utils.defaultAbiCoder.encode(
+      ['address', 'bytes'],
+      [accounts[0].address, data]
+    )
+    const escrowPrevBalance = await waffle.provider.getBalance(l2Address)
+    await testBridge.outboundTransfer(
+      weth.address,
+      accounts[0].address,
+      wethAmount,
+      maxGas,
+      gasPrice,
+      data
+    )
+    const escrowedWeth = await weth.balanceOf(testBridge.address)
+    assert.equal(escrowedWeth.toNumber(), 0, 'Weth should not be escrowed')
+    const escrowedETH = await waffle.provider.getBalance(l2Address)
+    assert.equal(escrowedETH.sub(escrowPrevBalance).toNumber(), wethAmount, 'ETH should be escrowed')
+  })
+
+  it('should escrow deposited weth as eth (new entrypoint)', async function () {
+    // send weth to bridge
+    const wethAmount = 100
+    await weth.deposit({ value: wethAmount })
+    await weth.approve(testBridge.address, wethAmount)
+
+    let data = ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'bytes'],
+      [maxSubmissionCost, '0x']
+    )
+
+    // router usually does this encoding part
+    data = ethers.utils.defaultAbiCoder.encode(
+      ['address', 'bytes'],
+      [accounts[0].address, data]
+    )
+    const escrowPrevBalance = await waffle.provider.getBalance(l2Address)
+    await testBridge.outboundTransferCustomRefund(
+      weth.address,
+      accounts[0].address,
+      accounts[0].address,
+      wethAmount,
+      maxGas,
+      gasPrice,
+      data
+    )
+    const escrowedWeth = await weth.balanceOf(testBridge.address)
+    assert.equal(escrowedWeth.toNumber(), 0, 'Weth should not be escrowed')
+    const escrowedETH = await waffle.provider.getBalance(l2Address)
+    assert.equal(escrowedETH.sub(escrowPrevBalance).toNumber(), wethAmount, 'ETH should be escrowed')
+  })
+
+  it('should revert post mint call correctly in outbound', async function () {
+    // send weth to bridge
+    const wethAmount = 100
+    await weth.deposit({ value: wethAmount })
+    await weth.approve(testBridge.address, wethAmount)
+
+    let data = ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'bytes'],
+      [maxSubmissionCost, '0x01']
+    )
+
+    // router usually does this encoding part
+    data = ethers.utils.defaultAbiCoder.encode(
+      ['address', 'bytes'],
+      [accounts[0].address, data]
+    )
+
+    await expect(
+      testBridge.outboundTransfer(
+        weth.address,
+        accounts[0].address,
+        wethAmount,
+        maxGas,
+        gasPrice,
+        data
+      )
+    ).to.be.revertedWith('EXTRA_DATA_DISABLED')
+  })
+
+  it('should revert on inbound if there is data for post mint call', async function () {
+    // send weth to bridge
+    const wethAmount = 100
+    await weth.deposit({ value: wethAmount })
+    await weth.approve(testBridge.address, wethAmount)
+
+    let data = ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'bytes'],
+      [maxSubmissionCost, '0x12']
+    )
+
+    // router usually does this encoding part
+    data = ethers.utils.defaultAbiCoder.encode(
+      ['address', 'bytes'],
+      [accounts[0].address, data]
+    )
+
+    const exitNum = 0
+    const withdrawData = ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'bytes'],
+      [exitNum, '0x11']
+    )
+
+    await expect(
+      testBridge.finalizeInboundTransfer(
+        weth.address,
+        accounts[0].address,
+        accounts[0].address,
+        wethAmount,
+        withdrawData
+      )
+    ).to.be.revertedWith('')
+  })
+  it.skip('should withdraw weth from L2', async function () {
+    // send weth to bridge
+    const wethAmount = 100
+    await weth.deposit({ value: wethAmount })
+    await weth.approve(testBridge.address, wethAmount)
+
+    let data = ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'bytes'],
+      [maxSubmissionCost, '0x']
+    )
+
+    // router usually does this encoding part
+    data = ethers.utils.defaultAbiCoder.encode(
+      ['address', 'bytes'],
+      [accounts[0].address, data]
+    )
+
+    await testBridge.outboundTransfer(
+      weth.address,
+      accounts[0].address,
+      wethAmount,
+      maxGas,
+      gasPrice,
+      data
+    )
+
+    await inbox.setL2ToL1Sender(l2Address)
+
+    const prevUserBalance = await weth.balanceOf(accounts[0].address)
+
+    const exitNum = 0
+    const withdrawData = ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'bytes'],
+      [exitNum, '0x']
+    )
+
+    await testBridge.finalizeInboundTransfer(
+      weth.address,
+      accounts[0].address,
+      accounts[0].address,
+      wethAmount,
+      withdrawData
+    )
+
+    const postUserBalance = await weth.balanceOf(accounts[0].address)
+
+    assert.equal(
+      prevUserBalance.toNumber() + wethAmount,
+      postUserBalance.toNumber(),
+      'Weth not escrowed'
+    )
+  })
+
+  it('should submit the correct submission cost to the inbox', async function () {
+    const L1WethGateway = await ethers.getContractFactory('L1WethGateway')
+    const l1WethGateway = await L1WethGateway.deploy()
+
+    await l1WethGateway.initialize(
+      l2Address,
+      accounts[0].address,
+      inbox.address,
+      weth.address, // _l1Weth
+      accounts[0].address, // _l2Weth
+    )
+
+    // send weth to bridge
+    const wethAmount = 100
+    await weth.deposit({ value: wethAmount })
+    await weth.approve(l1WethGateway.address, wethAmount)
+
+    let data = ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'bytes'],
+      [maxSubmissionCost, '0x']
+    )
+
+    data = ethers.utils.defaultAbiCoder.encode(
+      ['address', 'bytes'],
+      [accounts[0].address, data]
+    )
+
+    const tx = await l1WethGateway.outboundTransfer(
+      weth.address,
+      accounts[0].address,
+      wethAmount,
+      maxGas,
+      gasPrice,
+      data
+    )
+    const receipt = await tx.wait()
+    // TicketData(uint256)
+    const expectedTopic =
+      '0x7efacbad201ebbc50ec0ce4b474c54b735a31b1bac996acff50df7de0314e8f9'
+    const events = receipt.events
+
+    if (!events) {
+      const msg = 'No events in receipt'
+      assert(events, msg)
+      throw new Error(msg)
+    }
+
+    const logs = events
+      .filter((curr: any) => curr.topics[0] === expectedTopic)
+      .map((curr: any) => inbox.interface.parseLog(curr))
+
+    assert.equal(
+      logs[0].args.maxSubmissionCost.toNumber(),
+      maxSubmissionCost,
+      'Invalid submission cost'
+    )
+
+    const escrowedWeth = await weth.balanceOf(l1WethGateway.address)
+    assert.equal(escrowedWeth.toNumber(), 0, 'Weth should not be escrowed')
+  })
+})

--- a/packages/arb-bridge-peripherals/test/wethBridge.l1.ts
+++ b/packages/arb-bridge-peripherals/test/wethBridge.l1.ts
@@ -18,7 +18,7 @@
 import { ethers, waffle } from 'hardhat'
 import { assert, expect } from 'chai'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-import { Contract, ContractFactory, providers } from 'ethers'
+import { Contract, ContractFactory } from 'ethers'
 import { TestWETH9 } from '../build/types'
 
 describe('Bridge peripherals layer 1', () => {
@@ -31,8 +31,7 @@ describe('Bridge peripherals layer 1', () => {
   const maxGas = 1000000000
   const gasPrice = 0
   let l2Address: string
-  let weth: TestWETH9;
-  
+  let weth: TestWETH9
   before(async function () {
     accounts = await ethers.getSigners()
     l2Address = accounts[1].address
@@ -44,14 +43,14 @@ describe('Bridge peripherals layer 1', () => {
     inbox = await Inbox.deploy()
 
     const Weth = await ethers.getContractFactory('TestWETH9')
-    weth = await Weth.deploy('weth','weth')
+    weth = await Weth.deploy('weth', 'weth')
 
     await testBridge.initialize(
       l2Address,
       accounts[0].address,
       inbox.address,
       weth.address, // _l1Weth
-      accounts[0].address, // _l2Weth
+      accounts[0].address // _l2Weth
     )
   })
 
@@ -83,7 +82,11 @@ describe('Bridge peripherals layer 1', () => {
     const escrowedWeth = await weth.balanceOf(testBridge.address)
     assert.equal(escrowedWeth.toNumber(), 0, 'Weth should not be escrowed')
     const escrowedETH = await waffle.provider.getBalance(l2Address)
-    assert.equal(escrowedETH.sub(escrowPrevBalance).toNumber(), wethAmount, 'ETH should be escrowed')
+    assert.equal(
+      escrowedETH.sub(escrowPrevBalance).toNumber(),
+      wethAmount,
+      'ETH should be escrowed'
+    )
   })
 
   it('should escrow deposited weth as eth (new entrypoint)', async function () {
@@ -115,7 +118,11 @@ describe('Bridge peripherals layer 1', () => {
     const escrowedWeth = await weth.balanceOf(testBridge.address)
     assert.equal(escrowedWeth.toNumber(), 0, 'Weth should not be escrowed')
     const escrowedETH = await waffle.provider.getBalance(l2Address)
-    assert.equal(escrowedETH.sub(escrowPrevBalance).toNumber(), wethAmount, 'ETH should be escrowed')
+    assert.equal(
+      escrowedETH.sub(escrowPrevBalance).toNumber(),
+      wethAmount,
+      'ETH should be escrowed'
+    )
   })
 
   it('should revert post mint call correctly in outbound', async function () {
@@ -153,17 +160,6 @@ describe('Bridge peripherals layer 1', () => {
     await weth.deposit({ value: wethAmount })
     await weth.approve(testBridge.address, wethAmount)
 
-    let data = ethers.utils.defaultAbiCoder.encode(
-      ['uint256', 'bytes'],
-      [maxSubmissionCost, '0x12']
-    )
-
-    // router usually does this encoding part
-    data = ethers.utils.defaultAbiCoder.encode(
-      ['address', 'bytes'],
-      [accounts[0].address, data]
-    )
-
     const exitNum = 0
     const withdrawData = ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'bytes'],
@@ -180,6 +176,7 @@ describe('Bridge peripherals layer 1', () => {
       )
     ).to.be.revertedWith('')
   })
+
   it.skip('should withdraw weth from L2', async function () {
     // send weth to bridge
     const wethAmount = 100
@@ -242,7 +239,7 @@ describe('Bridge peripherals layer 1', () => {
       accounts[0].address,
       inbox.address,
       weth.address, // _l1Weth
-      accounts[0].address, // _l2Weth
+      accounts[0].address // _l2Weth
     )
 
     // send weth to bridge
@@ -281,8 +278,8 @@ describe('Bridge peripherals layer 1', () => {
     }
 
     const logs = events
-      .filter((curr: any) => curr.topics[0] === expectedTopic)
-      .map((curr: any) => inbox.interface.parseLog(curr))
+      .filter(curr => curr.topics[0] === expectedTopic)
+      .map(curr => inbox.interface.parseLog(curr))
 
     assert.equal(
       logs[0].args.maxSubmissionCost.toNumber(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,11 +1843,6 @@ arb-ts@^0.0.36:
     dotenv "^10.0.0"
     ethers "^5.1.0"
 
-arbos-precompiles@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/arbos-precompiles/-/arbos-precompiles-1.0.1.tgz#90de6534d652d5c17b7f6a8c4f58d66bd4cc2d67"
-  integrity sha512-KHTyjtp70ApKgTsLANlM7p75l7PKfP4ptjeh9XEwQsR8ZLxjZ5gsZOXydsKoMqgUUK0HfQtTpsZyZc4B1BLARQ==
-
 archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
@@ -5362,7 +5357,7 @@ fmix@^0.1.0:
   dependencies:
     imul "^1.0.0"
 
-follow-redirects@^1.12.1, follow-redirects@^1.14.0, follow-redirects@^1.14.7:
+follow-redirects@^1.12.1, follow-redirects@^1.14.0:
   version "1.14.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
@@ -7858,7 +7853,7 @@ minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6, minimist@~1.2.5:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@~1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -8174,12 +8169,10 @@ node-environment-flags@1.0.6:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
-node-fetch@2.6.1, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7, node-fetch@~1.7.1:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
+node-fetch@2.6.1, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@~1.7.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   version "4.3.0"
@@ -10798,11 +10791,6 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
-
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
@@ -12084,11 +12072,6 @@ web3@^1.0.0:
     web3-shh "1.6.1"
     web3-utils "1.6.1"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
-
 websocket@1.0.32:
   version "1.0.32"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.32.tgz#1f16ddab3a21a2d929dec1687ab21cfdc6d3dbb1"
@@ -12117,14 +12100,6 @@ whatwg-fetch@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,6 +1843,11 @@ arb-ts@^0.0.36:
     dotenv "^10.0.0"
     ethers "^5.1.0"
 
+arbos-precompiles@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arbos-precompiles/-/arbos-precompiles-1.0.1.tgz#90de6534d652d5c17b7f6a8c4f58d66bd4cc2d67"
+  integrity sha512-KHTyjtp70ApKgTsLANlM7p75l7PKfP4ptjeh9XEwQsR8ZLxjZ5gsZOXydsKoMqgUUK0HfQtTpsZyZc4B1BLARQ==
+
 archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
@@ -5357,10 +5362,10 @@ fmix@^0.1.0:
   dependencies:
     imul "^1.0.0"
 
-follow-redirects@^1.12.1, follow-redirects@^1.14.0:
-  version "1.14.6"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.6.tgz#8cfb281bbc035b3c067d6cd975b0f6ade6e855cd"
-  integrity sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==
+follow-redirects@^1.12.1, follow-redirects@^1.14.0, follow-redirects@^1.14.7:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 for-each@^0.3.3, for-each@~0.3.3:
   version "0.3.3"
@@ -7853,10 +7858,10 @@ minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@~1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6, minimist@~1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass@^2.6.0, minipass@^2.9.0:
   version "2.9.0"
@@ -8169,10 +8174,12 @@ node-environment-flags@1.0.6:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
-node-fetch@2.6.1, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@~1.7.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+node-fetch@2.6.1, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7, node-fetch@~1.7.1:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   version "4.3.0"
@@ -10791,6 +10798,11 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
@@ -12072,6 +12084,11 @@ web3@^1.0.0:
     web3-shh "1.6.1"
     web3-utils "1.6.1"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 websocket@1.0.32:
   version "1.0.32"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.32.tgz#1f16ddab3a21a2d929dec1687ab21cfdc6d3dbb1"
@@ -12100,6 +12117,14 @@ whatwg-fetch@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Add optional refund address entry point to gateway router smart contracts. One concern is that without changing `L1ArbitrumMessenger.sol` the `excessFeeRefundAddress` and `callValueRefundAddress` must be set to the same address, which allow that address to cancel the retryable to break the L1L2 atomicity.