### PR TITLE
Log L1 error after 10 warnings printed

### DIFF
--- a/packages/arb-rpc-node/batcher/batcher.go
+++ b/packages/arb-rpc-node/batcher/batcher.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 
 	"github.com/offchainlabs/arbitrum/packages/arb-evm/message"
 	"github.com/offchainlabs/arbitrum/packages/arb-rpc-node/snapshot"
@@ -203,7 +202,7 @@ func newBatcher(
 				server.Lock()
 				if server.pendingSentBatches.Len() > 0 {
 					if err := server.checkForNextBatch(ctx, receiptFetcher); err != nil {
-						log.Error().Err(err).Msg("error checking for submitted batch")
+						logger.Error().Err(err).Msg("error checking for submitted batch")
 					}
 				}
 				server.Unlock()

--- a/packages/arb-rpc-node/batcher/sequencerBatcher.go
+++ b/packages/arb-rpc-node/batcher/sequencerBatcher.go
@@ -893,16 +893,16 @@ func (b *SequencerBatcher) publishBatch(ctx context.Context, dontPublishBlockNum
 		doingReorg := b.consecutiveShouldReorgGaps >= 10
 
 		var msg string
-		var log *zerolog.Event
+		var partialLog *zerolog.Event
 		if doingReorg {
 			msg = "Exceeded max sequencer delay! Reorganizing to compensate..."
-			log = logger.Error()
+			partialLog = logger.Error()
 		} else {
 			msg = "Exceeded max sequencer delay! Waiting to see if this is consistent..."
-			log = logger.Warn()
+			partialLog = logger.Warn()
 		}
 
-		log.
+		partialLog.
 			Str("delayBlocks", delayBlocks.String()).
 			Str("delaySeconds", delaySeconds.String()).
 			Str("aheadBlocks", aheadBlocks.String()).


### PR DESCRIPTION
* First 10 log messages are warning level when L1 unable to be contacted.  Log messages after the first 10 are logged as error
* Normalize a few log calls that were not using per-project custom loggers