### PR TITLE
Fix broadcaster deadlock

### DIFF
--- a/packages/arb-node-core/cmd/arb-relay/arb-relay.go
+++ b/packages/arb-node-core/cmd/arb-relay/arb-relay.go
@@ -125,7 +125,7 @@ func NewArbRelay(settings configuration.Feed) *ArbRelay {
 		broadcastClients = append(broadcastClients, client)
 	}
 	return &ArbRelay{
-		broadcaster:              broadcaster.NewBroadcaster(settings.Output),
+		broadcaster:              broadcaster.NewBroadcaster(&settings.Output),
 		broadcastClients:         broadcastClients,
 		confirmedAccumulatorChan: confirmedAccumulatorChan,
 	}

--- a/packages/arb-node-core/cmd/arb-relay/arb-relay_test.go
+++ b/packages/arb-node-core/cmd/arb-relay/arb-relay_test.go
@@ -33,15 +33,8 @@ func TestRelayRebroadcasts(t *testing.T) {
 	ctx := context.Background()
 
 	// Start up an Arbitrum sequencer broadcaster
-	broadcasterSettings := configuration.FeedOutput{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "9742",
-		Ping:          5 * time.Second,
-		ClientTimeout: 15 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	broadcasterSettings := configuration.DefaultFeedOutput()
+	broadcasterSettings.Port = "9742"
 
 	bc := broadcaster.NewBroadcaster(broadcasterSettings)
 
@@ -56,16 +49,9 @@ func TestRelayRebroadcasts(t *testing.T) {
 			Timeout: 20 * time.Second,
 			URLs:    []string{"ws://127.0.0.1:9742"},
 		},
-		Output: configuration.FeedOutput{
-			Addr:          "0.0.0.0",
-			IOTimeout:     2 * time.Second,
-			Port:          "7429",
-			Ping:          5 * time.Second,
-			ClientTimeout: 15 * time.Second,
-			Queue:         1,
-			Workers:       128,
-		},
+		Output: *configuration.DefaultFeedOutput(),
 	}
+	relaySettings.Output.Port = "7429"
 
 	// Start up an arbitrum sequencer relay
 	arbRelay := NewArbRelay(relaySettings)

--- a/packages/arb-rpc-node/cmd/arb-dev-sequencer/arb-dev-sequencer.go
+++ b/packages/arb-rpc-node/cmd/arb-dev-sequencer/arb-dev-sequencer.go
@@ -101,20 +101,13 @@ func startup() error {
 	config := configuration.Config{
 		Core: *configuration.DefaultCoreSettingsMaxExecution(),
 		Feed: configuration.Feed{
-			Output: configuration.FeedOutput{
-				Addr:          "127.0.0.1",
-				IOTimeout:     2 * time.Second,
-				Port:          "9642",
-				Ping:          5 * time.Second,
-				ClientTimeout: 15 * time.Second,
-				Queue:         1,
-				Workers:       2,
-			},
+			Output: *configuration.DefaultFeedOutput(),
 		},
 		Node: *configuration.DefaultNodeSettings(),
 	}
 	config.Node.Sequencer.CreateBatchBlockInterval = *createBatchBlockInterval
 	config.Node.Sequencer.DelayedMessagesTargetDelay = *delayedMessagesTargetDelay
+	config.Feed.Output.Workers = 2
 
 	//go http.ListenAndServe("localhost:6060", nil)
 

--- a/packages/arb-rpc-node/rpc/launch.go
+++ b/packages/arb-rpc-node/rpc/launch.go
@@ -140,7 +140,7 @@ func SetupBatcher(
 		if err != nil {
 			return nil, err
 		}
-		feedBroadcaster := broadcaster.NewBroadcaster(config.Feed.Output)
+		feedBroadcaster := broadcaster.NewBroadcaster(&config.Feed.Output)
 		seqBatcher, err := batcher.NewSequencerBatcher(
 			ctx,
 			batcherMode.Core,

--- a/packages/arb-util/broadcastclient/broadcastclient_test.go
+++ b/packages/arb-util/broadcastclient/broadcastclient_test.go
@@ -29,15 +29,8 @@ import (
 func TestReceiveMessages(t *testing.T) {
 	ctx := context.Background()
 
-	settings := configuration.FeedOutput{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "9742",
-		Ping:          5 * time.Second,
-		ClientTimeout: 20 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	settings := configuration.DefaultFeedOutput()
+	settings.Port = "9742"
 
 	messageCount := 1000
 	messageDelay := 0 * time.Millisecond
@@ -106,15 +99,10 @@ func startMakeBroadcastClient(ctx context.Context, t *testing.T, index int, expe
 func TestServerClientDisconnect(t *testing.T) {
 	ctx := context.Background()
 
-	settings := configuration.FeedOutput{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "9743",
-		Ping:          1 * time.Second,
-		ClientTimeout: 2 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	settings := configuration.DefaultFeedOutput()
+	settings.Port = "9743"
+	settings.Ping = 1 * time.Second
+	settings.ClientTimeout = 2 * time.Second
 
 	b := broadcaster.NewBroadcaster(settings)
 
@@ -162,15 +150,10 @@ func TestServerClientDisconnect(t *testing.T) {
 func TestBroadcastClientReconnectsOnServerDisconnect(t *testing.T) {
 	ctx := context.Background()
 
-	settings := configuration.FeedOutput{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "9743",
-		Ping:          50 * time.Second,
-		ClientTimeout: 150 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	settings := configuration.DefaultFeedOutput()
+	settings.Port = "9743"
+	settings.Ping = 50 * time.Second
+	settings.ClientTimeout = 150 * time.Second
 
 	b1 := broadcaster.NewBroadcaster(settings)
 
@@ -200,15 +183,8 @@ func TestBroadcastClientReconnectsOnServerDisconnect(t *testing.T) {
 func TestBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
 	ctx := context.Background()
 
-	settings := configuration.FeedOutput{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "9842",
-		Ping:          5 * time.Second,
-		ClientTimeout: 15 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	settings := configuration.DefaultFeedOutput()
+	settings.Port = "9842"
 
 	b := broadcaster.NewBroadcaster(settings)
 

--- a/packages/arb-util/broadcaster/broadcaster.go
+++ b/packages/arb-util/broadcaster/broadcaster.go
@@ -38,7 +38,7 @@ type Broadcaster struct {
 	prevConfirmedAcc common.Hash
 }
 
-func NewBroadcaster(settings configuration.FeedOutput) *Broadcaster {
+func NewBroadcaster(settings *configuration.FeedOutput) *Broadcaster {
 	catchupBuffer := NewConfirmedAccumulatorCatchupBuffer()
 	return &Broadcaster{
 		server:        wsbroadcastserver.NewWSBroadcastServer(settings, catchupBuffer),

--- a/packages/arb-util/broadcaster/broadcaster_test.go
+++ b/packages/arb-util/broadcaster/broadcaster_test.go
@@ -35,15 +35,7 @@ import (
 func TestBroadcasterSendsConfirmedAccumulatorMessages(t *testing.T) {
 	ctx := context.Background()
 
-	broadcasterSettings := configuration.FeedOutput{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "9642",
-		Ping:          5 * time.Second,
-		ClientTimeout: 20 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	broadcasterSettings := configuration.DefaultFeedOutput()
 
 	b := NewBroadcaster(broadcasterSettings)
 
@@ -156,15 +148,8 @@ func TestBroadcasterRespondsToPing(t *testing.T) {
 	t.Skip("Server is not responding to ping anymore")
 	ctx := context.Background()
 
-	broadcasterSettings := configuration.FeedOutput{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "9643",
-		Ping:          5 * time.Second,
-		ClientTimeout: 20 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	broadcasterSettings := configuration.DefaultFeedOutput()
+	broadcasterSettings.Port = "9643"
 
 	b := NewBroadcaster(broadcasterSettings)
 
@@ -214,15 +199,8 @@ func TestBroadcasterReorganizesCacheBasedOnAccumulator(t *testing.T) {
 	ctx, cancelFunc, _ := cmdhelp.CreateLaunchContext()
 	defer cancelFunc()
 
-	broadcasterSettings := configuration.FeedOutput{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "9642",
-		Ping:          5 * time.Second,
-		ClientTimeout: 30 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	broadcasterSettings := configuration.DefaultFeedOutput()
+	broadcasterSettings.ClientTimeout = 30
 
 	b := NewBroadcaster(broadcasterSettings)
 

--- a/packages/arb-util/broadcaster/broadcasterload_test.go
+++ b/packages/arb-util/broadcaster/broadcasterload_test.go
@@ -36,15 +36,8 @@ var ClientCount = 10
 func TestBroadcasterLoad(t *testing.T) {
 	ctx := context.Background()
 
-	broadcasterSettings := configuration.FeedOutput{
-		Addr:          "0.0.0.0",
-		IOTimeout:     2 * time.Second,
-		Port:          "9942",
-		Ping:          5 * time.Second,
-		ClientTimeout: 15 * time.Second,
-		Queue:         1,
-		Workers:       128,
-	}
+	broadcasterSettings := configuration.DefaultFeedOutput()
+	broadcasterSettings.Port = "9942"
 
 	b := NewBroadcaster(broadcasterSettings)
 

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -125,6 +125,20 @@ type FeedOutput struct {
 	ClientTimeout time.Duration `koanf:"client-timeout"`
 	Queue         int           `koanf:"queue"`
 	Workers       int           `koanf:"workers"`
+	MaxSendQueue  int           `koanf:"max-send-queue"`
+}
+
+func DefaultFeedOutput() *FeedOutput {
+	return &FeedOutput{
+		Addr:          "0.0.0.0",
+		IOTimeout:     5 * time.Second,
+		Port:          "9642",
+		Ping:          5 * time.Second,
+		ClientTimeout: 15 * time.Second,
+		Queue:         1,
+		Workers:       128,
+		MaxSendQueue:  4096,
+	}
 }
 
 type Feed struct {
@@ -833,10 +847,11 @@ func ParseRelay() (*Config, error) {
 func AddFeedOutputOptions(f *flag.FlagSet) {
 	f.String("feed.output.addr", "0.0.0.0", "address to bind the relay feed output to")
 	f.Duration("feed.output.io-timeout", 5*time.Second, "duration to wait before timing out HTTP to WS upgrade")
-	f.Int("feed.output.port", 9642, "port to bind the relay feed output to")
+	f.String("feed.output.port", "9642", "port to bind the relay feed output to")
 	f.Duration("feed.output.ping", 5*time.Second, "duration for ping interval")
-	f.Duration("feed.output.client-timeout", 15*time.Second, "duraction to wait before timing out connections to client")
+	f.Duration("feed.output.client-timeout", 15*time.Second, "duration to wait before timing out connections to client")
 	f.Int("feed.output.workers", 100, "Number of threads to reserve for HTTP to WS upgrade")
+	f.Int("feed.output.max-send-queue", 4096, "Maximum number of messages allowed to accumulate before client is disconnected")
 }
 
 func AddForwarderTarget(f *flag.FlagSet) {

--- a/packages/arb-util/wsbroadcastserver/clientconnection.go
+++ b/packages/arb-util/wsbroadcastserver/clientconnection.go
@@ -31,10 +31,6 @@ import (
 	"github.com/mailru/easygo/netpoll"
 )
 
-// MaxSendQueue is the maximum number of items in a clients out channel before client gets disconnected.
-// If set too low, a burst of items will cause all clients to be disconnected
-const MaxSendQueue = 1000
-
 // ClientConnection represents client connection.
 type ClientConnection struct {
 	ioMutex sync.Mutex
@@ -47,6 +43,7 @@ type ClientConnection struct {
 	lastHeardUnix int64
 	cancelFunc    context.CancelFunc
 	out           chan []byte
+	maxSendQueue  int
 }
 
 func NewClientConnection(conn net.Conn, desc *netpoll.Desc, clientManager *ClientManager) *ClientConnection {
@@ -56,7 +53,7 @@ func NewClientConnection(conn net.Conn, desc *netpoll.Desc, clientManager *Clien
 		Name:          conn.RemoteAddr().String() + strconv.Itoa(rand.Intn(10)),
 		clientManager: clientManager,
 		lastHeardUnix: time.Now().Unix(),
-		out:           make(chan []byte, MaxSendQueue),
+		out:           make(chan []byte, clientManager.maxSendQueue),
 	}
 }
 

--- a/packages/arb-util/wsbroadcastserver/clientmanager.go
+++ b/packages/arb-util/wsbroadcastserver/clientmanager.go
@@ -165,7 +165,7 @@ func (cm *ClientManager) doBroadcast(bm interface{}) ([]*ClientConnection, error
 	for client := range cm.clientPtrMap {
 		if len(client.out) >= cm.maxSendQueue {
 			// Queue for client too backed up, disconnect instead of blocking on channel send
-			logger.Error().Str("client", client.Name).Int("sendQueue", len(client.out)).Msg("disconnecting because sendQueue too large")
+			logger.Info().Str("client", client.Name).Int("sendQueue", len(client.out)).Msg("disconnecting because sendQueue too large")
 			clientDeleteList = append(clientDeleteList, client)
 		} else {
 			client.out <- buf.Bytes()
@@ -192,7 +192,7 @@ func (cm *ClientManager) verifyClients() []*ClientConnection {
 		} else {
 			err := client.Ping()
 			if err != nil {
-				logger.Warn().Str("client", client.Name).Msg("disconnecting because error pinging client")
+				logger.Info().Str("client", client.Name).Msg("disconnecting because error pinging client")
 				clientDeleteList = append(clientDeleteList, client)
 			}
 		}

--- a/packages/arb-util/wsbroadcastserver/clientmanager.go
+++ b/packages/arb-util/wsbroadcastserver/clientmanager.go
@@ -51,6 +51,7 @@ type ClientManager struct {
 	clientAction  chan ClientConnectionAction
 	settings      configuration.FeedOutput
 	catchupBuffer CatchupBuffer
+	maxSendQueue  int
 }
 
 type ClientConnectionAction struct {
@@ -67,6 +68,7 @@ func NewClientManager(poller netpoll.Poller, settings configuration.FeedOutput, 
 		clientAction:  make(chan ClientConnectionAction, 128),
 		settings:      settings,
 		catchupBuffer: catchupBuffer,
+		maxSendQueue:  settings.MaxSendQueue,
 	}
 }
 
@@ -144,65 +146,59 @@ func (cm *ClientManager) Broadcast(bm interface{}) {
 	cm.broadcastChan <- bm
 }
 
-func (cm *ClientManager) doBroadcast(bm interface{}) error {
+func (cm *ClientManager) doBroadcast(bm interface{}) ([]*ClientConnection, error) {
 	if err := cm.catchupBuffer.OnDoBroadcast(bm); err != nil {
-		return err
+		return nil, err
 	}
 
 	var buf bytes.Buffer
 	writer := wsutil.NewWriter(&buf, ws.StateServerSide, ws.OpText)
 	encoder := json.NewEncoder(writer)
 	if err := encoder.Encode(bm); err != nil {
-		return errors.Wrap(err, "unable to encode message")
+		return nil, errors.Wrap(err, "unable to encode message")
 	}
 	if err := writer.Flush(); err != nil {
-		return errors.Wrap(err, "unable to flush message")
+		return nil, errors.Wrap(err, "unable to flush message")
 	}
 
 	clientDeleteList := make([]*ClientConnection, 0, len(cm.clientPtrMap))
 	for client := range cm.clientPtrMap {
-		if len(client.out) == MaxSendQueue {
-			// Queue for client too backed up, so delete after going through all other clients
+		if len(client.out) >= cm.maxSendQueue {
+			// Queue for client too backed up, disconnect instead of blocking on channel send
+			logger.Error().Str("client", client.Name).Int("sendQueue", len(client.out)).Msg("disconnecting because sendQueue too large")
 			clientDeleteList = append(clientDeleteList, client)
 		} else {
 			client.out <- buf.Bytes()
 		}
 	}
 
-	for _, client := range clientDeleteList {
-		logger.Warn().Str("client", client.Name).Msg("disconnecting client, queue too large")
-		cm.Remove(client)
-	}
-
-	return nil
+	return clientDeleteList, nil
 }
 
 // verifyClients should be called every cm.settings.ClientPingInterval
-func (cm *ClientManager) verifyClients() {
+func (cm *ClientManager) verifyClients() []*ClientConnection {
 	clientConnectionCount := len(cm.clientPtrMap)
 
-	// Create list of clients to clients to remove
-	deadClientList := make([]*ClientConnection, 0, clientConnectionCount)
+	// Create list of clients to remove
+	clientDeleteList := make([]*ClientConnection, 0, clientConnectionCount)
+
+	// Send ping to all connected clients
+	logger.Debug().Int("count", len(cm.clientPtrMap)).Msg("pinging clients")
 	for client := range cm.clientPtrMap {
 		diff := time.Since(client.GetLastHeard())
 		if diff > cm.settings.ClientTimeout {
-			deadClientList = append(deadClientList, client)
+			logger.Debug().Str("client", client.Name).Msg("disconnecting because connection timed out")
+			clientDeleteList = append(clientDeleteList, client)
+		} else {
+			err := client.Ping()
+			if err != nil {
+				logger.Warn().Str("client", client.Name).Msg("disconnecting because error pinging client")
+				clientDeleteList = append(clientDeleteList, client)
+			}
 		}
 	}
 
-	for _, deadClient := range deadClientList {
-		logger.Debug().Str("client", deadClient.Name).Msg("disconnecting because connection timed out")
-		cm.Remove(deadClient)
-	}
-
-	// Send ping to all remaining clients
-	logger.Debug().Int("count", len(cm.clientPtrMap)).Msg("pinging clients")
-	for client := range cm.clientPtrMap {
-		err := client.Ping()
-		if err != nil {
-			logWarn(err, "error pinging client")
-		}
-	}
+	return clientDeleteList
 }
 
 func (cm *ClientManager) Stop() {
@@ -219,6 +215,7 @@ func (cm *ClientManager) Start(parentCtx context.Context) {
 
 		pingInterval := time.NewTicker(cm.settings.Ping)
 		defer pingInterval.Stop()
+		var clientDeleteList []*ClientConnection
 		for {
 			select {
 			case <-ctx.Done():
@@ -234,12 +231,20 @@ func (cm *ClientManager) Start(parentCtx context.Context) {
 					cm.removeClient(clientAction.cc)
 				}
 			case bm := <-cm.broadcastChan:
-				err := cm.doBroadcast(bm)
+				var err error
+				clientDeleteList, err = cm.doBroadcast(bm)
 				if err != nil {
 					logError(err, "failed to do a broadcast")
 				}
 			case <-pingInterval.C:
-				cm.verifyClients()
+				clientDeleteList = cm.verifyClients()
+			}
+
+			if len(clientDeleteList) > 0 {
+				for _, client := range clientDeleteList {
+					cm.removeClient(client)
+				}
+				clientDeleteList = nil
 			}
 		}
 	}()

--- a/packages/arb-util/wsbroadcastserver/wsbroadcastserver.go
+++ b/packages/arb-util/wsbroadcastserver/wsbroadcastserver.go
@@ -43,10 +43,10 @@ type WSBroadcastServer struct {
 	catchupBuffer CatchupBuffer
 }
 
-func NewWSBroadcastServer(settings configuration.FeedOutput, catchupBuffer CatchupBuffer) *WSBroadcastServer {
+func NewWSBroadcastServer(settings *configuration.FeedOutput, catchupBuffer CatchupBuffer) *WSBroadcastServer {
 	return &WSBroadcastServer{
 		startMutex:    &sync.Mutex{},
-		settings:      settings,
+		settings:      *settings,
 		started:       false,
 		catchupBuffer: catchupBuffer,
 	}


### PR DESCRIPTION
* Fix broadcaster deadlock when channel fills up with client connections to delete
* Increase default MaxSendQueue and make it a configurable option