### PR TITLE
Make wallet creation explicit

### DIFF
--- a/packages/arb-node-core/cmd/arb-db/arb-db.go
+++ b/packages/arb-node-core/cmd/arb-db/arb-db.go
@@ -23,6 +23,7 @@ import (
 	"github.com/offchainlabs/arbitrum/packages/arb-util/configuration"
 	"github.com/pkg/errors"
 	golog "log"
+	"os"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -53,8 +54,9 @@ func startup() error {
 	config, err := configuration.ParseDBTool()
 	if err != nil || len(config.Persistent.Chain) == 0 {
 		fmt.Printf("\n")
-		fmt.Printf("Sample usage: arb-db --persistent.chain='.arbitrum/mainnet' --core.database.metadata\n")
-		fmt.Printf("              arb-db --persistent.chain='.arbitrum/mainnet' --core.database.prune-on-startup\n")
+		fmt.Printf("Sample usage: %s --persistent.chain='.arbitrum/mainnet' --core.database.metadata\n", os.Args[0])
+		fmt.Printf("              %s --persistent.chain='.arbitrum/mainnet' --core.database.make-validator\n", os.Args[0])
+		fmt.Printf("              %s --persistent.chain='.arbitrum/mainnet' --core.database.prune-on-startup\n", os.Args[0])
 		if err != nil && !strings.Contains(err.Error(), "help requested") {
 			fmt.Printf("%s\n", err.Error())
 		}

--- a/packages/arb-node-core/cmd/arb-validator/arb-validator.go
+++ b/packages/arb-node-core/cmd/arb-validator/arb-validator.go
@@ -147,6 +147,7 @@ func startup() error {
 			fmt.Printf("\nNotice: %s\n\n", err.Error())
 			return nil
 		}
+
 		return errors.Wrap(err, "error loading wallet keystore")
 	}
 	logger.Info().Str("address", auth.From.String()).Msg("Loaded wallet")

--- a/packages/arb-node-core/cmd/arb-validator/arb-validator.go
+++ b/packages/arb-node-core/cmd/arb-validator/arb-validator.go
@@ -140,9 +140,12 @@ func startup() error {
 	bridgeUtilsAddr := ethcommon.HexToAddress(config.BridgeUtilsAddress)
 	validatorUtilsAddr := ethcommon.HexToAddress(config.Validator.UtilsAddress)
 	validatorWalletFactoryAddr := ethcommon.HexToAddress(config.Validator.WalletFactoryAddress)
-	auth, _, err := cmdhelp.GetKeystore(config, walletConfig, l1ChainId, false)
+	auth, _, finished, err := cmdhelp.GetKeystore(config, walletConfig, l1ChainId, false)
 	if err != nil {
 		return errors.Wrap(err, "error loading wallet keystore")
+	}
+	if finished {
+		return nil
 	}
 	logger.Info().Str("address", auth.From.String()).Msg("Loaded wallet")
 

--- a/packages/arb-node-core/cmd/arb-validator/arb-validator.go
+++ b/packages/arb-node-core/cmd/arb-validator/arb-validator.go
@@ -140,12 +140,14 @@ func startup() error {
 	bridgeUtilsAddr := ethcommon.HexToAddress(config.BridgeUtilsAddress)
 	validatorUtilsAddr := ethcommon.HexToAddress(config.Validator.UtilsAddress)
 	validatorWalletFactoryAddr := ethcommon.HexToAddress(config.Validator.WalletFactoryAddress)
-	auth, _, finished, err := cmdhelp.GetKeystore(config, walletConfig, l1ChainId, false)
+	auth, _, err := cmdhelp.GetKeystore(config, walletConfig, l1ChainId, false)
 	if err != nil {
+		if strings.Contains(err.Error(), "only-create-key") {
+			logger.Info().Msg(err.Error())
+			fmt.Printf("\nNotice: %s\n\n", err.Error())
+			return nil
+		}
 		return errors.Wrap(err, "error loading wallet keystore")
-	}
-	if finished {
-		return nil
 	}
 	logger.Info().Str("address", auth.From.String()).Msg("Loaded wallet")
 

--- a/packages/arb-node-core/cmdhelp/wallet.go
+++ b/packages/arb-node-core/cmdhelp/wallet.go
@@ -82,9 +82,6 @@ func GetKeystore(
 		}
 
 		if len(walletConfig.Fireblocks.FeedSigner.PrivateKey) != 0 {
-			if walletConfig.Local.OnlyCreateKey {
-				return nil, nil, errors.New("wallet using fireblocks for key, remove --wallet.local.only-create-key to run normally")
-			}
 			privateKey, err := crypto.HexToECDSA(walletConfig.Local.PrivateKey)
 			if err != nil {
 				return nil, nil, errors.Wrap(err, "error loading feed private key")

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -282,13 +282,14 @@ func startup() error {
 		batcherMode = rpc.ForwarderBatcherMode{Config: config.Node.Forwarder}
 	} else {
 		var auth *bind.TransactOpts
-		var finished bool
-		auth, dataSigner, finished, err = cmdhelp.GetKeystore(config, walletConfig, l1ChainId, true)
+		auth, dataSigner, err = cmdhelp.GetKeystore(config, walletConfig, l1ChainId, true)
 		if err != nil {
+			if strings.Contains(err.Error(), "only-create-key") {
+				logger.Info().Msg(err.Error())
+				fmt.Printf("\nNotice: %s\n\n", err.Error())
+				return nil
+			}
 			return errors.Wrap(err, "error running GetKeystore")
-		}
-		if finished {
-			return nil
 		}
 
 		if config.Node.Sequencer.Dangerous.DisableBatchPosting {

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -282,9 +282,13 @@ func startup() error {
 		batcherMode = rpc.ForwarderBatcherMode{Config: config.Node.Forwarder}
 	} else {
 		var auth *bind.TransactOpts
-		auth, dataSigner, err = cmdhelp.GetKeystore(config, walletConfig, l1ChainId, true)
+		var finished bool
+		auth, dataSigner, finished, err = cmdhelp.GetKeystore(config, walletConfig, l1ChainId, true)
 		if err != nil {
 			return errors.Wrap(err, "error running GetKeystore")
+		}
+		if finished {
+			return nil
 		}
 
 		if config.Node.Sequencer.Dangerous.DisableBatchPosting {

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -304,9 +304,10 @@ func (f *FeedSigner) Password() *string {
 }
 
 type WalletLocal struct {
-	Pathname     string `koanf:"pathname"`
-	PasswordImpl string `koanf:"password"`
-	PrivateKey   string `koanf:"private-key"`
+	OnlyCreateKey bool   `koanf:"only-create-key"`
+	Pathname      string `koanf:"pathname"`
+	PasswordImpl  string `koanf:"password"`
+	PrivateKey    string `koanf:"private-key"`
 }
 
 func (w WalletLocal) Password() *string {

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -541,6 +541,7 @@ func ParseNonRelay(ctx context.Context, f *flag.FlagSet, defaultWalletPathname s
 	f.String("rollup.address", "", "layer 2 rollup contract address")
 	f.String("rollup.machine.filename", "", "file to load machine from")
 
+	f.Bool("wallet.local.only-create-key", false, "create new wallet and exit")
 	f.String("wallet.local.pathname", defaultWalletPathname, "path to store wallet in")
 	f.String("wallet.local.password", PASSWORD_NOT_SET, "password for wallet")
 	f.String("wallet.local.private-key", "", "wallet private key string")


### PR DESCRIPTION
If wallet is required and does not exist, user needs to add `--wallet.local.only-create-key` to the command line.  If wallet exists, command line must not have `--wallet.local.only-create-key`.