### PR TITLE
Close idle connections when reconnecting to L1 node

### DIFF
--- a/packages/arb-rpc-node/cmd/arb-cli/arb-cli.go
+++ b/packages/arb-rpc-node/cmd/arb-cli/arb-cli.go
@@ -385,7 +385,7 @@ func run(ctx context.Context) error {
 	arbUrl := os.Args[1]
 	privKeystr := os.Args[2]
 
-	client, err := ethutils.NewRPCEthClient(arbUrl)
+	client, err := ethutils.NewRPCEthClient(ctx, arbUrl)
 	if err != nil {
 		return err
 	}

--- a/packages/arb-rpc-node/cmd/arb-dev-sequencer/arb-dev-sequencer.go
+++ b/packages/arb-rpc-node/cmd/arb-dev-sequencer/arb-dev-sequencer.go
@@ -137,7 +137,7 @@ func startup() error {
 	rollupCreator := common.HexToAddress(rollupCreatorAddresssString)
 	bridgeUtilsAddress := common.HexToAddress(bridgeUtilsAddressString)
 
-	ethclint, err := ethutils.NewRPCEthClient(ethURL)
+	ethclint, err := ethutils.NewRPCEthClient(ctx, ethURL)
 	if err != nil {
 		return errors.Wrap(err, "error running NewRPcEthClient")
 	}

--- a/packages/arb-util/ethutils/client.go
+++ b/packages/arb-util/ethutils/client.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -130,6 +131,9 @@ func (r *RPCEthClient) reconnect(ctx context.Context) error {
 	if r.rpc != nil {
 		r.rpc.Close()
 	}
+	r.eth = nil
+	r.rpc = nil
+	runtime.GC()
 	if r.transport != nil {
 		r.transport.CloseIdleConnections()
 	}

--- a/packages/arb-util/ethutils/client.go
+++ b/packages/arb-util/ethutils/client.go
@@ -131,10 +131,10 @@ func (r *RPCEthClient) reconnect(ctx context.Context) error {
 	if r.rpc != nil {
 		r.rpc.Close()
 	}
-	r.eth = nil
-	r.rpc = nil
-	runtime.GC()
 	if r.transport != nil {
+		r.eth = nil
+		r.rpc = nil
+		runtime.GC()
 		r.transport.CloseIdleConnections()
 	}
 	rpccl, err := r.newRPCClient(ctx)


### PR DESCRIPTION
We have seen some cases where the kubernetes network layer starts returning 503 for various reasons, and the build in Go connection pool keeps the bad connection open, persisting the error even if the underlying network has fixed itself.

To work around this issue, manually close all idle connections when an error is encountered.