### PR TITLE
Mark TokenGateway.onlyCounterpartGateway as abstract

### DIFF
--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/gateway/L2GatewayRouter.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/arbitrum/gateway/L2GatewayRouter.sol
@@ -30,8 +30,7 @@ import "arb-bridge-eth/contracts/libraries/AddressAliasHelper.sol";
 contract L2GatewayRouter is GatewayRouter, L2ArbitrumMessenger {
     modifier onlyCounterpartGateway() override {
         require(
-            msg.sender == counterpartGateway ||
-                AddressAliasHelper.undoL1ToL2Alias(msg.sender) == counterpartGateway,
+            msg.sender == AddressAliasHelper.applyL1ToL2Alias(counterpartGateway),
             "ONLY_COUNTERPART_GATEWAY"
         );
         _;

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/TokenGateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/TokenGateway.sol
@@ -27,12 +27,10 @@ abstract contract TokenGateway is ITokenGateway {
     address public counterpartGateway;
     address public router;
 
-    modifier onlyCounterpartGateway() virtual {
-        // this method is overriden in gateways that require special logic for validation
-        // ie L2 to L1 messages need to be validated against the outbox
-        require(msg.sender == counterpartGateway, "ONLY_COUNTERPART_GATEWAY");
-        _;
-    }
+    // This modifier is overriden in gateways to validate the message sender
+    // For L1 to L2 messages need to be validated against the aliased counterpartGateway
+    // For L2 to L1 messages need to be validated against the bridge and L2ToL1Sender
+    modifier onlyCounterpartGateway() virtual;
 
     function _initialize(address _counterpartGateway, address _router) internal virtual {
         // This initializes internal variables of the abstract contract it can be chained together with other functions.

--- a/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/TokenGateway.sol
+++ b/packages/arb-bridge-peripherals/contracts/tokenbridge/libraries/gateway/TokenGateway.sol
@@ -30,6 +30,7 @@ abstract contract TokenGateway is ITokenGateway {
     // This modifier is overriden in gateways to validate the message sender
     // For L1 to L2 messages need to be validated against the aliased counterpartGateway
     // For L2 to L1 messages need to be validated against the bridge and L2ToL1Sender
+    // prettier-ignore
     modifier onlyCounterpartGateway() virtual;
 
     function _initialize(address _counterpartGateway, address _router) internal virtual {


### PR DESCRIPTION
The current virtual function doesn’t make much sense because the lack of aliasing (for L2) or outbox checking (for L1), making it abstract and expect implementation in child contract. 

Also removed a deprecated check in L2GatewayRouter.