### PR TITLE
Handle core machine thread errors

### DIFF
--- a/packages/arb-avm-cpp/avm/src/machinethread.cpp
+++ b/packages/arb-avm-cpp/avm/src/machinethread.cpp
@@ -99,7 +99,14 @@ void MachineThread::clearError() {
 }
 
 void MachineThread::operator()() {
-    last_assertion = run();
+    try {
+        last_assertion = run();
+    } catch (const std::exception& e) {
+        machine_error_string = e.what();
+        machine_status = MACHINE_ERROR;
+        return;
+    }
+
     if (machine_status == MACHINE_RUNNING) {
         machine_status = MACHINE_SUCCESS;
     }

--- a/packages/arb-avm-cpp/cavm/carbstorage.cpp
+++ b/packages/arb-avm-cpp/cavm/carbstorage.cpp
@@ -37,6 +37,8 @@ CArbStorage* createArbStorage(const char* db_path,
     coreConfig.message_process_count = arb_core_config.message_process_count;
     coreConfig.add_messages_max_failure_count =
         arb_core_config.add_messages_max_failure_count;
+    coreConfig.thread_max_failure_count =
+        arb_core_config.thread_max_failure_count;
     coreConfig.checkpoint_load_gas_cost =
         arb_core_config.checkpoint_load_gas_cost;
     coreConfig.checkpoint_load_gas_factor =

--- a/packages/arb-avm-cpp/cavm/carbstorage.h
+++ b/packages/arb-avm-cpp/cavm/carbstorage.h
@@ -29,6 +29,7 @@ extern "C" {
 typedef struct {
     int32_t message_process_count;
     int32_t add_messages_max_failure_count;
+    int32_t thread_max_failure_count;
     int32_t checkpoint_load_gas_cost;
     int32_t checkpoint_load_gas_factor;
     int32_t checkpoint_max_execution_gas;

--- a/packages/arb-avm-cpp/cmachine/storage.go
+++ b/packages/arb-avm-cpp/cmachine/storage.go
@@ -75,6 +75,7 @@ func NewArbStorage(dbPath string, coreConfig *configuration.Core) (*ArbStorage, 
 	cConfig := C.CArbCoreConfig{
 		message_process_count:          C.int(coreConfig.MessageProcessCount),
 		add_messages_max_failure_count: C.int(coreConfig.AddMessagesMaxFailureCount),
+		thread_max_failure_count:       C.int(coreConfig.ThreadMaxFailureCount),
 		checkpoint_load_gas_cost:       C.int(coreConfig.CheckpointLoadGasCost),
 		checkpoint_load_gas_factor:     C.int(coreConfig.CheckpointLoadGasFactor),
 		checkpoint_max_execution_gas:   C.int(coreConfig.CheckpointMaxExecutionGas),

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
@@ -107,6 +107,7 @@ class ArbCore {
         uint256_t next_checkpoint_gas;
         uint256_t next_basic_cache_gas;
         uint32_t add_messages_failure_count;
+        uint32_t thread_failure_count;
         std::chrono::time_point<std::chrono::steady_clock>
             next_rocksdb_save_timepoint;
         std::chrono::time_point<std::chrono::steady_clock>
@@ -129,6 +130,7 @@ class ArbCore {
               next_checkpoint_gas(_next_checkpoint_gas),
               next_basic_cache_gas(_next_basic_cache_gas),
               add_messages_failure_count(0),
+              thread_failure_count(0),
               next_rocksdb_save_timepoint(),
               profiling_begin_timepoint(std::chrono::steady_clock::now()),
               last_messages_ready_check_timepoint(profiling_begin_timepoint),
@@ -228,7 +230,8 @@ class ArbCore {
     std::variant<rocksdb::Status, MachineStateKeys> getCheckpointUsingGas(
         ReadTransaction& tx,
         const uint256_t& total_gas);
-    rocksdb::Status reorgToLastMessage(ValueCache& cache);
+    rocksdb::Status reorgToLastCheckpoint(ValueCache& cache);
+    rocksdb::Status reorgToPenultimateCheckpoint(ValueCache& cache);
     rocksdb::Status reorgToL1Block(const uint256_t& l1_block_number,
                                    bool initial_start,
                                    ValueCache& cache);

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/util.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/util.hpp
@@ -26,6 +26,9 @@ struct ArbCoreConfig {
     // Number of consecutive addMessages failures before thread exits
     uint32_t add_messages_max_failure_count{0};
 
+    // Number of consecutive core thread failures before thread exits
+    uint32_t thread_max_failure_count{0};
+
     // Time it takes to run checkpoint for given gas
     // is equivalent to the time it takes to load checkpoing from database
     uint256_t checkpoint_load_gas_cost{1'000'000};

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -562,14 +562,19 @@ func updatePrunePoint(ctx context.Context, rollup *ethbridge.RollupWatcher, look
 	// Prune any stale database entries while we wait
 	latestNode, err := rollup.LatestConfirmedNode(ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "couldn't get latest confirmed node")
+	}
+
+	if latestNode.Cmp(big.NewInt(0)) == 0 {
+		logger.Info().Msg("no confirmed nodes so nothing to prune")
+		return nil
 	}
 
 	// Prune checkpoints up to confirmed node before last confirmed node
 	previousConfirmedNode := new(big.Int).Sub(latestNode, big.NewInt(1))
 	previousNodeInfo, err := rollup.LookupNode(ctx, previousConfirmedNode)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "couldn't lookup previous confirmed node "+previousConfirmedNode.String())
 	}
 
 	confirmedGas := previousNodeInfo.AfterState().TotalGasConsumed

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -69,6 +69,7 @@ type Database struct {
 
 type Core struct {
 	AddMessagesMaxFailureCount int           `koanf:"add-messages-max-failure-count"`
+	ThreadMaxFailureCount      int           `koanf:"thread-max-failure-count"`
 	Cache                      CoreCache     `koanf:"cache"`
 	CheckpointGasFrequency     int           `koanf:"checkpoint-gas-frequency"`
 	CheckpointLoadGasCost      int           `koanf:"checkpoint-load-gas-cost"`
@@ -850,6 +851,7 @@ func AddCore(f *flag.FlagSet, maxExecutionGas int) {
 	f.Duration("core.cache.timed-expire", 20*time.Minute, "length of time to hold L2 blocks in arbcore timed memory cache")
 
 	f.Int("core.add-messages-max-failure-count", 10, "number of add messages failures before exiting program")
+	f.Int("core.thread-max-failure-count", 0, "number of core thread failures before exiting program, 0 to ignore errors")
 	f.Int("core.checkpoint-gas-frequency", 1_000_000_000, "amount of gas between saving checkpoints")
 	f.Int("core.checkpoint-load-gas-cost", 250_000_000, "running machine for given gas takes same amount of time as loading database entry")
 	f.Int("core.checkpoint-load-gas-factor", 4, "factor to weight difference in database checkpoint vs cache checkpoint")


### PR DESCRIPTION
* Handle exceptions in machinethread
* Retry with progressively older database checkpoint when machine error or invalid machine
* To avoid any race conditions, ensure that database changes are committed before saving core thread to cache