### PR TITLE
Only update prune point when maybe pruning

### DIFF
--- a/packages/arb-rpc-node/cmd/arb-node/arb-node.go
+++ b/packages/arb-rpc-node/cmd/arb-node/arb-node.go
@@ -341,8 +341,10 @@ func startup() error {
 		}
 	}
 
-	if err := cmdhelp.UpdatePrunePoint(ctx, rollup, mon.Core); err != nil {
-		logger.Error().Err(err).Msg("error pruning database")
+	if config.Core.CheckpointPruningMode != "off" {
+		if err := cmdhelp.UpdatePrunePoint(ctx, rollup, mon.Core); err != nil {
+			logger.Error().Err(err).Msg("error pruning database")
+		}
 	}
 
 	var dataSigner func([]byte) ([]byte, error)
@@ -531,7 +533,7 @@ func startup() error {
 		}()
 	}
 
-	if config.Core.CheckpointPruningMode == "on" {
+	if config.Core.CheckpointPruningMode != "off" {
 		ticker := time.NewTicker(time.Minute)
 		go func() {
 			defer ticker.Stop()


### PR DESCRIPTION
This removes the need for a large distance log query on boot which delays the classic node coming up. It also fixes what I think was a minor bug, not updating the prune point when the pruning mode was defaulted