### PR TITLE
Remove unneeded unaliased check for crosschain message

### DIFF
--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/gateway/L2ArbitrumGateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/gateway/L2ArbitrumGateway.sol
@@ -55,8 +55,7 @@ abstract contract L2ArbitrumGateway is L2ArbitrumMessenger, TokenGateway {
 
     modifier onlyCounterpartGateway() override {
         require(
-            msg.sender == counterpartGateway ||
-                AddressAliasHelper.undoL1ToL2Alias(msg.sender) == counterpartGateway,
+            msg.sender == AddressAliasHelper.applyL1ToL2Alias(counterpartGateway),
             "ONLY_COUNTERPART_GATEWAY"
         );
         _;


### PR DESCRIPTION
Also flipped it to apply the alias on the gateway address, instead of undoing it on the msg sender.
Feels more natural and clean (also if we were using immutables this would be better optimised)