### PR TITLE
Fix block tracing

### DIFF
--- a/packages/arb-rpc-node/web3/trace.go
+++ b/packages/arb-rpc-node/web3/trace.go
@@ -436,6 +436,7 @@ func (t *Trace) block(ctx context.Context, blockNum rpc.BlockNumberOrHash, trace
 	for i := uint64(0); i < blockLog.BlockStats.TxCount.Uint64(); i++ {
 		txRes := txResults[i]
 		txTrace, err := t.traceTransaction(ctx, cursor, txRes, logIndex, traceDestroyed)
+		logIndex.Add(logIndex, big.NewInt(1))
 		if err != nil {
 			logger.
 				Warn().
@@ -446,7 +447,6 @@ func (t *Trace) block(ctx context.Context, blockNum rpc.BlockNumberOrHash, trace
 			continue
 		}
 		res = append(res, txTrace)
-		logIndex.Add(logIndex, big.NewInt(1))
 	}
 	return res, blockInfo, cursor, nil
 }

--- a/packages/arb-rpc-node/web3/trace.go
+++ b/packages/arb-rpc-node/web3/trace.go
@@ -435,14 +435,14 @@ func (t *Trace) block(ctx context.Context, blockNum rpc.BlockNumberOrHash, trace
 	res := make([]*rawTxTrace, 0, len(txResults))
 	for i := uint64(0); i < blockLog.BlockStats.TxCount.Uint64(); i++ {
 		txRes := txResults[i]
-		failMsg := logger.
-			Warn().
-			Uint64("block", blockInfo.Header.Number.Uint64()).
-			Str("txhash", txRes.IncomingRequest.MessageID.String()).
-			Err(err)
 		txTrace, err := t.traceTransaction(ctx, cursor, txRes, logIndex, traceDestroyed)
 		if err != nil {
-			failMsg.Msg("error getting trace for transaction")
+			logger.
+				Warn().
+				Uint64("block", blockInfo.Header.Number.Uint64()).
+				Str("txhash", txRes.IncomingRequest.MessageID.String()).
+				Err(err).
+				Msg("error getting trace for transaction")
 			continue
 		}
 		res = append(res, txTrace)


### PR DESCRIPTION
A bug was discovered where block tracing was broken in blocks containing transactions that had no traces. The update will fix the results of the `arbtrace_block` and `arbtrace_replayBlockTransactions` RPC calls in that case