### PR TITLE
Fix RocksDB column family options initialization

### DIFF
--- a/packages/arb-avm-cpp/data_storage/src/datastorage.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/datastorage.cpp
@@ -33,10 +33,10 @@ DataStorage::DataStorage(const std::string& db_path,
     auto lock = tryLockShared();
 
     rocksdb::TransactionDBOptions txn_options{};
-    rocksdb::Options options{};
-    rocksdb::ColumnFamilyOptions cf_options{};
-    rocksdb::ColumnFamilyOptions small_cf_options{};
-    rocksdb::ColumnFamilyOptions hashkey_cf_options{};
+    rocksdb::Options options;
+    rocksdb::ColumnFamilyOptions cf_options;
+    rocksdb::ColumnFamilyOptions small_cf_options;
+    rocksdb::ColumnFamilyOptions hashkey_cf_options;
     rocksdb::BlockBasedTableOptions table_options{};
     options.create_if_missing = true;
     options.create_missing_column_families = true;


### PR DESCRIPTION
I believe the ColumnFamilyOptions were previously initialized using "aggregate initialization": https://en.cppreference.com/w/cpp/language/aggregate_initialization

ColumnFamilyOptions provides a default constructor which we should use instead. As-is, on recent versions of rocksdb, it was instantiating shared pointers with uninitialized memory.