### PR TITLE
Always ignore the last `delay blocks` number of L1 blocks

### DIFF
--- a/packages/arb-node-core/monitor/inboxReader.go
+++ b/packages/arb-node-core/monitor/inboxReader.go
@@ -246,11 +246,9 @@ func (ir *InboxReader) getMessages(ctx context.Context, temporarilyParanoid bool
 			}
 		}
 
-		if !reorgingDelayed && !reorgingSequencer && inboxReaderDelayBlocks > 0 {
-			currentHeight = new(big.Int).Sub(currentHeight, big.NewInt(inboxReaderDelayBlocks))
-			if currentHeight.Sign() <= 0 {
-				currentHeight = currentHeight.SetInt64(1)
-			}
+		currentHeight = new(big.Int).Sub(currentHeight, big.NewInt(inboxReaderDelayBlocks))
+		if currentHeight.Sign() <= 0 {
+			currentHeight = currentHeight.SetInt64(1)
 		}
 
 		EthHeightGauge.Update(currentHeight.Int64())


### PR DESCRIPTION
This update fixes a corner case where latest L1 blocks were not ignored