### PR TITLE
Add http headers to feed

### DIFF
--- a/packages/arb-node-core/cmd/arb-relay/arb-relay.go
+++ b/packages/arb-node-core/cmd/arb-relay/arb-relay.go
@@ -145,7 +145,6 @@ const RECENT_FEED_ITEM_TTL time.Duration = time.Second * 10
 
 func (ar *ArbRelay) Start(parentContext context.Context) (chan bool, error) {
 	ctx, cancelFunc := context.WithCancel(parentContext)
-	defer cancelFunc()
 	done := make(chan bool)
 
 	// connect returns

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -298,7 +298,7 @@ func startup() error {
 				config.Feed.Input.Timeout,
 				broadcastClientErrChan,
 			)
-			broadcastClient.ConnectInBackground(ctx, sequencerFeed, nil)
+			broadcastClient.ConnectInBackground(ctx, sequencerFeed)
 		}
 	}
 

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -279,7 +279,7 @@ func startup() error {
 	// Message count is 1 based, seqNum is 0 based, so next seqNum to request is same as current message count
 	seqNumToRequest, err := mon.Core.GetMessageCount()
 	if err != nil {
-		logger.Error().Err(err).Msg("can't get message count")
+		return errors.Wrap(err, "can't get message count")
 	}
 
 	var sequencerFeed chan broadcaster.BroadcastFeedMessage

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -277,7 +277,7 @@ func startup() error {
 	}
 
 	// Message count is 1 based, seqNum is 0 based, so next seqNum to request is same as current message count
-	seqNumToRequest, err := mon.Core.GetMessageCount()
+	currentMessageCount, err := mon.Core.GetMessageCount()
 	if err != nil {
 		return errors.Wrap(err, "can't get message count")
 	}
@@ -294,7 +294,7 @@ func startup() error {
 			broadcastClient := broadcastclient.NewBroadcastClient(
 				url,
 				config.Node.ChainID,
-				seqNumToRequest,
+				currentMessageCount,
 				config.Feed.Input.Timeout,
 				broadcastClientErrChan,
 			)

--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -278,6 +278,12 @@ func startup() error {
 		}()
 	}
 
+	// Message count is 1 based, seqNum is 0 based, so next seqNum to request is same as current message count
+	seqNumToRequest, err := mon.Core.GetMessageCount()
+	if err != nil {
+		logger.Error().Err(err).Msg("can't get message count")
+	}
+
 	var sequencerFeed chan broadcaster.BroadcastFeedMessage
 	broadcastClientErrChan := make(chan error)
 	if len(config.Feed.Input.URLs) == 0 {
@@ -287,7 +293,13 @@ func startup() error {
 	} else {
 		sequencerFeed = make(chan broadcaster.BroadcastFeedMessage, 4096)
 		for _, url := range config.Feed.Input.URLs {
-			broadcastClient := broadcastclient.NewBroadcastClient(url, config.Node.ChainID, nil, config.Feed.Input.Timeout, broadcastClientErrChan)
+			broadcastClient := broadcastclient.NewBroadcastClient(
+				url,
+				config.Node.ChainID,
+				seqNumToRequest,
+				config.Feed.Input.Timeout,
+				broadcastClientErrChan,
+			)
 			broadcastClient.ConnectInBackground(ctx, sequencerFeed, nil)
 		}
 	}

--- a/packages/arb-rpc-node/rpc/launch.go
+++ b/packages/arb-rpc-node/rpc/launch.go
@@ -152,7 +152,7 @@ func SetupBatcher(
 		if err != nil {
 			return nil, nil, err
 		}
-		feedBroadcaster := broadcaster.NewBroadcaster(&config.Feed.Output)
+		feedBroadcaster := broadcaster.NewBroadcaster(&config.Feed.Output, config.L2.ChainID)
 		seqBatcher, err := batcher.NewSequencerBatcher(
 			ctx,
 			batcherMode.Core,

--- a/packages/arb-util/broadcastclient/broadcastclient.go
+++ b/packages/arb-util/broadcastclient/broadcastclient.go
@@ -19,6 +19,7 @@ package broadcastclient
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/arblog"
 	"io"
 	"math/big"
@@ -322,10 +323,12 @@ func (bc *BroadcastClient) startBackgroundReader(ctx context.Context, messageRec
 					if res.ConfirmedAccumulator.IsConfirmed && bc.ConfirmedAccumulatorListener != nil {
 						bc.ConfirmedAccumulatorListener <- res.ConfirmedAccumulator.Accumulator
 					}
-				} else if res.Version == 2 {
-					logger.Fatal().Int("version", res.Version).Msg("connected to nitro feed with classic client")
+				} else if res.Version >= 2 {
+					bc.errChan <- fmt.Errorf("connected to nitro feed with classic client, server version: %d", res.Version)
+					break
 				} else {
-					logger.Fatal().Int("version", res.Version).Msg("unrecognized feed version")
+					bc.errChan <- fmt.Errorf("unrecognized feed version, server version: %d", res.Version)
+					break
 				}
 			}
 		}

--- a/packages/arb-util/broadcastclient/broadcastclient.go
+++ b/packages/arb-util/broadcastclient/broadcastclient.go
@@ -63,21 +63,21 @@ var logger = arblog.Logger.With().Str("component", "broadcaster").Logger()
 func NewBroadcastClient(
 	websocketUrl string,
 	chainId uint64,
-	lastInboxSeqNum *big.Int,
+	requestedInboxSeqNum *big.Int,
 	idleTimeout time.Duration,
 	broadcastClientErrChan chan error,
 ) *BroadcastClient {
-	var seqNum *big.Int
-	if lastInboxSeqNum == nil {
-		seqNum = big.NewInt(0)
+	var lastSeqNum *big.Int
+	if requestedInboxSeqNum == nil || requestedInboxSeqNum.Cmp(big.NewInt(0)) <= 0 {
+		lastSeqNum = big.NewInt(0)
 	} else {
-		seqNum = lastInboxSeqNum
+		lastSeqNum = new(big.Int).Sub(requestedInboxSeqNum, big.NewInt(1))
 	}
 
 	return &BroadcastClient{
 		websocketUrl:    websocketUrl,
 		chainId:         chainId,
-		lastInboxSeqNum: seqNum,
+		lastInboxSeqNum: lastSeqNum,
 		connMutex:       &sync.Mutex{},
 		errChan:         broadcastClientErrChan,
 		retryMutex:      &sync.Mutex{},

--- a/packages/arb-util/broadcastclient/broadcastclient.go
+++ b/packages/arb-util/broadcastclient/broadcastclient.go
@@ -39,7 +39,9 @@ import (
 )
 
 type BroadcastClient struct {
-	websocketUrl    string
+	websocketUrl string
+
+	// sequence number of the previous message
 	lastInboxSeqNum *big.Int
 
 	chainId uint64
@@ -234,9 +236,6 @@ func (bc *BroadcastClient) startBackgroundReader(ctx context.Context, messageRec
 				}
 				_ = bc.conn.Close()
 				earlyFrameData = bc.RetryConnect(ctx, messageReceiver)
-				if err != nil {
-					logger.Warn().Err(err).Str("feed", bc.websocketUrl).Int("opcode", int(op)).Msgf("retryConnect failed")
-				}
 				continue
 			}
 

--- a/packages/arb-util/broadcastclient/broadcastclient_test.go
+++ b/packages/arb-util/broadcastclient/broadcastclient_test.go
@@ -85,8 +85,8 @@ func startMakeBroadcastClient(ctx context.Context, t *testing.T, index int, expe
 	}
 	accListener := broadcastClient.ConfirmedAccumulatorListener
 
-	if broadcastClient.ChainId() != 9742 {
-		t.Fatalf("Incorrect chain id: %d", broadcastClient.ChainId())
+	if broadcastClient.chainId != 9742 {
+		t.Fatalf("Incorrect chain id: %d", broadcastClient.chainId)
 	}
 
 	go func() {

--- a/packages/arb-util/broadcastclient/broadcastclient_test.go
+++ b/packages/arb-util/broadcastclient/broadcastclient_test.go
@@ -18,12 +18,13 @@ package broadcastclient
 
 import (
 	"context"
-	"github.com/offchainlabs/arbitrum/packages/arb-util/configuration"
+	"math/big"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/offchainlabs/arbitrum/packages/arb-util/broadcaster"
+	"github.com/offchainlabs/arbitrum/packages/arb-util/configuration"
 )
 
 func TestReceiveMessages(t *testing.T) {
@@ -34,11 +35,11 @@ func TestReceiveMessages(t *testing.T) {
 
 	messageCount := 1000
 	messageDelay := 0 * time.Millisecond
-	clientCount := 2
+	clientCount := 10
 
-	b := broadcaster.NewBroadcaster(settings)
+	b := broadcaster.NewBroadcaster(settings, 9742)
 
-	_, err := b.Start(ctx)
+	broadcasterErrChan, err := b.Start(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,6 +59,8 @@ func TestReceiveMessages(t *testing.T) {
 	wg.Wait()
 
 	select {
+	case err := <-broadcasterErrChan:
+		t.Fatal(err)
 	case err := <-errChan:
 		t.Fatal(err)
 	default:
@@ -65,7 +68,14 @@ func TestReceiveMessages(t *testing.T) {
 }
 
 func startMakeBroadcastClient(ctx context.Context, t *testing.T, index int, expectedCount int, wg *sync.WaitGroup) {
-	broadcastClient := NewBroadcastClient("ws://127.0.0.1:9742/", nil, 20*time.Second)
+	broadcastClientErrChan := make(chan error)
+	broadcastClient := NewBroadcastClient(
+		"ws://127.0.0.1:9742/",
+		9742,
+		nil,
+		20*time.Second,
+		broadcastClientErrChan,
+	)
 	messageCount := 0
 
 	// connect returns
@@ -74,6 +84,10 @@ func startMakeBroadcastClient(ctx context.Context, t *testing.T, index int, expe
 		t.Fatal(err)
 	}
 	accListener := broadcastClient.ConfirmedAccumulatorListener
+
+	if broadcastClient.ChainId() != 9742 {
+		t.Fatalf("Incorrect chain id: %d", broadcastClient.ChainId())
+	}
 
 	go func() {
 		defer wg.Done()
@@ -87,6 +101,9 @@ func startMakeBroadcastClient(ctx context.Context, t *testing.T, index int, expe
 					return
 				}
 			case <-accListener:
+			case err := <-broadcastClientErrChan:
+				t.Errorf("broadcast client error: %s", err.Error())
+				return
 			case <-time.After(60 * time.Second):
 				t.Errorf("Client %d expected %d meesages, only got %d messages\n", index, expectedCount, messageCount)
 				return
@@ -104,7 +121,7 @@ func TestServerClientDisconnect(t *testing.T) {
 	settings.Ping = 1 * time.Second
 	settings.ClientTimeout = 2 * time.Second
 
-	b := broadcaster.NewBroadcaster(settings)
+	b := broadcaster.NewBroadcaster(settings, 9743)
 
 	_, err := b.Start(ctx)
 	if err != nil {
@@ -112,7 +129,8 @@ func TestServerClientDisconnect(t *testing.T) {
 	}
 	defer b.Stop()
 
-	broadcastClient := NewBroadcastClient("ws://127.0.0.1:9743/", nil, 20*time.Second)
+	broadcastClientErrChan := make(chan error)
+	broadcastClient := NewBroadcastClient("ws://127.0.0.1:9743/", 9743, nil, 20*time.Second, broadcastClientErrChan)
 
 	client, err := broadcastClient.Connect(ctx)
 	if err != nil {
@@ -125,6 +143,8 @@ func TestServerClientDisconnect(t *testing.T) {
 
 	// Wait for client to receive batch to ensure it is connected
 	select {
+	case err := <-broadcastClientErrChan:
+		t.Fatalf("broadcast client error: %s", err)
 	case receivedMsg := <-client:
 		t.Logf("Received Message, Sequence Message: %v\n", receivedMsg.FeedItem.BatchItem.SequencerMessage)
 	case <-time.After(5 * time.Second):
@@ -151,11 +171,11 @@ func TestBroadcastClientReconnectsOnServerDisconnect(t *testing.T) {
 	ctx := context.Background()
 
 	settings := configuration.DefaultFeedOutput()
-	settings.Port = "9743"
+	settings.Port = "9744"
 	settings.Ping = 50 * time.Second
 	settings.ClientTimeout = 150 * time.Second
 
-	b1 := broadcaster.NewBroadcaster(settings)
+	b1 := broadcaster.NewBroadcaster(settings, 9744)
 
 	_, err := b1.Start(ctx)
 	if err != nil {
@@ -163,7 +183,8 @@ func TestBroadcastClientReconnectsOnServerDisconnect(t *testing.T) {
 	}
 	defer b1.Stop()
 
-	broadcastClient := NewBroadcastClient("ws://127.0.0.1:9743/", nil, 2*time.Second)
+	broadcastClientErrChan := make(chan error)
+	broadcastClient := NewBroadcastClient("ws://127.0.0.1:9744/", 9744, nil, 2*time.Second, broadcastClientErrChan)
 
 	// connect returns
 	_, err = broadcastClient.Connect(ctx)
@@ -180,13 +201,13 @@ func TestBroadcastClientReconnectsOnServerDisconnect(t *testing.T) {
 	}
 }
 
-func TestBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
+func implementBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T, clientChainId uint64, serverChainId uint64) {
 	ctx := context.Background()
 
 	settings := configuration.DefaultFeedOutput()
 	settings.Port = "9842"
 
-	b := broadcaster.NewBroadcaster(settings)
+	b := broadcaster.NewBroadcaster(settings, serverChainId)
 
 	_, err := b.Start(ctx)
 	if err != nil {
@@ -208,10 +229,27 @@ func TestBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	hash3, feedItem3, signature3 := newBroadcastMessage()
+	err = b.BroadcastSingle(hash3, feedItem3.BatchItem, signature3.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	var wg sync.WaitGroup
 	for i := 0; i < 2; i++ {
 		wg.Add(1)
-		connectAndGetCachedMessages(ctx, t, i, &wg)
+		err := connectAndGetCachedMessages(ctx, t, i, &wg, clientChainId, clientChainId != serverChainId)
+		if err != nil {
+			if clientChainId == serverChainId {
+				t.Log("error occurred when chain id is correct")
+				t.Fatal(err)
+			}
+			// Abort test without error
+			wg.Done()
+			break
+		} else if clientChainId != serverChainId {
+			t.Error("no error occurred when chain id incorrect")
+		}
 	}
 
 	wg.Wait()
@@ -224,6 +262,9 @@ func TestBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
 
 	// Send next accumulator because only previous accumulator is sent to clients
 	b.ConfirmedAccumulator(feedItem2.BatchItem.Accumulator) // remove the first message we generated
+
+	// Send next accumulator because only previous accumulator is sent to clients
+	b.ConfirmedAccumulator(feedItem3.BatchItem.Accumulator) // remove the first message we generated
 
 	updateTimeout := time.After(2 * time.Second)
 	for {
@@ -239,7 +280,7 @@ func TestBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
 	}
 
 	// Send second accumulator again so that the previously added accumulator is sent
-	b.ConfirmedAccumulator(feedItem2.BatchItem.Accumulator)
+	b.ConfirmedAccumulator(feedItem3.BatchItem.Accumulator)
 
 	updateTimeout = time.After(2 * time.Second)
 	for {
@@ -255,11 +296,28 @@ func TestBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
 	}
 }
 
-func connectAndGetCachedMessages(ctx context.Context, t *testing.T, clientIndex int, wg *sync.WaitGroup) {
-	broadcastClient := NewBroadcastClient("ws://127.0.0.1:9842/", nil, 60*time.Second)
+func TestBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
+	chainId := uint64(9842)
+	implementBroadcasterSendsCachedMessagesOnClientConnect(t, chainId, chainId)
+}
+
+func TestBadBroadcasterSendsCachedMessagesOnClientConnect(t *testing.T) {
+	chainId := uint64(9842)
+	implementBroadcasterSendsCachedMessagesOnClientConnect(t, chainId, chainId+1)
+}
+
+func connectAndGetCachedMessages(ctx context.Context, t *testing.T, clientIndex int, wg *sync.WaitGroup, chainId uint64, connectShouldFail bool) error {
+	broadcastClientErrChan := make(chan error)
+	requestedSeqNum := big.NewInt(42)
+	broadcastClient := NewBroadcastClient("ws://127.0.0.1:9842/", chainId, requestedSeqNum, 60*time.Second, broadcastClientErrChan)
 	testClient, err := broadcastClient.Connect(ctx)
 	if err != nil {
-		t.Fatal(err)
+		if !connectShouldFail {
+			t.Fatal(err)
+		}
+		return err
+	} else if connectShouldFail {
+		t.Fatal("broadcast client didn't fail when it should have")
 	}
 
 	go func() {
@@ -270,8 +328,13 @@ func connectAndGetCachedMessages(ctx context.Context, t *testing.T, clientIndex 
 
 		// Wait for client to receive first item
 		select {
+		case err := <-broadcastClientErrChan:
+			t.Errorf("broadcast client error: %s", err.Error())
 		case receivedMsg := <-testClient:
-			t.Logf("client %d received first message: %v\n", clientIndex, receivedMsg.FeedItem.BatchItem.SequencerMessage)
+			if receivedMsg.FeedItem.BatchItem.LastSeqNum.Cmp(requestedSeqNum) != 0 {
+				t.Errorf("expected seqnum %d but got %d instead", requestedSeqNum, receivedMsg.FeedItem.BatchItem.LastSeqNum)
+			}
+			t.Logf("client %d received first message: (%v) %v\n", clientIndex, receivedMsg.FeedItem.BatchItem.LastSeqNum, receivedMsg.FeedItem.BatchItem.SequencerMessage)
 		case <-time.After(10 * time.Second):
 			t.Errorf("client %d did not receive first batch item\n", clientIndex)
 			return
@@ -279,11 +342,15 @@ func connectAndGetCachedMessages(ctx context.Context, t *testing.T, clientIndex 
 
 		// Wait for client to receive second item
 		select {
+		case err := <-broadcastClientErrChan:
+			t.Errorf("broadcast client error: %s", err.Error())
 		case receivedMsg := <-testClient:
-			t.Logf("client %d received second message: %v\n", clientIndex, receivedMsg.FeedItem.BatchItem.SequencerMessage)
+			t.Logf("client %d received second message: (%v) %v\n", clientIndex, receivedMsg.FeedItem.BatchItem.LastSeqNum, receivedMsg.FeedItem.BatchItem.SequencerMessage)
 		case <-time.After(10 * time.Second):
 			t.Errorf("client %d did not receive second batch item\n", clientIndex)
 			return
 		}
 	}()
+
+	return nil
 }

--- a/packages/arb-util/broadcaster/broadcaster.go
+++ b/packages/arb-util/broadcaster/broadcaster.go
@@ -54,11 +54,6 @@ func (b *Broadcaster) Start(ctx context.Context) (chan error, error) {
 	return b.server.Start(ctx)
 }
 
-// SetChainId not thread safe, call before calling Start
-func (b *Broadcaster) SetChainId(chainId uint64) {
-	b.server.SetChainId(chainId)
-}
-
 func (b *Broadcaster) BroadcastSingle(prevAcc common.Hash, batchItem inbox.SequencerBatchItem, signature []byte) error {
 	var broadcastMessages []*BroadcastFeedMessage
 

--- a/packages/arb-util/broadcaster/broadcaster_test.go
+++ b/packages/arb-util/broadcaster/broadcaster_test.go
@@ -31,12 +31,14 @@ import (
 	"github.com/offchainlabs/arbitrum/packages/arb-util/configuration"
 )
 
+var chainId = uint64(5555)
+
 func TestBroadcasterSendsConfirmedAccumulatorMessages(t *testing.T) {
 	ctx := context.Background()
 
 	broadcasterSettings := configuration.DefaultFeedOutput()
 
-	b := NewBroadcaster(broadcasterSettings)
+	b := NewBroadcaster(broadcasterSettings, chainId)
 
 	_, err := b.Start(ctx)
 	if err != nil {
@@ -150,7 +152,7 @@ func TestBroadcasterRespondsToPing(t *testing.T) {
 	broadcasterSettings := configuration.DefaultFeedOutput()
 	broadcasterSettings.Port = "9643"
 
-	b := NewBroadcaster(broadcasterSettings)
+	b := NewBroadcaster(broadcasterSettings, chainId)
 
 	_, err := b.Start(ctx)
 	if err != nil {
@@ -201,7 +203,7 @@ func TestBroadcasterReorganizesCacheBasedOnAccumulator(t *testing.T) {
 	broadcasterSettings := configuration.DefaultFeedOutput()
 	broadcasterSettings.ClientTimeout = 30
 
-	b := NewBroadcaster(broadcasterSettings)
+	b := NewBroadcaster(broadcasterSettings, chainId)
 
 	_, err := b.Start(ctx)
 	if err != nil {

--- a/packages/arb-util/broadcaster/broadcasterload_test.go
+++ b/packages/arb-util/broadcaster/broadcasterload_test.go
@@ -39,7 +39,7 @@ func TestBroadcasterLoad(t *testing.T) {
 	broadcasterSettings := configuration.DefaultFeedOutput()
 	broadcasterSettings.Port = "9942"
 
-	b := NewBroadcaster(broadcasterSettings)
+	b := NewBroadcaster(broadcasterSettings, chainId)
 
 	_, err := b.Start(ctx)
 	if err != nil {

--- a/packages/arb-util/broadcaster/confirmedaccumulatorcatchupbuffer.go
+++ b/packages/arb-util/broadcaster/confirmedaccumulatorcatchupbuffer.go
@@ -56,7 +56,7 @@ func (q *ConfirmedAccumulatorCatchupBuffer) OnRegisterClient(ctx context.Context
 					startingIndex--
 				}
 				for ; startingIndex > 0; startingIndex-- {
-					if q.broadcastMessages[startingIndex].FeedItem.BatchItem.LastSeqNum.Cmp(requestedLastSeqNum) >= 0 {
+					if q.broadcastMessages[startingIndex].FeedItem.BatchItem.LastSeqNum.Cmp(requestedLastSeqNum) <= 0 {
 						break
 					}
 				}

--- a/packages/arb-util/broadcaster/confirmedaccumulatorcatchupbuffer.go
+++ b/packages/arb-util/broadcaster/confirmedaccumulatorcatchupbuffer.go
@@ -45,16 +45,12 @@ func (q *ConfirmedAccumulatorCatchupBuffer) OnRegisterClient(ctx context.Context
 			startingIndex = int(new(big.Int).Sub(requestedLastSeqNum, q.broadcastMessages[0].FeedItem.BatchItem.LastSeqNum).Uint64())
 			comparison := q.broadcastMessages[startingIndex].FeedItem.BatchItem.LastSeqNum.Cmp(requestedLastSeqNum)
 			if comparison < 0 {
-				startingIndex++
-				for ; startingIndex < len(q.broadcastMessages); startingIndex++ {
+				for ; startingIndex < len(q.broadcastMessages)-1; startingIndex++ {
 					if q.broadcastMessages[startingIndex].FeedItem.BatchItem.LastSeqNum.Cmp(requestedLastSeqNum) >= 0 {
 						break
 					}
 				}
 			} else if comparison > 0 {
-				if startingIndex > 0 {
-					startingIndex--
-				}
 				for ; startingIndex > 0; startingIndex-- {
 					if q.broadcastMessages[startingIndex].FeedItem.BatchItem.LastSeqNum.Cmp(requestedLastSeqNum) <= 0 {
 						break

--- a/packages/arb-util/broadcaster/confirmedaccumulatorcatchupbuffer.go
+++ b/packages/arb-util/broadcaster/confirmedaccumulatorcatchupbuffer.go
@@ -34,44 +34,67 @@ func NewConfirmedAccumulatorCatchupBuffer() *ConfirmedAccumulatorCatchupBuffer {
 	return &ConfirmedAccumulatorCatchupBuffer{}
 }
 
-func (q *ConfirmedAccumulatorCatchupBuffer) OnRegisterClient(ctx context.Context, clientConnection *wsbroadcastserver.ClientConnection) error {
-	start := time.Now()
-	// send the newly connected client any messages starting with requested sequence number
+func (q *ConfirmedAccumulatorCatchupBuffer) getCacheMessages(requestedSeqNum *big.Int) *BroadcastMessage {
+	if len(q.broadcastMessages) == 0 {
+		return nil
+	}
 	startingIndex := 0
 	// Ignore messages older than requested sequence number
-	if clientConnection.RequestedSeqNum().Cmp(big.NewInt(0)) > 0 {
-		requestedLastSeqNum := new(big.Int).Sub(clientConnection.RequestedSeqNum(), big.NewInt(1))
+	if requestedSeqNum.Cmp(big.NewInt(0)) > 0 {
+		requestedLastSeqNum := new(big.Int).Sub(requestedSeqNum, big.NewInt(1))
 		if q.broadcastMessages[0].FeedItem.BatchItem.LastSeqNum.Cmp(requestedLastSeqNum) < 0 {
 			startingIndex = int(new(big.Int).Sub(requestedLastSeqNum, q.broadcastMessages[0].FeedItem.BatchItem.LastSeqNum).Uint64())
+			if startingIndex >= len(q.broadcastMessages) {
+				startingIndex = len(q.broadcastMessages) - 1
+			}
 			comparison := q.broadcastMessages[startingIndex].FeedItem.BatchItem.LastSeqNum.Cmp(requestedLastSeqNum)
-			if comparison < 0 {
-				for ; startingIndex < len(q.broadcastMessages)-1; startingIndex++ {
-					if q.broadcastMessages[startingIndex].FeedItem.BatchItem.LastSeqNum.Cmp(requestedLastSeqNum) >= 0 {
+			if comparison > 0 {
+				for startingIndex > 1 {
+					comparison2 := q.broadcastMessages[startingIndex-1].FeedItem.BatchItem.LastSeqNum.Cmp(requestedLastSeqNum)
+					if comparison2 < 0 {
+						// Found messages to broadcast
 						break
 					}
+					startingIndex--
 				}
-			} else if comparison > 0 {
-				for ; startingIndex > 0; startingIndex-- {
-					if q.broadcastMessages[startingIndex].FeedItem.BatchItem.LastSeqNum.Cmp(requestedLastSeqNum) <= 0 {
+			} else if comparison < 0 {
+				for {
+					startingIndex++
+					if startingIndex >= len(q.broadcastMessages) {
+						// End of array with nothing found
+						return nil
+					}
+					if q.broadcastMessages[startingIndex].FeedItem.BatchItem.LastSeqNum.Cmp(requestedLastSeqNum) >= 0 {
+						// Found messages to broadcast
 						break
 					}
 				}
 			}
 		}
 	}
-	if startingIndex < len(q.broadcastMessages) {
-		messagesToSend := q.broadcastMessages[startingIndex:]
-		if len(messagesToSend) > 0 {
-			bm := BroadcastMessage{
-				Version:  1,
-				Messages: messagesToSend,
-			}
 
-			err := clientConnection.Write(bm)
-			if err != nil {
-				logger.Error().Err(err).Str("client", clientConnection.Name).Str("elapsed", time.Since(start).String()).Msg("error sending client cached messages")
-				return err
-			}
+	messagesToSend := q.broadcastMessages[startingIndex:]
+	if len(messagesToSend) > 0 {
+		bm := BroadcastMessage{
+			Version:  1,
+			Messages: messagesToSend,
+		}
+
+		return &bm
+	}
+
+	return nil
+}
+
+func (q *ConfirmedAccumulatorCatchupBuffer) OnRegisterClient(ctx context.Context, clientConnection *wsbroadcastserver.ClientConnection) error {
+	start := time.Now()
+	// send the newly connected client any messages starting with requested sequence number
+	bm := q.getCacheMessages(clientConnection.RequestedSeqNum())
+	if bm != nil {
+		err := clientConnection.Write(bm)
+		if err != nil {
+			logger.Error().Err(err).Str("client", clientConnection.Name).Str("elapsed", time.Since(start).String()).Msg("error sending client cached messages")
+			return err
 		}
 	}
 

--- a/packages/arb-util/broadcaster/confirmedaccumulatorcatchupbuffer_test.go
+++ b/packages/arb-util/broadcaster/confirmedaccumulatorcatchupbuffer_test.go
@@ -36,95 +36,31 @@ func TestGetEmptyCacheMessages(t *testing.T) {
 	}
 }
 
+func createDummyBroadcastMessages(lastSeqNums []int) []*BroadcastFeedMessage {
+	broadcastMessages := make([]*BroadcastFeedMessage, 0, len(lastSeqNums))
+	for _, lastSeqNum := range lastSeqNums {
+		broadcastMessage := &BroadcastFeedMessage{
+			FeedItem: SequencerFeedItem{
+				BatchItem: inbox.SequencerBatchItem{
+					LastSeqNum:        big.NewInt(int64(lastSeqNum)),
+					Accumulator:       common.Hash{},
+					TotalDelayedCount: big.NewInt(0),
+					SequencerMessage:  []byte{},
+				},
+				PrevAcc: common.Hash{},
+			},
+			Signature: []byte{},
+		}
+		broadcastMessages = append(broadcastMessages, broadcastMessage)
+	}
+
+	return broadcastMessages
+}
+
 func TestGetCacheMessages(t *testing.T) {
 	buffer := ConfirmedAccumulatorCatchupBuffer{
-		broadcastMessages: []*BroadcastFeedMessage{
-			&BroadcastFeedMessage{
-				FeedItem: SequencerFeedItem{
-					BatchItem: inbox.SequencerBatchItem{
-						LastSeqNum:        big.NewInt(40),
-						Accumulator:       common.Hash{},
-						TotalDelayedCount: big.NewInt(0),
-						SequencerMessage:  []byte{},
-					},
-					PrevAcc: common.Hash{},
-				},
-				Signature: []byte{},
-			},
-			&BroadcastFeedMessage{
-				FeedItem: SequencerFeedItem{
-					BatchItem: inbox.SequencerBatchItem{
-						LastSeqNum:        big.NewInt(40),
-						Accumulator:       common.Hash{},
-						TotalDelayedCount: big.NewInt(0),
-						SequencerMessage:  []byte{},
-					},
-					PrevAcc: common.Hash{},
-				},
-				Signature: []byte{},
-			},
-			&BroadcastFeedMessage{
-				FeedItem: SequencerFeedItem{
-					BatchItem: inbox.SequencerBatchItem{
-						LastSeqNum:        big.NewInt(41),
-						Accumulator:       common.Hash{},
-						TotalDelayedCount: big.NewInt(0),
-						SequencerMessage:  []byte{},
-					},
-					PrevAcc: common.Hash{},
-				},
-				Signature: []byte{},
-			},
-			&BroadcastFeedMessage{
-				FeedItem: SequencerFeedItem{
-					BatchItem: inbox.SequencerBatchItem{
-						LastSeqNum:        big.NewInt(45),
-						Accumulator:       common.Hash{},
-						TotalDelayedCount: big.NewInt(0),
-						SequencerMessage:  []byte{},
-					},
-					PrevAcc: common.Hash{},
-				},
-				Signature: []byte{},
-			},
-			&BroadcastFeedMessage{
-				FeedItem: SequencerFeedItem{
-					BatchItem: inbox.SequencerBatchItem{
-						LastSeqNum:        big.NewInt(46),
-						Accumulator:       common.Hash{},
-						TotalDelayedCount: big.NewInt(0),
-						SequencerMessage:  []byte{},
-					},
-					PrevAcc: common.Hash{},
-				},
-				Signature: []byte{},
-			},
-			&BroadcastFeedMessage{
-				FeedItem: SequencerFeedItem{
-					BatchItem: inbox.SequencerBatchItem{
-						LastSeqNum:        big.NewInt(47),
-						Accumulator:       common.Hash{},
-						TotalDelayedCount: big.NewInt(0),
-						SequencerMessage:  []byte{},
-					},
-					PrevAcc: common.Hash{},
-				},
-				Signature: []byte{},
-			},
-			&BroadcastFeedMessage{
-				FeedItem: SequencerFeedItem{
-					BatchItem: inbox.SequencerBatchItem{
-						LastSeqNum:        big.NewInt(48),
-						Accumulator:       common.Hash{},
-						TotalDelayedCount: big.NewInt(0),
-						SequencerMessage:  []byte{},
-					},
-					PrevAcc: common.Hash{},
-				},
-				Signature: []byte{},
-			},
-		},
-		cacheSize: 10,
+		broadcastMessages: createDummyBroadcastMessages([]int{40, 40, 41, 45, 46, 47, 48}),
+		cacheSize:         10,
 	}
 
 	// Get everything
@@ -169,6 +105,7 @@ func TestGetCacheMessages(t *testing.T) {
 		t.Errorf("expected lastSeqNum 45, got %d", bm.Messages[0].FeedItem.BatchItem.LastSeqNum.Int64())
 	}
 
+	// Test when duplicate message
 	bm = buffer.getCacheMessages(big.NewInt(42))
 	if len(bm.Messages) != 5 {
 		t.Errorf("expected only 5 messages, got %d messages", len(bm.Messages))

--- a/packages/arb-util/broadcaster/confirmedaccumulatorcatchupbuffer_test.go
+++ b/packages/arb-util/broadcaster/confirmedaccumulatorcatchupbuffer_test.go
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020-2021, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package broadcaster
+
+import (
+	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
+	"github.com/offchainlabs/arbitrum/packages/arb-util/inbox"
+	"math/big"
+	"testing"
+)
+
+func TestGetEmptyCacheMessages(t *testing.T) {
+	buffer := ConfirmedAccumulatorCatchupBuffer{
+		broadcastMessages: []*BroadcastFeedMessage{},
+		cacheSize:         10,
+	}
+
+	// Get everything
+	bm := buffer.getCacheMessages(big.NewInt(0))
+	if bm != nil {
+		t.Error("shouldn't have returned anything")
+	}
+}
+
+func TestGetCacheMessages(t *testing.T) {
+	buffer := ConfirmedAccumulatorCatchupBuffer{
+		broadcastMessages: []*BroadcastFeedMessage{
+			&BroadcastFeedMessage{
+				FeedItem: SequencerFeedItem{
+					BatchItem: inbox.SequencerBatchItem{
+						LastSeqNum:        big.NewInt(40),
+						Accumulator:       common.Hash{},
+						TotalDelayedCount: big.NewInt(0),
+						SequencerMessage:  []byte{},
+					},
+					PrevAcc: common.Hash{},
+				},
+				Signature: []byte{},
+			},
+			&BroadcastFeedMessage{
+				FeedItem: SequencerFeedItem{
+					BatchItem: inbox.SequencerBatchItem{
+						LastSeqNum:        big.NewInt(40),
+						Accumulator:       common.Hash{},
+						TotalDelayedCount: big.NewInt(0),
+						SequencerMessage:  []byte{},
+					},
+					PrevAcc: common.Hash{},
+				},
+				Signature: []byte{},
+			},
+			&BroadcastFeedMessage{
+				FeedItem: SequencerFeedItem{
+					BatchItem: inbox.SequencerBatchItem{
+						LastSeqNum:        big.NewInt(41),
+						Accumulator:       common.Hash{},
+						TotalDelayedCount: big.NewInt(0),
+						SequencerMessage:  []byte{},
+					},
+					PrevAcc: common.Hash{},
+				},
+				Signature: []byte{},
+			},
+			&BroadcastFeedMessage{
+				FeedItem: SequencerFeedItem{
+					BatchItem: inbox.SequencerBatchItem{
+						LastSeqNum:        big.NewInt(45),
+						Accumulator:       common.Hash{},
+						TotalDelayedCount: big.NewInt(0),
+						SequencerMessage:  []byte{},
+					},
+					PrevAcc: common.Hash{},
+				},
+				Signature: []byte{},
+			},
+			&BroadcastFeedMessage{
+				FeedItem: SequencerFeedItem{
+					BatchItem: inbox.SequencerBatchItem{
+						LastSeqNum:        big.NewInt(46),
+						Accumulator:       common.Hash{},
+						TotalDelayedCount: big.NewInt(0),
+						SequencerMessage:  []byte{},
+					},
+					PrevAcc: common.Hash{},
+				},
+				Signature: []byte{},
+			},
+			&BroadcastFeedMessage{
+				FeedItem: SequencerFeedItem{
+					BatchItem: inbox.SequencerBatchItem{
+						LastSeqNum:        big.NewInt(47),
+						Accumulator:       common.Hash{},
+						TotalDelayedCount: big.NewInt(0),
+						SequencerMessage:  []byte{},
+					},
+					PrevAcc: common.Hash{},
+				},
+				Signature: []byte{},
+			},
+			&BroadcastFeedMessage{
+				FeedItem: SequencerFeedItem{
+					BatchItem: inbox.SequencerBatchItem{
+						LastSeqNum:        big.NewInt(48),
+						Accumulator:       common.Hash{},
+						TotalDelayedCount: big.NewInt(0),
+						SequencerMessage:  []byte{},
+					},
+					PrevAcc: common.Hash{},
+				},
+				Signature: []byte{},
+			},
+		},
+		cacheSize: 10,
+	}
+
+	// Get everything
+	bm := buffer.getCacheMessages(big.NewInt(0))
+	if len(bm.Messages) != 7 {
+		t.Error("didn't return all messages")
+	}
+
+	// Get everything
+	bm = buffer.getCacheMessages(big.NewInt(1))
+	if len(bm.Messages) != 7 {
+		t.Error("didn't return all messages")
+	}
+
+	// Get everything
+	bm = buffer.getCacheMessages(big.NewInt(41))
+	if len(bm.Messages) != 7 {
+		t.Error("didn't return all messages")
+	}
+
+	// Get nothing
+	bm = buffer.getCacheMessages(big.NewInt(100))
+	if bm != nil {
+		t.Error("should not have returned anything")
+	}
+
+	// Test single
+	bm = buffer.getCacheMessages(big.NewInt(49))
+	if len(bm.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d messages", len(bm.Messages))
+	}
+	if bm.Messages[0].FeedItem.BatchItem.LastSeqNum.Cmp(big.NewInt(48)) != 0 {
+		t.Errorf("expected lastSeqNum 48, got %d", bm.Messages[0].FeedItem.BatchItem.LastSeqNum.Int64())
+	}
+
+	// Test when messages missing
+	bm = buffer.getCacheMessages(big.NewInt(46))
+	if len(bm.Messages) != 4 {
+		t.Errorf("expected 4 messages, got %d messages", len(bm.Messages))
+	}
+	if bm.Messages[0].FeedItem.BatchItem.LastSeqNum.Cmp(big.NewInt(45)) != 0 {
+		t.Errorf("expected lastSeqNum 45, got %d", bm.Messages[0].FeedItem.BatchItem.LastSeqNum.Int64())
+	}
+
+	bm = buffer.getCacheMessages(big.NewInt(42))
+	if len(bm.Messages) != 5 {
+		t.Errorf("expected only 5 messages, got %d messages", len(bm.Messages))
+	}
+	if bm.Messages[0].FeedItem.BatchItem.LastSeqNum.Cmp(big.NewInt(41)) != 0 {
+		t.Errorf("expected lastSeqNum 41, got %d", bm.Messages[0].FeedItem.BatchItem.LastSeqNum.Int64())
+	}
+
+}

--- a/packages/arb-util/configuration/configuration.go
+++ b/packages/arb-util/configuration/configuration.go
@@ -115,19 +115,22 @@ type TestReorgTo struct {
 }
 
 type FeedInput struct {
-	Timeout time.Duration `koanf:"timeout"`
-	URLs    []string      `koanf:"url"`
+	RequireChainId bool          `koanf:"require-chain-id"`
+	Timeout        time.Duration `koanf:"timeout"`
+	URLs           []string      `koanf:"url"`
 }
 
 type FeedOutput struct {
-	Addr          string        `koanf:"addr"`
-	IOTimeout     time.Duration `koanf:"io-timeout"`
-	Port          string        `koanf:"port"`
-	Ping          time.Duration `koanf:"ping"`
-	ClientTimeout time.Duration `koanf:"client-timeout"`
-	Queue         int           `koanf:"queue"`
-	Workers       int           `koanf:"workers"`
-	MaxSendQueue  int           `koanf:"max-send-queue"`
+	Addr           string        `koanf:"addr"`
+	IOTimeout      time.Duration `koanf:"io-timeout"`
+	Port           string        `koanf:"port"`
+	Ping           time.Duration `koanf:"ping"`
+	ClientTimeout  time.Duration `koanf:"client-timeout"`
+	Queue          int           `koanf:"queue"`
+	RequireChainId bool          `koanf:"require-chain-id"`
+	RequireVersion bool          `koanf:"require-version"`
+	Workers        int           `koanf:"workers"`
+	MaxSendQueue   int           `koanf:"max-send-queue"`
 }
 
 func DefaultFeedOutput() *FeedOutput {
@@ -411,9 +414,12 @@ type Config struct {
 	GasPrice           float64     `koanf:"gas-price"`
 	Healthcheck        Healthcheck `koanf:"healthcheck"`
 	L1                 struct {
-		ChainID int    `koanf:"chain-id"`
+		ChainID uint64 `koanf:"chain-id"`
 		URL     string `koanf:"url"`
 	} `koanf:"l1"`
+	L2 struct {
+		ChainID uint64 `koanf:"chain-id"`
+	} `koanf:"l2"`
 	Log           Log        `koanf:"log"`
 	Node          Node       `koanf:"node"`
 	Persistent    Persistent `koanf:"persistent"`
@@ -741,11 +747,11 @@ func ParseNonRelay(ctx context.Context, f *flag.FlagSet, defaultWalletPathname s
 		}
 	}
 
-	if out.L1.ChainID != 0 && l1ChainId.Int64() != int64(out.L1.ChainID) {
+	if out.L1.ChainID != 0 && l1ChainId.Uint64() != out.L1.ChainID {
 		logger.
 			Error().
-			Int("expected-chainid", out.L1.ChainID).
-			Int64("l1-chainid", l1ChainId.Int64()).
+			Uint64("expected-chainid", out.L1.ChainID).
+			Uint64("l1-chainid", l1ChainId.Uint64()).
 			Msg("unexpected chain id")
 		return nil, nil, nil, nil, fmt.Errorf("expected chain id %v but l1 node has chain id %v", out.L1.ChainID, l1ChainId)
 	}
@@ -853,6 +859,7 @@ func AddFeedOutputOptions(f *flag.FlagSet) {
 	f.String("feed.output.port", "9642", "port to bind the relay feed output to")
 	f.Duration("feed.output.ping", 5*time.Second, "duration for ping interval")
 	f.Duration("feed.output.client-timeout", 15*time.Second, "duration to wait before timing out connections to client")
+	f.Bool("feed.output.require-chain-id", false, "disconnect if Chain-Id HTTP header not present")
 	f.Int("feed.output.workers", 100, "Number of threads to reserve for HTTP to WS upgrade")
 	f.Int("feed.output.max-send-queue", 4096, "Maximum number of messages allowed to accumulate before client is disconnected")
 }
@@ -936,6 +943,8 @@ func beginCommonParse(f *flag.FlagSet) (*koanf.Koanf, error) {
 	f.String("conf.s3.object-key", "", "S3 object key")
 	f.String("conf.string", "", "configuration as JSON string")
 
+	f.Bool("feed.input.require-chain-id", false, "disconnect if Chain-Id HTTP header not present")
+	f.Bool("feed.input.require-version", false, "disconnect if Arbitrum-Feed-Version HTTP header not present")
 	f.Duration("feed.input.timeout", 20*time.Second, "duration to wait before timing out connection to server")
 	f.StringSlice("feed.input.url", []string{}, "URL of sequencer feed source")
 
@@ -945,6 +954,8 @@ func beginCommonParse(f *flag.FlagSet) (*koanf.Koanf, error) {
 
 	f.String("log.rpc", "info", "log level for rpc")
 	f.String("log.core", "info", "log level for general arb node logging")
+
+	f.Uint64("l2.chain-id", 0, "if set other than 0, will be used to validate L2 feed connection")
 
 	f.Bool("pprof-enable", false, "enable profiling server")
 

--- a/packages/arb-util/wsbroadcastserver/clientmanager.go
+++ b/packages/arb-util/wsbroadcastserver/clientmanager.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"math/big"
 	"net"
 	"sync/atomic"
 	"time"
@@ -85,9 +86,9 @@ func (cm *ClientManager) registerClient(ctx context.Context, clientConnection *C
 }
 
 // Register registers new connection as a Client.
-func (cm *ClientManager) Register(conn net.Conn, desc *netpoll.Desc) *ClientConnection {
+func (cm *ClientManager) Register(conn net.Conn, desc *netpoll.Desc, requestedSeqNum *big.Int) *ClientConnection {
 	createClient := ClientConnectionAction{
-		NewClientConnection(conn, desc, cm),
+		NewClientConnection(conn, desc, cm, requestedSeqNum),
 		true,
 	}
 

--- a/packages/arb-util/wsbroadcastserver/wsbroadcastserver.go
+++ b/packages/arb-util/wsbroadcastserver/wsbroadcastserver.go
@@ -67,11 +67,6 @@ func NewWSBroadcastServer(settings *configuration.FeedOutput, catchupBuffer Catc
 	}
 }
 
-// SetChainId not thread safe, call before calling Start
-func (s *WSBroadcastServer) SetChainId(chainId uint64) {
-	s.chainId = chainId
-}
-
 func (s *WSBroadcastServer) Start(ctx context.Context) (chan error, error) {
 	s.startMutex.Lock()
 	defer s.startMutex.Unlock()


### PR DESCRIPTION
Add feed server and client versions, as well as chain id to ensure broadcast feed client and server are compatible.

On connect, client can request a particular sequence number, that way the broadcaster doesn't have to waste time sending old sequence numbers that the client already has.