### PR TITLE
Add timeout when updating prune point

### DIFF
--- a/packages/arb-node-core/cmdhelp/database.go
+++ b/packages/arb-node-core/cmdhelp/database.go
@@ -11,8 +11,14 @@ import (
 
 func UpdatePrunePoint(parentCtx context.Context, rollup *ethbridge.RollupWatcher, lookup core.ArbCoreLookup, lookupTimeout time.Duration) error {
 	// Prune any stale database entries while we wait
-	ctx, cancelFunc := context.WithTimeout(parentCtx, lookupTimeout)
-	defer cancelFunc()
+	var ctx context.Context
+	var cancelFunc context.CancelFunc
+	if lookupTimeout > 0 {
+		ctx, cancelFunc = context.WithTimeout(parentCtx, lookupTimeout)
+		defer cancelFunc()
+	} else {
+		ctx = parentCtx
+	}
 	latestNode, err := rollup.LatestConfirmedNode(ctx)
 	if err != nil {
 		return errors.Wrap(err, "couldn't get latest confirmed node")

--- a/packages/arb-node-core/staker/staker.go
+++ b/packages/arb-node-core/staker/staker.go
@@ -95,7 +95,7 @@ func NewStaker(
 	}, val.delayedBridge, nil
 }
 
-func (s *Staker) RunInBackground(ctx context.Context, stakerDelay time.Duration) chan bool {
+func (s *Staker) RunInBackground(ctx context.Context, stakerDelay time.Duration, lookupTimeout time.Duration) chan bool {
 	done := make(chan bool)
 	go func() {
 		defer func() {
@@ -132,7 +132,7 @@ func (s *Staker) RunInBackground(ctx context.Context, stakerDelay time.Duration)
 			}
 			delay := time.After(stakerDelay)
 			// Prune any stale database entries while we wait
-			err = cmdhelp.UpdatePrunePoint(ctx, s.rollup.RollupWatcher, s.lookup)
+			err = cmdhelp.UpdatePrunePoint(ctx, s.rollup.RollupWatcher, s.lookup, lookupTimeout)
 			if err != nil {
 				logger.Error().Err(err).Msg("error pruning database")
 			}

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -330,7 +330,7 @@ func startup() error {
 		}
 	}
 
-	if err := cmdhelp.UpdatePrunePoint(ctx, rollup, mon.Core); err != nil {
+	if err := cmdhelp.UpdatePrunePoint(ctx, rollup, mon.Core, config.Core.PruneNodeLookupTimeout); err != nil {
 		logger.Error().Err(err).Msg("error pruning database")
 	}
 
@@ -523,7 +523,7 @@ func startup() error {
 		go func() {
 			defer ticker.Stop()
 			for {
-				if err := cmdhelp.UpdatePrunePoint(ctx, rollup, mon.Core); err != nil {
+				if err := cmdhelp.UpdatePrunePoint(ctx, rollup, mon.Core, config.Core.PruneNodeLookupTimeout); err != nil {
 					logger.Error().Err(err).Msg("error pruning database")
 				}
 				select {
@@ -537,7 +537,7 @@ func startup() error {
 
 	var stakerDone chan bool
 	if stakerManager != nil {
-		stakerDone = stakerManager.RunInBackground(ctx, config.Validator.StakerDelay)
+		stakerDone = stakerManager.RunInBackground(ctx, config.Validator.StakerDelay, config.Core.PruneNodeLookupTimeout)
 	} else {
 		stakerDone = make(chan bool)
 	}

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -80,6 +80,7 @@ type Core struct {
 	CheckpointMaxToPrune           int           `koanf:"checkpoint-max-to-prune"`
 	CheckpointPruningMode          string        `koanf:"checkpoint-pruning-mode"`
 	CheckpointPruneOnStartup       bool          `koanf:"checkpoint-prune-on-startup"`
+	PruneNodeLookupTimeout         time.Duration `koanf:"prune-node-lookup-timeout"`
 	Database                       Database      `koanf:"database"`
 	Debug                          bool          `koanf:"debug"`
 	DebugTiming                    bool          `koanf:"debug-timing"`
@@ -889,6 +890,7 @@ func AddCore(f *flag.FlagSet, maxExecutionGas int) {
 	f.Int("core.checkpoint-max-execution-gas", maxExecutionGas, "maximum amount of gas any given checkpoint is allowed to execute")
 	f.Int("core.checkpoint-max-to-prune", 2, "number of checkpoints to delete at a time, 0 for no limit")
 	f.Bool("core.checkpoint-prune-on-startup", false, "perform full database pruning on startup")
+	f.Duration("core.prune-node-lookup-timeout", time.Second*15, "how long to wait for confirmed node lookup")
 	f.String("core.checkpoint-pruning-mode", "default", "Prune old checkpoints: 'on', 'off', or 'default'")
 
 	f.Bool("core.database.compact", false, "perform database compaction")


### PR DESCRIPTION
The method `rollup.LookupNode` seems to hang occasionally.  Add default 15 second timeout, adjustable with `--core.prune-node-lookup-timeout`