### PR TITLE
Miscellaneous ArbOS dumping changes

### DIFF
--- a/packages/arb-avm-cpp/cavm/cmachine.h
+++ b/packages/arb-avm-cpp/cavm/cmachine.h
@@ -91,9 +91,11 @@ void machineExecutionConfigSetStopOnSideload(CMachineExecutionConfig* c,
 void machineExecutionConfigSetStopOnBreakpoint(CMachineExecutionConfig* c,
                                                int stop_on_breakpoint);
 
-int dumpRetriables(CArbCore* a, CMachine* m, const char* filename);
+int dumpRetryables(CArbCore* a, CMachine* m, const char* filename);
 
 int dumpAccounts(CArbCore* a, CMachine* m, const char* filename);
+
+int dumpAddressTable(CArbCore* a, CMachine* m, const char* filename);
 
 #ifdef __cplusplus
 }

--- a/packages/arb-avm-cpp/cavm/dumpstate.cpp
+++ b/packages/arb-avm-cpp/cavm/dumpstate.cpp
@@ -262,13 +262,14 @@ void writeKvsToFile(ValueLoader loader,
     retryables.close();
 }
 
-int dumpRetriables(CArbCore* a, CMachine* m, const char* filename) {
+int dumpRetryables(CArbCore* a, CMachine* m, const char* filename) {
     assert(m);
     assert(a);
     auto mach = static_cast<Machine*>(m);
     auto arbCore = static_cast<ArbCore*>(a);
     std::string stringFileName(filename);
-    auto l = arbCore->makeValueLoader();
+    auto l = ValueLoader(
+        std::make_unique<SimpleValueLoader>(arbCore->getDataStorage()));
 
     auto root = resolveTuple(l, mach->machine_state.registerVal);
     auto accountStore = indexTup(l, indexTup(l, root, 6), 1);
@@ -285,7 +286,8 @@ int dumpAccounts(CArbCore* a, CMachine* m, const char* filename) {
     auto mach = static_cast<Machine*>(m);
     auto arbCore = static_cast<ArbCore*>(a);
     std::string stringFileName(filename);
-    auto l = arbCore->makeValueLoader();
+    auto l = ValueLoader(
+        std::make_unique<SimpleValueLoader>(arbCore->getDataStorage()));
 
     auto root = resolveTuple(l, mach->machine_state.registerVal);
     auto accountStore = indexTup(l, indexTup(l, root, 6), 1);
@@ -302,7 +304,8 @@ int dumpAddressTable(CArbCore* a, CMachine* m, const char* filename) {
     auto mach = static_cast<Machine*>(m);
     auto arbCore = static_cast<ArbCore*>(a);
     std::string stringFileName(filename);
-    auto l = arbCore->makeValueLoader();
+    auto l = ValueLoader(
+        std::make_unique<SimpleValueLoader>(arbCore->getDataStorage()));
 
     auto root = resolveTuple(l, mach->machine_state.registerVal);
     auto addressTable = indexTup(l, indexTup(l, root, 5), 4);

--- a/packages/arb-avm-cpp/cavm/dumpstate.cpp
+++ b/packages/arb-avm-cpp/cavm/dumpstate.cpp
@@ -138,6 +138,9 @@ void kvsNodeForAll(ValueLoader loader,
 
 template <typename F>
 void kvsForAll(ValueLoader loader, Tuple kvs, F&& func) {
+    if (kvs.tuple_size() != 2) {
+        throw std::runtime_error("kvs container tuple must have 2 elements");
+    }
     kvsNodeForAll(loader, kvs.get_element(0), false, parallelKvsLayers,
                   std::forward<F>(func));
 }
@@ -311,7 +314,7 @@ int dumpAddressTable(CArbCore* a, CMachine* m, const char* filename) {
     auto addressTable = indexTup(l, indexTup(l, root, 5), 4);
     auto addressKvs = indexTup(l, addressTable, 1);
 
-    writeKvsToFile(l, addressTable, stringFileName, serializeAddressKey);
+    writeKvsToFile(l, addressKvs, stringFileName, serializeAddressKey);
 
     return 0;
 }

--- a/packages/arb-avm-cpp/cmachine/arbcore.go
+++ b/packages/arb-avm-cpp/cmachine/arbcore.go
@@ -519,7 +519,7 @@ func (ac *ArbCore) DumpArbosState(m machine.Machine, dirname string) error {
 	defer C.free(unsafe.Pointer(caddresstablepath))
 	retval = C.dumpAddressTable(ac.c, mach.c, caddresstablepath)
 	if retval != 0 {
-		return errors.Errorf("dumpRetryables failed")
+		return errors.Errorf("dumpAddressTable failed")
 	}
 
 	return nil

--- a/packages/arb-avm-cpp/cmachine/arbcore.go
+++ b/packages/arb-avm-cpp/cmachine/arbcore.go
@@ -26,6 +26,7 @@ import "C"
 import (
 	"bytes"
 	"math/big"
+	"path/filepath"
 	"runtime"
 	"unsafe"
 
@@ -492,20 +493,35 @@ func (ac *ArbCore) TakeMachine(executionCursor core.ExecutionCursor) (machine.Ma
 	return ret, nil
 }
 
-func (ac *ArbCore) DumpAccounts(m machine.Machine, filename string) error {
+func (ac *ArbCore) DumpArbosState(m machine.Machine, dirname string) error {
 	defer runtime.KeepAlive(ac)
 	mach, ok := m.(*Machine)
 	if !ok {
 		return errors.Errorf("bad machine")
 	}
 	defer runtime.KeepAlive(mach)
-	cfname := C.CString(filename)
-	defer C.free(unsafe.Pointer(cfname))
 
-	retval := C.dumpAccounts(ac.c, mach.c, cfname)
+	caccountspath := C.CString(filepath.Join(dirname, "accounts.json"))
+	defer C.free(unsafe.Pointer(caccountspath))
+	retval := C.dumpAccounts(ac.c, mach.c, caccountspath)
 	if retval != 0 {
 		return errors.Errorf("dumpAccounts failed")
 	}
+
+	cretryablespath := C.CString(filepath.Join(dirname, "retryables.json"))
+	defer C.free(unsafe.Pointer(cretryablespath))
+	retval = C.dumpRetryables(ac.c, mach.c, cretryablespath)
+	if retval != 0 {
+		return errors.Errorf("dumpRetryables failed")
+	}
+
+	caddresstablepath := C.CString(filepath.Join(dirname, "addresstable.json"))
+	defer C.free(unsafe.Pointer(caddresstablepath))
+	retval = C.dumpAddressTable(ac.c, mach.c, caddresstablepath)
+	if retval != 0 {
+		return errors.Errorf("dumpRetryables failed")
+	}
+
 	return nil
 }
 

--- a/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
+++ b/packages/arb-avm-cpp/data_storage/include/data_storage/arbcore.hpp
@@ -314,9 +314,11 @@ class ArbCore {
     // Useful for unit tests
     uint256_t maxCheckpointGas();
 
-   public:
     // Controlling checkpoint pruning
     void updateCheckpointPruningGas(uint256_t gas);
+
+    // Useful for manual value loading
+    std::shared_ptr<DataStorage> getDataStorage();
 
    private:
     uint256_t getCheckpointPruningGas();

--- a/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
@@ -4015,6 +4015,10 @@ uint256_t ArbCore::getCheckpointPruningGas() {
     return unsafe_checkpoint_pruning_gas_used;
 }
 
+std::shared_ptr<DataStorage> ArbCore::getDataStorage() {
+    return data_storage;
+}
+
 std::string optionalUint256ToString(std::optional<uint256_t>& value) {
     if (!value.has_value()) {
         return "empty";

--- a/packages/arb-rpc-node/cmd/arb-block/dumpstate.go
+++ b/packages/arb-rpc-node/cmd/arb-block/dumpstate.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"path"
 
 	"github.com/offchainlabs/arbitrum/packages/arb-util/core"
 )
@@ -21,5 +20,5 @@ func dumpArbState(arbcore core.ArbCore, height uint64, dirname string) error {
 	if err != nil {
 		return err
 	}
-	return arbcore.DumpAccounts(machine, path.Join(dirname, "accounts.json"))
+	return arbcore.DumpArbosState(machine, dirname)
 }

--- a/packages/arb-util/core/lookup.go
+++ b/packages/arb-util/core/lookup.go
@@ -98,7 +98,7 @@ type ArbCoreLookup interface {
 	// SaveRocksdbCheckpoint tells rocksdb to save a copy of the current database state
 	SaveRocksdbCheckpoint()
 
-	DumpAccounts(mach machine.Machine, filename string) error
+	DumpArbosState(mach machine.Machine, dirname string) error
 }
 
 type ArbCoreInbox interface {


### PR DESCRIPTION
- Invoke retryable and address table dumping code
- Fix address table dumping code
- Use custom argument parsing code that doesn't require an L1 connection
- Enable lazy value loading
- Use custom value loader to fix memory leak