### PR TITLE
DIsable feed if empty URL

### DIFF
--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -288,7 +288,7 @@ func startup() error {
 
 	var sequencerFeed chan broadcaster.BroadcastFeedMessage
 	broadcastClientErrChan := make(chan error)
-	if len(config.Feed.Input.URLs) == 0 {
+	if len(config.Feed.Input.URLs) == 0 || len(config.Feed.Input.URLs[0]) == 0 {
 		logger.Warn().Msg("Missing --feed.input.url so not subscribing to feed")
 	} else if config.Node.Type() == configuration.ValidatorNodeType {
 		logger.Info().Msg("Ignoring feed because running as validator")


### PR DESCRIPTION
Setting `--feed.input.url=""` to an empty string on command line creates an empty list.  If set using environment variable, creates a list with a single entry of an empty string, so treat that as disabling feed as well.