### PR TITLE
While executing machine, periodically `sleep(0)`

### DIFF
--- a/packages/arb-avm-cpp/avm/src/machine.cpp
+++ b/packages/arb-avm-cpp/avm/src/machine.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <iostream>
+#include <thread>
 
 #include <avm/inboxmessage.hpp>
 #include <avm/machine.hpp>
@@ -77,11 +78,14 @@ Assertion Machine::run() {
     uint256_t initialConsumed = machine_state.getTotalMessagesRead();
     uint32_t delayAbortCheckCounter = 0;
     while (true) {
-        if (delayAbortCheckCounter >= 100) {
+        if (delayAbortCheckCounter >= 1000000) {
             if (is_aborted.load(std::memory_order_relaxed)) {
                 break;
             }
             delayAbortCheckCounter = 0;
+
+            // Allow other threads to run
+            std::this_thread::sleep_for(std::chrono::seconds(0));
         }
         delayAbortCheckCounter++;
         if (has_gas_limit) {

--- a/packages/arb-avm-cpp/avm/src/machine.cpp
+++ b/packages/arb-avm-cpp/avm/src/machine.cpp
@@ -85,7 +85,7 @@ Assertion Machine::run() {
             delayAbortCheckCounter = 0;
 
             // Allow other threads to run
-            std::this_thread::sleep_for(std::chrono::seconds(0));
+            std::this_thread::yield();
         }
         delayAbortCheckCounter++;
         if (has_gas_limit) {


### PR DESCRIPTION
When handling a large number of concurrent executionCursor requests, the tight machine loops can hog all the processors, preventing other things from being handled, like keeping up with the chain.  Add a periodic `sleep(0)` which will allow more of a fair scheduling across all of the threads.