### PR TITLE
Cleanup `MachineThread`

### DIFF
--- a/packages/arb-avm-cpp/avm/include/avm/machine.hpp
+++ b/packages/arb-avm-cpp/avm/include/avm/machine.hpp
@@ -79,7 +79,7 @@ class Machine {
         machine_state = std::move(machine.machine_state);
         return *this;
     }
-    ~Machine() = default;
+    virtual ~Machine() { abort(); };
 
     static Machine loadFromFile(const std::string& executable_filename) {
         return Machine{MachineState::loadFromFile(executable_filename)};

--- a/packages/arb-avm-cpp/avm/include/avm/machinethread.hpp
+++ b/packages/arb-avm-cpp/avm/include/avm/machinethread.hpp
@@ -48,13 +48,14 @@ class MachineThread : public Machine {
     Assertion last_assertion;
 
    public:
-    ~MachineThread() { abort(); }
+    virtual ~MachineThread() { abort(); }
     explicit MachineThread(MachineState machine_state_)
         : Machine(std::move(machine_state_)),
           reorg_check_data(machine_state.output.fully_processed_inbox) {}
 
     bool runMachine(MachineExecutionConfig config, bool asynchronous);
     bool continueRunningMachine(bool asynchronous);
+    void finishThread();
     virtual void abort();
     machine_status_enum status();
     std::string getErrorString();

--- a/packages/arb-avm-cpp/avm/src/machinethread.cpp
+++ b/packages/arb-avm-cpp/avm/src/machinethread.cpp
@@ -24,7 +24,14 @@ MachineThread::machine_status_enum MachineThread::status() {
 
 bool MachineThread::runMachine(MachineExecutionConfig config,
                                bool asynchronous) {
-    finishThread();
+    if (machine_status == MACHINE_RUNNING) {
+        if (asynchronous) {
+            // Core machine already running
+            return true;
+        }
+
+        finishThread();
+    }
     if (machine_status != MACHINE_NONE) {
         return false;
     }

--- a/packages/arb-avm-cpp/avm/src/machinethread.cpp
+++ b/packages/arb-avm-cpp/avm/src/machinethread.cpp
@@ -24,15 +24,11 @@ MachineThread::machine_status_enum MachineThread::status() {
 
 bool MachineThread::runMachine(MachineExecutionConfig config,
                                bool asynchronous) {
-    if (machine_status == MACHINE_RUNNING) {
-        if (asynchronous) {
-            // Core machine already running
-            return true;
-        }
-
-        finishThread();
-    }
     if (machine_status != MACHINE_NONE) {
+        if (machine_status == MACHINE_RUNNING) {
+            throw std::runtime_error(
+                "runMachine called when machine already running");
+        }
         return false;
     }
 
@@ -56,8 +52,11 @@ bool MachineThread::runMachine(MachineExecutionConfig config,
 }
 
 bool MachineThread::continueRunningMachine(bool asynchronous) {
-    finishThread();
     if (machine_status != MACHINE_NONE) {
+        if (machine_status == MACHINE_RUNNING) {
+            throw std::runtime_error(
+                "continueRunningMachine called when machine already running");
+        }
         return false;
     }
 

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/executioncursor.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/executioncursor.hpp
@@ -84,8 +84,10 @@ class ExecutionCursor {
     bool isAborted() { return is_aborted.load(); }
 
     [[nodiscard]] std::optional<uint256_t> machineHash() const {
-        if (std::holds_alternative<std::unique_ptr<Machine>>(machine) &&
-            std::get<std::unique_ptr<Machine>>(machine) != nullptr) {
+        if (std::holds_alternative<std::unique_ptr<Machine>>(machine)) {
+            if (std::get<std::unique_ptr<Machine>>(machine) == nullptr) {
+                throw std::runtime_error("machine unique_ptr is null");
+            }
             return std::get<std::unique_ptr<Machine>>(machine)->hash();
         } else {
             return std::get<MachineStateKeys>(machine).machineHash();
@@ -93,8 +95,10 @@ class ExecutionCursor {
     }
 
     [[nodiscard]] const MachineOutput& getOutput() const {
-        if (std::holds_alternative<std::unique_ptr<Machine>>(machine) &&
-            std::get<std::unique_ptr<Machine>>(machine) != nullptr) {
+        if (std::holds_alternative<std::unique_ptr<Machine>>(machine)) {
+            if (std::get<std::unique_ptr<Machine>>(machine) == nullptr) {
+                throw std::runtime_error("machine unique_ptr is null");
+            }
             return std::get<std::unique_ptr<Machine>>(machine)
                 ->machine_state.output;
         } else {

--- a/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
@@ -1458,10 +1458,7 @@ void ArbCore::printCoreThreadBacktrace() {
 bool ArbCore::reorgIfInvalidMachine(uint32_t& thread_failure_count,
                                     uint256_t& next_checkpoint_gas,
                                     ValueCache& cache) {
-    if (core_machine->status() == MachineThread::MACHINE_RUNNING) {
-        // Just continue
-        return true;
-    }
+    core_machine->finishThread();
 
     bool isMachineValid;
     if (core_machine->status() == MachineThread::MACHINE_ERROR) {

--- a/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
@@ -1458,8 +1458,6 @@ void ArbCore::printCoreThreadBacktrace() {
 bool ArbCore::reorgIfInvalidMachine(uint32_t& thread_failure_count,
                                     uint256_t& next_checkpoint_gas,
                                     ValueCache& cache) {
-    core_machine->finishThread();
-
     bool isMachineValid;
     if (core_machine->status() == MachineThread::MACHINE_ERROR) {
         std::cerr << "Attempting to recover from AVM machine error: "


### PR DESCRIPTION
* Finish pending thread if trying to start new machine thread
* Avoid dereferencing nullptr
* make `Machine` and `MachineThread` destructor virtual