### PR TITLE
Ensure sane validator settings

### DIFF
--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -123,7 +123,7 @@ func startup() error {
 		((len(config.Node.Sequencer.Lockout.Redis) == 0) != (len(config.Node.Sequencer.Lockout.SelfRPCURL) == 0)) {
 		printSampleUsage()
 		if err != nil && !strings.Contains(err.Error(), "help requested") {
-			fmt.Printf("%s\n", err.Error())
+			fmt.Printf("\n%s\n", err.Error())
 		}
 
 		return nil

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -747,6 +747,8 @@ func ParseNonRelay(ctx context.Context, f *flag.FlagSet, defaultWalletPathname s
 	if out.Node.Type() == SequencerNodeType && !out.Core.Cache.Last {
 		logger.Info().Msg("enabling last machine cache for sequencer")
 		out.Core.Cache.Last = true
+	} else if out.Node.Type() == ValidatorNodeType && out.Validator.OnlyCreateWalletContract && out.Validator.Strategy() == WatchtowerStrategy {
+		return nil, nil, nil, nil, errors.New("can't create validator wallet contract with watchtower validator strategy")
 	}
 
 	return out, wallet, l1Client, l1ChainId, nil


### PR DESCRIPTION
Terminate program If validator watchtower mode and only-create-wallet-contract set.  This is because watchtower does not need wallet, but can't create wallet contract without wallet