### PR TITLE
validator smart contract wallet options

### DIFF
--- a/packages/arb-node-core/challenge/common_test.go
+++ b/packages/arb-node-core/challenge/common_test.go
@@ -304,12 +304,12 @@ func initializeChallengeTest(
 
 	asserterAuth, err := transactauth.NewTransactAuth(ctx, client, asserter)
 	test.FailIfError(t, err)
-	asserterWallet, err := ethbridge.NewValidator(&asserterWalletAddress, ethcommon.Address{}, ethcommon.Address{}, client, asserterAuth, 0, nil)
+	asserterWallet, err := ethbridge.NewValidator(&asserterWalletAddress, ethcommon.Address{}, ethcommon.Address{}, client, asserterAuth, 0, 1000, nil)
 	test.FailIfError(t, err)
 
 	challengerAuth, err := transactauth.NewTransactAuth(ctx, client, challenger)
 	test.FailIfError(t, err)
-	challengerWallet, err := ethbridge.NewValidator(&challengerWalletAddress, ethcommon.Address{}, ethcommon.Address{}, client, challengerAuth, 0, nil)
+	challengerWallet, err := ethbridge.NewValidator(&challengerWalletAddress, ethcommon.Address{}, ethcommon.Address{}, client, challengerAuth, 0, 1000, nil)
 	test.FailIfError(t, err)
 
 	startChallenge := func(assertion *core.Assertion) {

--- a/packages/arb-node-core/cmdhelp/wallet.go
+++ b/packages/arb-node-core/cmdhelp/wallet.go
@@ -63,10 +63,9 @@ func GetKeystore(
 	var signer = func(data []byte) ([]byte, error) { return nil, errors.New("undefined signer") }
 	var auth *bind.TransactOpts
 
-	var message string
 	if len(walletConfig.Fireblocks.SSLKey) != 0 {
 		if walletConfig.Local.OnlyCreateKey {
-			return nil, nil, "", errors.New("using fireblocks keystore, remove --wallet.local.only-create-key to run normally")
+			return nil, nil, "using fireblocks keystore, remove --wallet.local.only-create-key to run normally", nil
 		}
 		fromAddress := ethcommon.HexToAddress(walletConfig.Fireblocks.SourceAddress)
 		logger.Info().Hex("address", fromAddress.Bytes()).Msg("fireblocks enabled")
@@ -118,7 +117,7 @@ func GetKeystore(
 		}
 	} else if len(walletConfig.Local.PrivateKey) != 0 {
 		if walletConfig.Local.OnlyCreateKey {
-			message = "wallet key already exists, remove --wallet.local.only-create-key to run normally"
+			return nil, nil, "wallet key already exists, remove --wallet.local.only-create-key to run normally", nil
 		}
 		privateKey, err := crypto.HexToECDSA(walletConfig.Local.PrivateKey)
 		if err != nil {
@@ -143,11 +142,11 @@ func GetKeystore(
 		}
 
 		if newKeystoreCreated {
-			message = "wallet key created, backup key (" + walletConfig.Local.Pathname + ") and remove --wallet.local.only-create-key to start normally"
+			return nil, nil, "wallet key created, backup key (" + walletConfig.Local.Pathname + ") and remove --wallet.local.only-create-key to start normally", nil
 		}
 
 		if walletConfig.Local.OnlyCreateKey {
-			message = "wallet key already created, backup key (" + walletConfig.Local.Pathname + ") and remove --wallet.local.only-create-key to run normally"
+			return nil, nil, "wallet key already created, backup key (" + walletConfig.Local.Pathname + ") and remove --wallet.local.only-create-key to run normally", nil
 		}
 
 		auth, err = bind.NewKeyStoreTransactorWithChainID(ks, *account, chainId)
@@ -169,7 +168,7 @@ func GetKeystore(
 		auth.GasPrice = big.NewInt(int64(gasPriceAsFloat))
 	}
 
-	return auth, signer, message, nil
+	return auth, signer, "", nil
 }
 
 func openKeystore(description string, walletPath string, walletPassword *string, createNewKey bool) (*keystore.KeyStore, *accounts.Account, bool, error) {

--- a/packages/arb-node-core/cmdhelp/wallet.go
+++ b/packages/arb-node-core/cmdhelp/wallet.go
@@ -82,7 +82,7 @@ func GetKeystore(
 		}
 
 		if len(walletConfig.Fireblocks.FeedSigner.PrivateKey) != 0 {
-			privateKey, err := crypto.HexToECDSA(walletConfig.Local.PrivateKey)
+			privateKey, err := crypto.HexToECDSA(walletConfig.Fireblocks.FeedSigner.PrivateKey)
 			if err != nil {
 				return nil, nil, errors.Wrap(err, "error loading feed private key")
 			}
@@ -142,11 +142,11 @@ func GetKeystore(
 		}
 
 		if newKeystoreCreated {
-			return nil, nil, errors.New("wallet key created, backup key and remove --wallet.local.only-create-key to start normally")
+			return nil, nil, errors.New("wallet key created, backup key (" + walletConfig.Local.Pathname + ") and remove --wallet.local.only-create-key to start normally")
 		}
 
 		if walletConfig.Local.OnlyCreateKey {
-			return nil, nil, errors.New("wallet key already created, remove --wallet.local.only-create-key to run normally")
+			return nil, nil, errors.New("wallet key already created, backup key (" + walletConfig.Local.Pathname + ") and remove --wallet.local.only-create-key to run normally")
 		}
 
 		auth, err = bind.NewKeyStoreTransactorWithChainID(ks, *account, chainId)

--- a/packages/arb-node-core/ethbridge/validator.go
+++ b/packages/arb-node-core/ethbridge/validator.go
@@ -104,7 +104,7 @@ func (v *ValidatorWallet) executeTransaction(ctx context.Context, tx *types.Tran
 	})
 }
 
-func (v *ValidatorWallet) createWalletIfNeeded(ctx context.Context) error {
+func (v *ValidatorWallet) CreateWalletIfNeeded(ctx context.Context) error {
 	if v.con != nil {
 		return nil
 	}
@@ -169,7 +169,7 @@ func (v *ValidatorWallet) ExecuteTransactions(ctx context.Context, builder *Buil
 		totalAmount = totalAmount.Add(totalAmount, tx.Value())
 	}
 
-	err := v.createWalletIfNeeded(ctx)
+	err := v.CreateWalletIfNeeded(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/arb-node-core/ethbridge/validator.go
+++ b/packages/arb-node-core/ethbridge/validator.go
@@ -212,7 +212,7 @@ func CreateValidatorWallet(
 	query := ethereum.FilterQuery{
 		BlockHash: nil,
 		FromBlock: big.NewInt(fromBlock),
-		ToBlock:   nil,
+		ToBlock:   big.NewInt(fromBlock + 1000),
 		Addresses: []ethcommon.Address{validatorWalletFactoryAddr},
 		Topics:    [][]ethcommon.Hash{{walletCreatedID}, nil, {transactAuth.From().Hash()}},
 	}

--- a/packages/arb-node-core/staker/staker_test.go
+++ b/packages/arb-node-core/staker/staker_test.go
@@ -189,17 +189,17 @@ func runStakersTest(t *testing.T, faultConfig challenge.FaultConfig, maxGasPerNo
 	val2Auth, err := transactauth.NewTransactAuth(ctx, client, auth2)
 	test.FailIfError(t, err)
 
-	validatorAddress, err := ethbridge.CreateValidatorWallet(ctx, validatorWalletFactory, rollupBlock.Int64(), valAuth, client)
+	validatorAddress, err := ethbridge.CreateValidatorWallet(ctx, validatorWalletFactory, rollupBlock.Int64(), 1000, valAuth, client)
 	test.FailIfError(t, err)
 
 	// Should lookup WalletCreated event
-	checkValidatorAddress, err := ethbridge.CreateValidatorWallet(ctx, validatorWalletFactory, rollupBlock.Int64(), valAuth, client)
+	checkValidatorAddress, err := ethbridge.CreateValidatorWallet(ctx, validatorWalletFactory, rollupBlock.Int64(), 1000, valAuth, client)
 	test.FailIfError(t, err)
 	if validatorAddress != checkValidatorAddress {
 		t.Error("CreateValidatorWallet didn't reuse existing wallet")
 	}
 
-	validatorAddress2, err := ethbridge.CreateValidatorWallet(ctx, validatorWalletFactory, rollupBlock.Int64(), val2Auth, client)
+	validatorAddress2, err := ethbridge.CreateValidatorWallet(ctx, validatorWalletFactory, rollupBlock.Int64(), 1000, val2Auth, client)
 	test.FailIfError(t, err)
 	if validatorAddress == validatorAddress2 {
 		t.Error("CreateValidatorWallet reused existing wallet for different address")
@@ -216,9 +216,9 @@ func runStakersTest(t *testing.T, faultConfig challenge.FaultConfig, maxGasPerNo
 	mon, shutdown := monitor.PrepareArbCore(t)
 	defer shutdown()
 
-	val, err := ethbridge.NewValidator(nil, validatorWalletFactory, rollupAddr, client, valAuth, 0, nil)
+	val, err := ethbridge.NewValidator(nil, validatorWalletFactory, rollupAddr, client, valAuth, 0, 1000, nil)
 	test.FailIfError(t, err)
-	val2, err := ethbridge.NewValidator(nil, validatorWalletFactory, rollupAddr, client, val2Auth, 0, nil)
+	val2, err := ethbridge.NewValidator(nil, validatorWalletFactory, rollupAddr, client, val2Auth, 0, 1000, nil)
 	test.FailIfError(t, err)
 
 	staker, _, err := NewStaker(ctx, mon.Core, client, val, rollupBlock.Int64(), common.NewAddressFromEth(validatorUtilsAddr), configuration.MakeNodesStrategy, bind.CallOpts{}, valAuth, configuration.Validator{})

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -150,11 +150,19 @@ func startup() error {
 				return err
 			}
 
+			if message == "" {
+				return errors.New("missing message when only-create-wallet-contract set")
+			}
+
 			// Always exit when only-create-wallet-address set.
 			return errors.New(message)
 		}
 
-		if walletConfig.Local.OnlyCreateKey || message != "" {
+		if config.Wallet.Local.OnlyCreateKey {
+			if message == "" {
+				return errors.New("missing message when only-create-key set")
+			}
+
 			// Always exit when only-create-key set
 			return errors.New(message)
 		}
@@ -365,7 +373,11 @@ func startup() error {
 		if err != nil {
 			return err
 		}
-		if message != "" {
+		if config.Wallet.Local.OnlyCreateKey {
+			if message == "" {
+				return errors.New("missing message when only-create-key set")
+			}
+
 			return errors.New(message)
 		}
 

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -683,7 +683,7 @@ func startValidator(
 	}
 
 	onValidatorWalletCreated := func(addr ethcommon.Address) {}
-	if config.Validator.ContractWalletAddress != "" {
+	if config.Validator.ContractWalletAddress == "" {
 		onValidatorWalletCreated = func(addr ethcommon.Address) {
 			chainState.ValidatorWallet = addr.String()
 			newChainStateData, err := json.Marshal(chainState)
@@ -700,18 +700,7 @@ func startValidator(
 		}
 	} else {
 		onValidatorWalletCreated = func(addr ethcommon.Address) {
-			log.Error().Msg("created wallet when --validator.wallet-address provided")
-			chainState.ValidatorWallet = addr.String()
-			newChainStateData, err := json.Marshal(chainState)
-			if err != nil {
-			} else if err := ioutil.WriteFile(config.Validator.ContractWalletAddressFilename, newChainStateData, 0644); err != nil {
-				log.Warn().Err(err).Msg("failed to write chain state config")
-			}
-			log.
-				Info().
-				Str("address", chainState.ValidatorWallet).
-				Str("filename", config.Validator.ContractWalletAddressFilename).
-				Msg("created validator smart contract wallet")
+			log.Error().Str("address", addr.String()).Msg("created wallet when --validator.wallet-address provided")
 		}
 	}
 

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -636,18 +636,18 @@ func startValidator(
 	validatorWalletFactoryAddr := ethcommon.HexToAddress(config.Validator.WalletFactoryAddress)
 
 	chainState := ChainState{}
-	if config.Validator.WalletAddress != "" {
-		if !ethcommon.IsHexAddress(config.Validator.WalletAddress) {
-			log.Error().Str("address", config.Validator.WalletAddress).Msg("invalid validator smart contract wallet")
+	if config.Validator.ContractWalletAddress != "" {
+		if !ethcommon.IsHexAddress(config.Validator.ContractWalletAddress) {
+			log.Error().Str("address", config.Validator.ContractWalletAddress).Msg("invalid validator smart contract wallet")
 			return nil, errors.New("invalid validator smart contract wallet address")
 		}
-		chainState.ValidatorWallet = config.Validator.WalletAddress
+		chainState.ValidatorWallet = config.Validator.ContractWalletAddress
 	} else {
-		chainStateFile, err := os.Open(config.Validator.WalletAddressFilename)
+		chainStateFile, err := os.Open(config.Validator.ContractWalletAddressFilename)
 		if err != nil {
 			// If file doesn't exist yet, will be created when needed
 			if !os.IsNotExist(err) {
-				return nil, errors.Wrap(err, "failed to open chainState file: "+config.Validator.WalletAddressFilename)
+				return nil, errors.Wrap(err, "failed to open chainState file: "+config.Validator.ContractWalletAddressFilename)
 			}
 		} else {
 			chainStateData, err := ioutil.ReadAll(chainStateFile)
@@ -683,19 +683,19 @@ func startValidator(
 	}
 
 	onValidatorWalletCreated := func(addr ethcommon.Address) {}
-	if config.Validator.WalletAddress != "" {
+	if config.Validator.ContractWalletAddress != "" {
 		onValidatorWalletCreated = func(addr ethcommon.Address) {
 			chainState.ValidatorWallet = addr.String()
 			newChainStateData, err := json.Marshal(chainState)
 			if err != nil {
 				log.Warn().Err(err).Msg("failed to marshal chain state")
-			} else if err := ioutil.WriteFile(config.Validator.WalletAddressFilename, newChainStateData, 0644); err != nil {
+			} else if err := ioutil.WriteFile(config.Validator.ContractWalletAddressFilename, newChainStateData, 0644); err != nil {
 				log.Warn().Err(err).Msg("failed to write chain state config")
 			}
 			log.
 				Info().
 				Str("address", chainState.ValidatorWallet).
-				Str("filename", config.Validator.WalletAddressFilename).
+				Str("filename", config.Validator.ContractWalletAddressFilename).
 				Msg("created validator smart contract wallet")
 		}
 	} else {
@@ -704,13 +704,13 @@ func startValidator(
 			chainState.ValidatorWallet = addr.String()
 			newChainStateData, err := json.Marshal(chainState)
 			if err != nil {
-			} else if err := ioutil.WriteFile(config.Validator.WalletAddressFilename, newChainStateData, 0644); err != nil {
+			} else if err := ioutil.WriteFile(config.Validator.ContractWalletAddressFilename, newChainStateData, 0644); err != nil {
 				log.Warn().Err(err).Msg("failed to write chain state config")
 			}
 			log.
 				Info().
 				Str("address", chainState.ValidatorWallet).
-				Str("filename", config.Validator.WalletAddressFilename).
+				Str("filename", config.Validator.ContractWalletAddressFilename).
 				Msg("created validator smart contract wallet")
 		}
 	}

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -590,7 +590,7 @@ func ParseNonRelay(ctx context.Context, f *flag.FlagSet, defaultWalletPathname s
 
 	f.String("rollup.address", "", "layer 2 rollup contract address")
 	f.Int64("rollup.from-block", 0, "layer 2 rollup contract creation block")
-	f.Int64("rollup.block-search-size", 1000, "number of blocks to search at a time when looking for validator smart contract wallet creation, 0 to search all blocks at once")
+	f.Int64("rollup.block-search-size", 0, "number of blocks to search at a time when looking for validator smart contract wallet creation, 0 to search all blocks at once")
 	f.String("rollup.machine.filename", "", "file to load machine from")
 
 	f.Bool("wallet.local.only-create-key", false, "create new wallet and exit")

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -284,16 +284,16 @@ type Rollup struct {
 }
 
 type Validator struct {
-	StrategyImpl             string            `koanf:"strategy"`
-	UtilsAddress             string            `koanf:"utils-address"`
-	StakerDelay              time.Duration     `koanf:"staker-delay"`
-	WalletFactoryAddress     string            `koanf:"wallet-factory-address"`
-	L1PostingStrategy        L1PostingStrategy `koanf:"l1-posting-strategy"`
-	DontChallenge            bool              `koanf:"dont-challenge"`
-	WithdrawDestination      string            `koanf:"withdraw-destination"`
-	OnlyCreateWalletContract bool              `koanf:"only-create-wallet-contract"`
-	WalletAddress            string            `koanf:"wallet-address"`
-	WalletAddressFilename    string            `koanf:"wallet-address-filename"`
+	StrategyImpl                  string            `koanf:"strategy"`
+	UtilsAddress                  string            `koanf:"utils-address"`
+	StakerDelay                   time.Duration     `koanf:"staker-delay"`
+	WalletFactoryAddress          string            `koanf:"wallet-factory-address"`
+	L1PostingStrategy             L1PostingStrategy `koanf:"l1-posting-strategy"`
+	DontChallenge                 bool              `koanf:"dont-challenge"`
+	WithdrawDestination           string            `koanf:"withdraw-destination"`
+	OnlyCreateWalletContract      bool              `koanf:"only-create-wallet-contract"`
+	ContractWalletAddress         string            `koanf:"contract-wallet-address"`
+	ContractWalletAddressFilename string            `koanf:"contract-wallet-address-filename"`
 }
 
 type ValidatorStrategy uint8
@@ -517,8 +517,8 @@ func ParseNode(ctx context.Context) (*Config, *Wallet, *ethutils.RPCEthClient, *
 	AddL1PostingStrategyOptions(f, "validator.")
 
 	f.Bool("validator.only-create-wallet-contract", false, "only create smart contract wallet contract, then exit")
-	f.String("validator.wallet-address-filename", "", "json file that validator smart contract wallet address is stored in")
-	f.String("validator.wallet-address", "", "validator smart contract wallet public address")
+	f.String("validator.contract-wallet-address-filename", "", "json file that validator smart contract wallet address is stored in")
+	f.String("validator.contract-wallet-address", "", "validator smart contract wallet public address")
 	f.String("validator.strategy", "StakeLatest", "strategy for validator to use")
 	f.String("validator.utils-address", "", "validator utilities address")
 	f.Duration("validator.staker-delay", 60*time.Second, "delay between updating stake")
@@ -808,11 +808,11 @@ func resolveDirectoryNames(out *Config, wallet *Wallet) error {
 	}
 
 	// Make validator smart contract wallet address relative to chain directory if not already absolute
-	if out.Validator.WalletAddressFilename == "" {
-		out.Validator.WalletAddressFilename = "chainState.json"
+	if out.Validator.ContractWalletAddressFilename == "" {
+		out.Validator.ContractWalletAddressFilename = "chainState.json"
 	}
-	if !filepath.IsAbs(out.Validator.WalletAddressFilename) {
-		out.Validator.WalletAddressFilename = path.Join(out.Persistent.Chain, out.Validator.WalletAddressFilename)
+	if !filepath.IsAbs(out.Validator.ContractWalletAddressFilename) {
+		out.Validator.ContractWalletAddressFilename = path.Join(out.Persistent.Chain, out.Validator.ContractWalletAddressFilename)
 	}
 
 	return nil

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -517,7 +517,7 @@ func ParseNode(ctx context.Context) (*Config, *Wallet, *ethutils.RPCEthClient, *
 	AddL1PostingStrategyOptions(f, "validator.")
 
 	f.Bool("validator.only-create-wallet-contract", false, "only create smart contract wallet contract, then exit")
-	f.String("validator.contract-wallet-address-filename", "", "json file that validator smart contract wallet address is stored in")
+	f.String("validator.contract-wallet-address-filename", "chainState.json", "json file that validator smart contract wallet address is stored in")
 	f.String("validator.contract-wallet-address", "", "validator smart contract wallet public address")
 	f.String("validator.strategy", "StakeLatest", "strategy for validator to use")
 	f.String("validator.utils-address", "", "validator utilities address")
@@ -808,9 +808,6 @@ func resolveDirectoryNames(out *Config, wallet *Wallet) error {
 	}
 
 	// Make validator smart contract wallet address relative to chain directory if not already absolute
-	if out.Validator.ContractWalletAddressFilename == "" {
-		out.Validator.ContractWalletAddressFilename = "chainState.json"
-	}
 	if !filepath.IsAbs(out.Validator.ContractWalletAddressFilename) {
 		out.Validator.ContractWalletAddressFilename = path.Join(out.Persistent.Chain, out.Validator.ContractWalletAddressFilename)
 	}

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -283,15 +283,16 @@ type Rollup struct {
 }
 
 type Validator struct {
-	StrategyImpl          string            `koanf:"strategy"`
-	UtilsAddress          string            `koanf:"utils-address"`
-	StakerDelay           time.Duration     `koanf:"staker-delay"`
-	WalletFactoryAddress  string            `koanf:"wallet-factory-address"`
-	L1PostingStrategy     L1PostingStrategy `koanf:"l1-posting-strategy"`
-	DontChallenge         bool              `koanf:"dont-challenge"`
-	WithdrawDestination   string            `koanf:"withdraw-destination"`
-	WalletAddress         string            `koanf:"wallet-address"`
-	WalletAddressFilename string            `koanf:"wallet-address-filename"`
+	StrategyImpl            string            `koanf:"strategy"`
+	UtilsAddress            string            `koanf:"utils-address"`
+	StakerDelay             time.Duration     `koanf:"staker-delay"`
+	WalletFactoryAddress    string            `koanf:"wallet-factory-address"`
+	L1PostingStrategy       L1PostingStrategy `koanf:"l1-posting-strategy"`
+	DontChallenge           bool              `koanf:"dont-challenge"`
+	WithdrawDestination     string            `koanf:"withdraw-destination"`
+	OnlyCreateWalletAddress bool              `koanf:"only-create-wallet-address"`
+	WalletAddress           string            `koanf:"wallet-address"`
+	WalletAddressFilename   string            `koanf:"wallet-address-filename"`
 }
 
 type ValidatorStrategy uint8
@@ -514,6 +515,7 @@ func ParseNode(ctx context.Context) (*Config, *Wallet, *ethutils.RPCEthClient, *
 	AddL1PostingStrategyOptions(f, "node.sequencer.")
 	AddL1PostingStrategyOptions(f, "validator.")
 
+	f.Bool("validator.only-create-wallet-address", false, "only create smart contract wallet, then exit")
 	f.String("validator.wallet-address-filename", "", "json file that validator smart contract wallet address is stored in")
 	f.String("validator.wallet-address", "", "validator smart contract wallet public address")
 	f.String("validator.strategy", "StakeLatest", "strategy for validator to use")

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -274,25 +274,26 @@ type Persistent struct {
 }
 
 type Rollup struct {
-	Address   string `koanf:"address"`
-	FromBlock int64  `koanf:"from-block"`
-	Machine   struct {
+	Address         string `koanf:"address"`
+	FromBlock       int64  `koanf:"from-block"`
+	BlockSearchSize int64  `koanf:"block-search-size"`
+	Machine         struct {
 		Filename string `koanf:"filename"`
 		URL      string `koanf:"url"`
 	} `koanf:"machine"`
 }
 
 type Validator struct {
-	StrategyImpl            string            `koanf:"strategy"`
-	UtilsAddress            string            `koanf:"utils-address"`
-	StakerDelay             time.Duration     `koanf:"staker-delay"`
-	WalletFactoryAddress    string            `koanf:"wallet-factory-address"`
-	L1PostingStrategy       L1PostingStrategy `koanf:"l1-posting-strategy"`
-	DontChallenge           bool              `koanf:"dont-challenge"`
-	WithdrawDestination     string            `koanf:"withdraw-destination"`
-	OnlyCreateWalletAddress bool              `koanf:"only-create-wallet-address"`
-	WalletAddress           string            `koanf:"wallet-address"`
-	WalletAddressFilename   string            `koanf:"wallet-address-filename"`
+	StrategyImpl             string            `koanf:"strategy"`
+	UtilsAddress             string            `koanf:"utils-address"`
+	StakerDelay              time.Duration     `koanf:"staker-delay"`
+	WalletFactoryAddress     string            `koanf:"wallet-factory-address"`
+	L1PostingStrategy        L1PostingStrategy `koanf:"l1-posting-strategy"`
+	DontChallenge            bool              `koanf:"dont-challenge"`
+	WithdrawDestination      string            `koanf:"withdraw-destination"`
+	OnlyCreateWalletContract bool              `koanf:"only-create-wallet-contract"`
+	WalletAddress            string            `koanf:"wallet-address"`
+	WalletAddressFilename    string            `koanf:"wallet-address-filename"`
 }
 
 type ValidatorStrategy uint8
@@ -515,7 +516,7 @@ func ParseNode(ctx context.Context) (*Config, *Wallet, *ethutils.RPCEthClient, *
 	AddL1PostingStrategyOptions(f, "node.sequencer.")
 	AddL1PostingStrategyOptions(f, "validator.")
 
-	f.Bool("validator.only-create-wallet-address", false, "only create smart contract wallet, then exit")
+	f.Bool("validator.only-create-wallet-contract", false, "only create smart contract wallet contract, then exit")
 	f.String("validator.wallet-address-filename", "", "json file that validator smart contract wallet address is stored in")
 	f.String("validator.wallet-address", "", "validator smart contract wallet public address")
 	f.String("validator.strategy", "StakeLatest", "strategy for validator to use")
@@ -588,6 +589,8 @@ func ParseNonRelay(ctx context.Context, f *flag.FlagSet, defaultWalletPathname s
 	f.Uint64("l1.chain-id", 0, "if set other than 0, will be used to validate database and L1 connection")
 
 	f.String("rollup.address", "", "layer 2 rollup contract address")
+	f.Int64("rollup.from-block", 0, "layer 2 rollup contract creation block")
+	f.Int64("rollup.block-search-size", 1000, "number of blocks to search at a time when looking for validator smart contract wallet creation, 0 to search all blocks at once")
 	f.String("rollup.machine.filename", "", "file to load machine from")
 
 	f.Bool("wallet.local.only-create-key", false, "create new wallet and exit")
@@ -696,11 +699,6 @@ func ParseNonRelay(ctx context.Context, f *flag.FlagSet, defaultWalletPathname s
 		return nil, nil, nil, nil, err
 	}
 
-	if len(out.Rollup.Machine.Filename) == 0 {
-		// Machine not provided, so use default
-		out.Rollup.Machine.Filename = path.Join(out.Persistent.Chain, "arbos.mexe")
-	}
-
 	_, err = os.Stat(out.Rollup.Machine.Filename)
 	if os.IsNotExist(err) && len(out.Rollup.Machine.URL) != 0 {
 		// Machine does not exist, so load it from provided URL
@@ -791,6 +789,11 @@ func resolveDirectoryNames(out *Config, wallet *Wallet) error {
 		out.Core.Database.SavePath = path.Join(out.Persistent.Chain, out.Core.Database.SavePath)
 	}
 
+	if len(out.Rollup.Machine.Filename) == 0 {
+		// Machine not provided, so use default chain specific machine
+		out.Rollup.Machine.Filename = path.Join(out.Persistent.Chain, "arbos.mexe")
+	}
+
 	// Make machine relative to storage directory if not already absolute
 	if !filepath.IsAbs(out.Rollup.Machine.Filename) {
 		out.Rollup.Machine.Filename = path.Join(out.Persistent.GlobalConfig, out.Rollup.Machine.Filename)
@@ -802,6 +805,14 @@ func resolveDirectoryNames(out *Config, wallet *Wallet) error {
 	}
 	if !filepath.IsAbs(wallet.Fireblocks.FeedSigner.Pathname) {
 		wallet.Fireblocks.FeedSigner.Pathname = path.Join(out.Persistent.Chain, wallet.Fireblocks.FeedSigner.Pathname)
+	}
+
+	// Make validator smart contract wallet address relative to chain directory if not already absolute
+	if out.Validator.WalletAddressFilename == "" {
+		out.Validator.WalletAddressFilename = "chainState.json"
+	}
+	if !filepath.IsAbs(out.Validator.WalletAddressFilename) {
+		out.Validator.WalletAddressFilename = path.Join(out.Persistent.Chain, out.Validator.WalletAddressFilename)
 	}
 
 	return nil

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -283,13 +283,15 @@ type Rollup struct {
 }
 
 type Validator struct {
-	StrategyImpl         string            `koanf:"strategy"`
-	UtilsAddress         string            `koanf:"utils-address"`
-	StakerDelay          time.Duration     `koanf:"staker-delay"`
-	WalletFactoryAddress string            `koanf:"wallet-factory-address"`
-	L1PostingStrategy    L1PostingStrategy `koanf:"l1-posting-strategy"`
-	DontChallenge        bool              `koanf:"dont-challenge"`
-	WithdrawDestination  string            `koanf:"withdraw-destination"`
+	StrategyImpl          string            `koanf:"strategy"`
+	UtilsAddress          string            `koanf:"utils-address"`
+	StakerDelay           time.Duration     `koanf:"staker-delay"`
+	WalletFactoryAddress  string            `koanf:"wallet-factory-address"`
+	L1PostingStrategy     L1PostingStrategy `koanf:"l1-posting-strategy"`
+	DontChallenge         bool              `koanf:"dont-challenge"`
+	WithdrawDestination   string            `koanf:"withdraw-destination"`
+	WalletAddress         string            `koanf:"wallet-address"`
+	WalletAddressFilename string            `koanf:"wallet-address-filename"`
 }
 
 type ValidatorStrategy uint8
@@ -512,6 +514,8 @@ func ParseNode(ctx context.Context) (*Config, *Wallet, *ethutils.RPCEthClient, *
 	AddL1PostingStrategyOptions(f, "node.sequencer.")
 	AddL1PostingStrategyOptions(f, "validator.")
 
+	f.String("validator.wallet-address-filename", "", "json file that validator smart contract wallet address is stored in")
+	f.String("validator.wallet-address", "", "validator smart contract wallet public address")
 	f.String("validator.strategy", "StakeLatest", "strategy for validator to use")
 	f.String("validator.utils-address", "", "validator utilities address")
 	f.Duration("validator.staker-delay", 60*time.Second, "delay between updating stake")


### PR DESCRIPTION
* Fix currently fireblocks feedsigner setup
* If validator auth needed, creat before reading database so any wallet errors return quicker
* if validator configured and only-create-key option set, create validator smart contract wallet right away instead of waiting until needed
* Add `--validator.wallet-address` and `--validator.wallet-address-filename` to easily specify validator smart contract wallet address