### PR TITLE
Fix message delivery context cancellation

### DIFF
--- a/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
@@ -182,7 +182,7 @@ bool ArbCore::deliverMessages(
     std::vector<std::vector<unsigned char>> delayed_messages,
     const std::optional<uint256_t>& reorg_batch_items) {
     auto status = message_data_status.load();
-    if (status != MESSAGES_EMPTY) {
+    if (status != MESSAGES_EMPTY && status != MESSAGES_SUCCESS) {
         std::cerr << "unable to deliver messages, status: " << status
                   << std::endl;
         return false;


### PR DESCRIPTION
- Don't cancel message delivery from the sequencer if a single user's transaction submission got canceled
- Allow for message delivery to recover from `waitForMessages` returning early due to a context cancellation (though this circumstance still isn't ideal as it might temporarily error)