### PR TITLE
Fix typo in Nitro node docs latest docker image

### DIFF
--- a/docs/Running_Nitro_Node.md
+++ b/docs/Running_Nitro_Node.md
@@ -6,7 +6,7 @@ sidebar_label: Running a Nitro Node
 
 ### Required Artifacts
 
-- Latest Docker Image: offchainlabs/nitro_node:v2.0.0-alpha.2
+- Latest Docker Image: `offchainlabs/nitro-node:v2.0.0-alpha.2`
 
 ### Required parameter
 


### PR DESCRIPTION
This changes the underscore to a dash, and adds code formatting.